### PR TITLE
fix: disable semantic-release GitHub PR/issue comments

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -12,6 +12,13 @@
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ],
-    "@semantic-release/github"
+    [
+      "@semantic-release/github",
+      {
+        "successComment": false,
+        "failComment": false,
+        "releasedLabels": false
+      }
+    ]
   ]
 }


### PR DESCRIPTION
## Summary
- `@semantic-release/github` was crashing with `404 Not Found` when trying to list commits on PR #9 (`Edsol/main` fork), which no longer exists
- This happened after npm publish succeeded, causing the full release step to fail
- Fix: configure `successComment: false`, `failComment: false`, and `releasedLabels: false` to skip the PR/issue lookup that triggers the error — GitHub releases are still created normally

## Test plan
- [ ] CI Release step completes without 404 error
- [ ] GitHub release is still created for new versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)