### PR TITLE
fix: create tests/.temp directory before running tests in CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
         run: npx tsc --noEmit
 
       - name: Test (PGlite + SQLite — no Docker required)
-        run: npx vitest run tests/pglite tests/sqlite.test.ts tests/sqlite-custom.test.ts
+        run: mkdir -p tests/.temp && npx vitest run tests/pglite tests/sqlite.test.ts tests/sqlite-custom.test.ts
 
       - name: Release
         env:


### PR DESCRIPTION
## Summary
- `tests/.temp` is listed in `.gitignore` so it never exists in the CI environment
- All pglite and sqlite tests were failing with `ENOENT: no such file or directory, mkdir '.../tests/.temp/pgdata-...'` because PGlite tries to `mkdirSync` inside it
- Fix: prepend `mkdir -p tests/.temp` to the test step in the workflow

## Test plan
- [ ] CI passes the Test step
- [ ] CI passes lint, type check, and release steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)