### PR TITLE
Relations & N+1: eager-load, window-fn pagination, eagerLoadRelations, composite-PK support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,12 @@ Generated schemas resolve nested relations without N+1 query explosions:
     relation in a single round-trip using Drizzle's relational query builder
     (`with:`), including nested relations and per-relation `where` / `orderBy` /
     `limit` / `offset` arguments.
--   **Mutations** — after an insert or update, if the selection set includes relation
-    fields, the affected rows are re-fetched by primary key through one relational
-    query so their relations are eagerly loaded (single- and composite-column primary
-    keys are supported). `delete` mutations keep using the request-scoped batch loader,
-    since the rows no longer exist to re-fetch.
+-   **Mutations (PostgreSQL & SQLite)** — after an insert or update, if the selection set
+    includes relation fields, the affected rows are re-fetched by primary key through one
+    relational query so their relations are eagerly loaded (single- and composite-column
+    primary keys are supported). `delete` mutations keep using the request-scoped batch
+    loader, since the rows no longer exist to re-fetch. MySQL mutations return only a
+    success flag (no row payload), so this step does not apply there.
 -   **Custom schemas** — each relation field also has a standalone resolver, exported as
     `entities.fieldResolvers[TableName][relationName]`. When you wire generated types
     into your own schema and your root resolver does **not** pre-fetch relations, these

--- a/README.md
+++ b/README.md
@@ -117,3 +117,44 @@ Generated schemas resolve nested relations without N+1 query explosions:
 > rely on SQL window functions. These require **PostgreSQL**, **MySQL 8.0+**, or
 > **SQLite 3.25+**. Relations without pagination, and all other query/mutation paths,
 > have no such requirement.
+
+### Overriding a relation's resolver without overfetching
+
+By default the eager `with:` pre-fetch is driven purely by the GraphQL selection set:
+any selected relation is fetched from the database, even if you intend to resolve it
+yourself (from a cache, another service, a dataloader, …). To override a relation's
+resolver, first opt it out of eager loading with `eagerLoadRelations` so the parent
+query stops fetching it, then supply your resolver with the standard
+[`@graphql-tools/schema`](https://the-guild.dev/graphql/tools) utilities:
+
+```Typescript
+import { addResolversToSchema } from '@graphql-tools/schema'
+
+const { schema } = buildSchema(db, {
+    // Exclude Users.posts from the parent query's `with:` clause.
+    // Other relations keep eager-loading as usual.
+    eagerLoadRelations: (table, relation) => !(table === 'Users' && relation === 'posts'),
+})
+
+const finalSchema = addResolversToSchema({
+    schema,
+    resolvers: {
+        Users: {
+            posts: (parent, args, context) => context.postsLoader.load(parent.id),
+        },
+    },
+})
+```
+
+`eagerLoadRelations` accepts:
+
+-   `true` (default) — eager-load every relation.
+-   `false` — never eager-load; every relation resolves lazily through its
+    (request-batched) field resolver.
+-   `(tableName, relationName) => boolean` — decide per relation. Returning `false`
+    excludes that relation from `with:` (and from the mutation eager re-fetch).
+
+Opting a relation out does **not** remove its field — it keeps resolving lazily via the
+request-scoped batch loader, so the field still works even before you override it. Table
+and relation names are the Drizzle schema keys (e.g. `Users`, `posts`), matching the keys
+of `entities.fieldResolvers`.

--- a/README.md
+++ b/README.md
@@ -84,3 +84,36 @@ Automatically create GraphQL schema or customizable schema config fields from Dr
         console.info('Server is running on http://localhost:4000/graphql')
     })
     ```
+
+## Relations & N+1 handling
+
+Generated schemas resolve nested relations without N+1 query explosions:
+
+-   **Queries** — root queries (`entities.queries.*`) eagerly load every requested
+    relation in a single round-trip using Drizzle's relational query builder
+    (`with:`), including nested relations and per-relation `where` / `orderBy` /
+    `limit` / `offset` arguments.
+-   **Mutations** — after an insert or update, if the selection set includes relation
+    fields, the affected rows are re-fetched by primary key through one relational
+    query so their relations are eagerly loaded (single- and composite-column primary
+    keys are supported). `delete` mutations keep using the request-scoped batch loader,
+    since the rows no longer exist to re-fetch.
+-   **Custom schemas** — each relation field also has a standalone resolver, exported as
+    `entities.fieldResolvers[TableName][relationName]`. When you wire generated types
+    into your own schema and your root resolver does **not** pre-fetch relations, these
+    resolvers batch all sibling loads in a request into a single `IN (…)` query
+    (request-scoped, keyed on the GraphQL `context`), preventing N+1. Per-parent
+    `limit` / `offset` on a to-many relation is applied across the whole batch using a
+    `ROW_NUMBER() OVER (PARTITION BY …)` window function — still one query, not one per
+    parent.
+
+    ```Typescript
+    // entities.fieldResolvers is keyed by table name, then relation name
+    const usersPostsResolver = entities.fieldResolvers.Users.posts
+    ```
+
+> [!IMPORTANT]
+> Per-parent paginated relations (a to-many relation field with `limit` or `offset`)
+> rely on SQL window functions. These require **PostgreSQL**, **MySQL 8.0+**, or
+> **SQLite 3.25+**. Relations without pagination, and all other query/mutation paths,
+> have no such requirement.

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,11 @@ export const buildSchema = <TDbClient extends AnyDrizzleDB<any>>(
 
   const typeNameMapper = config?.typeNameMapper;
 
+  // Normalize eagerLoadRelations (boolean | predicate | undefined) into a predicate.
+  const eagerOpt = config?.eagerLoadRelations;
+  const shouldEagerLoad: (tableName: string, relationName: string) => boolean =
+    eagerOpt === undefined || eagerOpt === true ? () => true : eagerOpt === false ? () => false : eagerOpt;
+
   // When a typeNameMapper is provided, the mapper's singular/plural forms disambiguate the
   // list and single fields even if the suffixes are identical (e.g. both '').
   // Only enforce the suffix-collision check when no mapper is active.
@@ -111,6 +116,7 @@ export const buildSchema = <TDbClient extends AnyDrizzleDB<any>>(
       prefixes,
       suffixes,
       typeNameMapper,
+      shouldEagerLoad,
     );
   } else if (is(db, PgAsyncDatabase)) {
     generatorOutput = generatePG(
@@ -122,6 +128,7 @@ export const buildSchema = <TDbClient extends AnyDrizzleDB<any>>(
       suffixes,
       config?.conflictDoNothing ?? false,
       typeNameMapper,
+      shouldEagerLoad,
     );
   } else if (is(db, BaseSQLiteDatabase)) {
     generatorOutput = generateSQLite(
@@ -132,6 +139,7 @@ export const buildSchema = <TDbClient extends AnyDrizzleDB<any>>(
       prefixes,
       suffixes,
       typeNameMapper,
+      shouldEagerLoad,
     );
   } else {
     throw new Error('Drizzle-GraphQL Error: Unknown database instance type');

--- a/src/types.ts
+++ b/src/types.ts
@@ -467,4 +467,37 @@ export type BuildSchemaConfig = {
    * the `users` table, and leaves other tables with their default names.
    */
   typeNameMapper?: (tableName: string) => { singular: string; plural: string } | undefined;
+  /**
+   * Controls whether a relation is eagerly pre-fetched via Drizzle's `with:` clause
+   * when its parent is loaded through a generated query or mutation.
+   *
+   * `true` (default) — every selected relation is eager-loaded in the parent's query.
+   *
+   * `false` — no relation is ever eager-loaded; all relations resolve lazily through
+   * their (request-batched) field resolvers.
+   *
+   * `(tableName, relationName) => boolean` — decide per relation. Return `false` to
+   * exclude that relation from `with:` (and from the mutation eager re-fetch).
+   *
+   * Opting a relation out does NOT remove its field resolver — it still resolves
+   * lazily via the request-scoped batch loader. This is the hook for overriding a
+   * relation's resolver (e.g. via `@graphql-tools/schema`'s `addResolversToSchema`)
+   * without the eager `with:` query also fetching it from the database:
+   *
+   * ```ts
+   * const { schema } = buildSchema(db, {
+   *   eagerLoadRelations: (t, r) => !(t === 'Users' && r === 'posts'),
+   * });
+   * const finalSchema = addResolversToSchema({
+   *   schema,
+   *   resolvers: { Users: { posts: (parent) => myLoader.load(parent.id) } },
+   * });
+   * ```
+   *
+   * Table and relation names are the Drizzle schema keys (e.g. `Users`, `posts`),
+   * matching the keys of `entities.fieldResolvers`.
+   *
+   * @default true
+   */
+  eagerLoadRelations?: boolean | ((tableName: string, relationName: string) => boolean);
 };

--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -1277,8 +1277,10 @@ export const pruneNonEagerRelations = (
  * Dialect builders pass the composite members' DB column names in via
  * `compositePkColumnNames`; we map them back to property names here.
  *
- * Resolution order: inline PK columns → composite PK columns → a column literally
- * named `id` → empty (caller falls back to the BatchLoader).
+ * Resolution order: inline PK columns → composite PK columns → empty. We deliberately
+ * do NOT guess a column named `id`: if no real primary key is declared, returning empty
+ * lets callers fall back to the batch loader rather than re-keying on a possibly
+ * non-unique column.
  */
 export const getPrimaryKeyPropNames = (table: Table, compositePkColumnNames?: readonly string[]): string[] => {
   const cols = getColumns(table);
@@ -1299,8 +1301,8 @@ export const getPrimaryKeyPropNames = (table: Table, compositePkColumnNames?: re
     }
   }
 
-  // Last resort: a column conventionally named `id`.
-  return cols.id ? ['id'] : [];
+  // No declared primary key — let the caller fall back to the batch loader.
+  return [];
 };
 
 /**

--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -1230,6 +1230,27 @@ export const extractRelationsParams = (
 };
 
 /**
+ * Returns a copy of `relationMap` containing only the relations that should be eagerly
+ * pre-fetched (per the `shouldEagerLoad` predicate). Pass the result wherever a query or
+ * mutation resolver builds its `with:` clause; pass the full map to type generation so
+ * opted-out relations still get a (lazily-resolved) field. Relations excluded here are
+ * never added to `with:`, so they don't overfetch — they resolve through their field
+ * resolver instead (or a resolver you override, e.g. via `@graphql-tools/schema`).
+ */
+export const pruneNonEagerRelations = (
+  relationMap: Record<string, Record<string, TableNamedRelations>>,
+  shouldEagerLoad: (tableName: string, relationName: string) => boolean,
+): Record<string, Record<string, TableNamedRelations>> => {
+  const out: Record<string, Record<string, TableNamedRelations>> = {};
+  for (const [tableName, rels] of Object.entries(relationMap)) {
+    out[tableName] = Object.fromEntries(
+      Object.entries(rels).filter(([relationName]) => shouldEagerLoad(tableName, relationName)),
+    );
+  }
+  return out;
+};
+
+/**
  * Returns the property names of a table's primary key column(s).
  *
  * drizzle-orm marks inline `.primaryKey()` columns with `column.primary === true`,

--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -37,6 +37,7 @@ import {
   One,
   or,
   type SQL,
+  sql,
 } from 'drizzle-orm';
 import type { GraphQLFieldResolver } from 'graphql';
 import {
@@ -53,7 +54,7 @@ import {
 import type { ResolveTree } from 'graphql-parse-resolve-info';
 import { getOrCreateLoader } from '../batch-loader/index.ts';
 import { capitalize } from '../case-ops/index.ts';
-import { remapFromGraphQLCore, remapToGraphQLArrayOutput, remapToGraphQLSingleOutput } from '../data-mappers/index.ts';
+import { remapFromGraphQLCore, remapToGraphQLArrayOutput } from '../data-mappers/index.ts';
 import { drizzleColumnToGraphQLType } from '../type-converter/index.ts';
 import type {
   ConvertedColumn,
@@ -195,41 +196,57 @@ export type RelationResolverFactory = (params: {
   isOne: boolean;
 }) => GraphQLFieldResolver<any, any> | undefined;
 
-const directRelationQuery = async (
+/**
+ * Fetches a to-many relation with per-parent limit/offset for ALL parents in a
+ * single query, using a window function (ROW_NUMBER() OVER (PARTITION BY fk ...)).
+ *
+ * This replaces the previous per-parent fallback that issued one query per parent
+ * (true N+1) whenever pagination args were present. Each parent gets its own
+ * limit/offset window while the database is hit exactly once for the whole batch.
+ *
+ * Window functions require PostgreSQL, MySQL >= 8.0, or SQLite >= 3.25.
+ * Returns raw rows (NOT remapped); the caller groups + remaps them.
+ */
+const batchedPaginatedRelationQuery = async (
   db: any,
   targetTable: Table,
-  targetTableName: string,
   foreignCol: Column,
-  localValue: any,
-  whereArg: any,
+  whereCondition: SQL | undefined,
   orderByArg: any,
-  limit: number | undefined,
-  offset: number | undefined,
-  isOne: boolean,
-): Promise<any> => {
-  const whereCondition = and(
-    eq(foreignCol, localValue),
-    whereArg ? extractFilters(targetTable, targetTableName, whereArg) : undefined,
-  );
+  limit: number | null,
+  offset: number | null,
+): Promise<any[]> => {
+  const cols = getColumns(targetTable);
 
-  let q = db.select().from(targetTable).where(whereCondition) as any;
-  if (orderByArg) {
-    q = q.orderBy(...extractOrderBy(targetTable, orderByArg));
-  }
-  if (offset != null) {
-    q = q.offset(offset);
-  }
+  const orderExprs = orderByArg ? extractOrderBy(targetTable, orderByArg) : [];
+  const orderClause = orderExprs.length ? sql` order by ${sql.join(orderExprs, sql`, `)}` : sql``;
+  const rowNumber = sql`row_number() over (partition by ${foreignCol}${orderClause})`.as('__rn');
+
+  // Subquery: every target column plus a per-partition row number.
+  const sub = db
+    .select({ ...cols, __rn: rowNumber })
+    .from(targetTable)
+    .where(whereCondition)
+    .as('__paginated');
+
+  // Outer: keep only the rows that fall inside each parent's window.
+  const lower = offset ?? 0;
+  const windowConds: any[] = [gt(sub.__rn, lower)];
   if (limit != null) {
-    q = q.limit(limit);
+    windowConds.push(lte(sub.__rn, lower + limit));
   }
-  const rows = await q;
-  if (isOne) {
-    if (!rows[0]) {
-      return null;
-    }
-    return remapToGraphQLSingleOutput(rows[0], targetTableName, targetTable);
+
+  const rows: any[] = await db
+    .select()
+    .from(sub)
+    .where(and(...windowConds))
+    .orderBy(sub.__rn);
+
+  // Strip the helper column so it doesn't leak into remapping/output.
+  for (const row of rows) {
+    delete row.__rn;
   }
-  return remapToGraphQLArrayOutput(rows, targetTableName, targetTable);
+  return rows;
 };
 
 /**
@@ -271,24 +288,16 @@ export const createRelationResolverFactory =
 
       const { where: whereArg, orderBy: orderByArg, limit, offset } = (args ?? {}) as any;
 
-      // Pagination args prevent batching — execute a direct per-item query.
-      if (limit != null || offset != null) {
-        return directRelationQuery(
-          db,
-          targetTable,
-          targetTableName,
-          foreignCol,
-          localValue,
-          whereArg,
-          orderByArg,
-          limit,
-          offset,
-          isOne,
-        );
-      }
-
-      // Batch path: collect all sibling calls in this tick and execute one IN-clause query.
-      const argsKey = JSON.stringify({ where: whereArg ?? null, orderBy: orderByArg ?? null });
+      // Batch path: collect all sibling calls in this tick and execute one query.
+      // Pagination args are part of the loader key so siblings sharing identical
+      // args batch together; per-parent limit/offset is applied inside the batch
+      // via a window function rather than bailing to a per-parent query (N+1).
+      const argsKey = JSON.stringify({
+        where: whereArg ?? null,
+        orderBy: orderByArg ?? null,
+        limit: limit ?? null,
+        offset: offset ?? null,
+      });
       const loaderKey = `${tableName}::${relationName}::${argsKey}`;
 
       const loader = getOrCreateLoader(context, loaderKey, async (parentIds: readonly any[]) => {
@@ -298,13 +307,27 @@ export const createRelationResolverFactory =
           whereArg ? extractFilters(targetTable, targetTableName, whereArg) : undefined,
         );
 
-        // Use plain db.select() so column refs are never aliased — avoids drizzle-orm v1
-        // RQB aliasing requirements that would require referencing via aliasedTable proxy.
-        let q = db.select().from(targetTable).where(whereCondition) as any;
-        if (orderByArg) {
-          q = q.orderBy(...extractOrderBy(targetTable, orderByArg));
+        let rows: any[];
+        if (limit != null || offset != null) {
+          // Per-parent pagination across the whole batch in one query.
+          rows = await batchedPaginatedRelationQuery(
+            db,
+            targetTable,
+            foreignCol,
+            whereCondition,
+            orderByArg,
+            limit ?? null,
+            offset ?? null,
+          );
+        } else {
+          // Use plain db.select() so column refs are never aliased — avoids drizzle-orm v1
+          // RQB aliasing requirements that would require referencing via aliasedTable proxy.
+          let q = db.select().from(targetTable).where(whereCondition) as any;
+          if (orderByArg) {
+            q = q.orderBy(...extractOrderBy(targetTable, orderByArg));
+          }
+          rows = await q;
         }
-        const rows: any[] = await q;
 
         // Group by FK value before remapping (remapping may delete null fields).
         if (isOne) {

--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -155,6 +155,36 @@ export const buildNamedRelations = (
 };
 
 /**
+ * Records each relation's target-table primary-key property names on the relation entry,
+ * so the pagination paths (the window-function batch loader and the eager `with:` orderBy
+ * default) can fall back to a deterministic PK order without re-deriving it per request.
+ *
+ * Composite primary keys are only visible through the dialect's getTableConfig, so the
+ * dialect builder passes a `resolvePkNames` that threads the composite column names in.
+ * Mutates the relation entries in place (they are shared with the pruned eager map and
+ * the resolver factory, so attaching once covers every consumer).
+ */
+export const attachTargetPrimaryKeys = (
+  namedRelations: Record<string, Record<string, TableNamedRelations>>,
+  tables: Record<string, Table>,
+  resolvePkNames: (table: Table) => string[],
+): void => {
+  const cache = new Map<string, readonly string[]>();
+  for (const rels of Object.values(namedRelations)) {
+    for (const relEntry of Object.values(rels)) {
+      const { targetTableName } = relEntry;
+      let pk = cache.get(targetTableName);
+      if (!pk) {
+        const targetTable = tables[targetTableName];
+        pk = targetTable ? resolvePkNames(targetTable) : [];
+        cache.set(targetTableName, pk);
+      }
+      relEntry.targetPkNames = pk;
+    }
+  }
+};
+
+/**
  * Extracts the join column info from a drizzle-orm v1 Relation object.
  * Returns the JS property name of the local column on the parent table and the
  * Column object for the foreign column on the target table, or undefined if the
@@ -215,12 +245,14 @@ const batchedPaginatedRelationQuery = async (
   orderByArg: any,
   limit: number | null,
   offset: number | null,
+  pkNames: readonly string[],
 ): Promise<any[]> => {
   const cols = getColumns(targetTable);
 
   // Always tiebreak the window by the target's primary key so per-parent limit/offset
   // slices are deterministic even when the client supplies no (or a non-unique) orderBy.
-  const pkOrderExprs = getPrimaryKeyPropNames(targetTable)
+  // pkNames is resolved at build time and includes composite keys.
+  const pkOrderExprs = pkNames
     .map((n) => cols[n])
     .filter(Boolean)
     .map((col) => asc(col!));
@@ -280,6 +312,8 @@ export const createRelationResolverFactory =
     }
 
     const { localColPropName, foreignCol, foreignColPropName } = joinCols;
+    // Resolved at build time (composite keys included) — used to tiebreak paginated batches.
+    const targetPkNames = relEntry.targetPkNames ?? [];
 
     return async (parent, args, context) => {
       // Eager path: the parent resolver pre-fetched this relation via Drizzle's `with`.
@@ -324,6 +358,7 @@ export const createRelationResolverFactory =
             orderByArg,
             limit ?? null,
             offset ?? null,
+            targetPkNames,
           );
         } else {
           // Use plain db.select() so column refs are never aliased — avoids drizzle-orm v1
@@ -1165,7 +1200,8 @@ const extractRelationsParamsInner = (
 
   const args: Record<string, Partial<ProcessedTableSelectArgs>> = {};
 
-  for (const [relName, { targetTableName }] of Object.entries(relationsForTable)) {
+  for (const [relName, relEntry] of Object.entries(relationsForTable)) {
+    const { targetTableName, targetPkNames } = relEntry;
     // The relation field resolves to the target table's own type, e.g. "Posts" not "UsersPostsRelation".
     const relTypeName = resolveTypeName(targetTableName, typeNameMapper);
     // Look up by field name OR by alias (when the caller uses an alias for the relation).
@@ -1205,14 +1241,16 @@ const extractRelationsParamsInner = (
       : undefined;
     // When a relation is paginated (limit/offset) but unordered, default to the target's
     // primary key so the per-parent slice is deterministic. Drizzle's RQB calls orderBy
-    // with the aliased table proxy, so resolve the PK columns from it.
+    // with the aliased table proxy, so resolve the PK columns from it. targetPkNames is
+    // resolved at build time and includes composite keys.
     const hasPagination = offset != null || limit != null;
+    const pkNames = targetPkNames ?? [];
     thisRecord.orderBy = relationArgs?.orderBy
       ? (aliasedTable: Table) => extractOrderBy(aliasedTable, relationArgs.orderBy!)
-      : hasPagination
+      : hasPagination && pkNames.length
         ? (aliasedTable: Table) => {
             const aliasedCols = getColumns(aliasedTable);
-            return getPrimaryKeyPropNames(tables[targetTableName]!)
+            return pkNames
               .map((n) => aliasedCols[n])
               .filter(Boolean)
               .map((col) => asc(col!));
@@ -1340,7 +1378,6 @@ export const withPrimaryKeyColumns = <T extends Record<string, any>>(
 export const eagerLoadMutationRelations = async (
   db: any,
   tableName: string,
-  table: Table,
   tables: Record<string, Table>,
   relationMap: Record<string, Record<string, TableNamedRelations>>,
   typeName: string,
@@ -1366,11 +1403,12 @@ export const eagerLoadMutationRelations = async (
     return rows;
   }
 
-  // Every mutated row must carry its primary-key value so the re-fetch can be keyed
-  // back to it. Callers force the PK into RETURNING, but if a value is still missing
-  // (e.g. a table without a real PK) we can't re-key — fall back to the raw rows and
-  // let relations resolve lazily through the batch loader.
-  if (rows.some((row) => pkNames.some((n) => row[n] == null))) {
+  // Only rows that carry every PK value can be re-keyed. Callers force the PK into
+  // RETURNING, but if a value is still missing for some rows, eager-load just those that
+  // are keyable and leave the rest untouched (their relations resolve lazily) rather than
+  // bailing the whole batch.
+  const keyableRows = rows.filter((row) => pkNames.every((n) => row[n] != null));
+  if (!keyableRows.length) {
     return rows;
   }
 
@@ -1391,13 +1429,31 @@ export const eagerLoadMutationRelations = async (
   let whereRaw: (aliased: any) => SQL | undefined;
   if (pkNames.length === 1) {
     const pkName = pkNames[0]!;
-    const ids = rows.map((r) => r[pkName]);
+    const ids = keyableRows.map((r) => r[pkName]);
     // drizzle-orm v1 RQB calls the where callback with the aliased table proxy;
     // reference the PK through it so the column ref matches the CTE alias.
     whereRaw = (aliased: any) => inArray(aliased[pkName], ids);
   } else {
-    // Composite PK: OR together one equality-tuple per mutated row.
-    whereRaw = (aliased: any) => or(...rows.map((row) => and(...pkNames.map((n) => eq(aliased[n], row[n])))));
+    // Composite PK: use a row-value IN — `(a, b) IN ((..), (..))` — so the database can
+    // plan it as a set membership test, instead of an OR of N per-row AND-tuples that
+    // blows up for large bulk mutations.
+    whereRaw = (aliased: any) => {
+      const lhs = sql.join(
+        pkNames.map((n) => sql`${aliased[n]}`),
+        sql`, `,
+      );
+      const tuples = sql.join(
+        keyableRows.map(
+          (row) =>
+            sql`(${sql.join(
+              pkNames.map((n) => sql`${row[n]}`),
+              sql`, `,
+            )})`,
+        ),
+        sql`, `,
+      );
+      return sql`(${lhs}) in (${tuples})`;
+    };
   }
 
   let enriched: any[];

--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -1286,6 +1286,26 @@ export const getPrimaryKeyPropNames = (table: Table, compositePkColumnNames?: re
 };
 
 /**
+ * Ensures a selected-columns map (SQL format: prop name → Column) includes the table's
+ * primary-key columns. Mutation resolvers pass their RETURNING columns through this so
+ * the eager-loader can re-key rows by PK even when the client didn't select it. Mutates
+ * and returns the same map.
+ */
+export const withPrimaryKeyColumns = <T extends Record<string, any>>(
+  columns: T,
+  table: Table,
+  pkNames: readonly string[],
+): T => {
+  const allCols = getColumns(table);
+  for (const pk of pkNames) {
+    if (!(pk in columns) && allCols[pk]) {
+      (columns as any)[pk] = allCols[pk];
+    }
+  }
+  return columns;
+};
+
+/**
  * After a mutation, if the GraphQL selection includes relation fields, re-fetch the
  * mutated rows through the relational query builder so relations are eagerly loaded
  * in a single query — making the per-field BatchLoader fallback unnecessary for
@@ -1326,8 +1346,25 @@ export const eagerLoadMutationRelations = async (
     return rows;
   }
 
+  // Every mutated row must carry its primary-key value so the re-fetch can be keyed
+  // back to it. Callers force the PK into RETURNING, but if a value is still missing
+  // (e.g. a table without a real PK) we can't re-key — fall back to the raw rows and
+  // let relations resolve lazily through the batch loader.
+  if (rows.some((row) => pkNames.some((n) => row[n] == null))) {
+    return rows;
+  }
+
+  // Re-fetch the columns the client selected, plus the PK so enriched rows can be
+  // mapped back to the mutated rows.
   const selectedColumns = extractSelectedColumnsFromTree(parsedInfo.fieldsByTypeName[typeName]!, table);
-  const keyOf = (row: any) => JSON.stringify(pkNames.map((n) => row[n]));
+  for (const pk of pkNames) {
+    selectedColumns[pk] = true;
+  }
+
+  // Normalize bigint PK values to strings: JSON.stringify throws on bigint, and a
+  // bigint and its string form never collide within a single column's values.
+  const keyOf = (row: any) =>
+    JSON.stringify(pkNames.map((n) => (typeof row[n] === 'bigint' ? row[n].toString() : row[n])));
 
   let whereRaw: (aliased: any) => SQL | undefined;
   if (pkNames.length === 1) {
@@ -1341,13 +1378,23 @@ export const eagerLoadMutationRelations = async (
     whereRaw = (aliased: any) => or(...rows.map((row) => and(...pkNames.map((n) => eq(aliased[n], row[n])))));
   }
 
-  const enriched: any[] = await queryBase.findMany({
-    columns: selectedColumns,
-    where: { RAW: whereRaw },
-    with: withParams,
-  });
+  let enriched: any[];
+  try {
+    enriched = await queryBase.findMany({
+      columns: selectedColumns,
+      where: { RAW: whereRaw },
+      with: withParams,
+    });
+  } catch {
+    // The write has already committed; a re-fetch failure (e.g. an RQB-incompatible
+    // column or relation) must not turn a successful mutation into an error. Fall back
+    // to the raw rows — relations then resolve lazily via the batch loader.
+    return rows;
+  }
 
-  // Preserve the mutation's original row order.
+  // Map enriched rows back onto the mutated rows, preserving original order. A row the
+  // re-fetch didn't return (e.g. deleted concurrently) keeps its original value rather
+  // than being dropped, so the result never reports fewer rows than were mutated.
   const byKey = new Map(enriched.map((r) => [keyOf(r), r]));
-  return rows.map((r) => byKey.get(keyOf(r))).filter((r) => r !== undefined);
+  return rows.map((r) => byKey.get(keyOf(r)) ?? r);
 };

--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -53,7 +53,7 @@ import {
 } from 'graphql';
 import type { ResolveTree } from 'graphql-parse-resolve-info';
 import { getOrCreateLoader } from '../batch-loader/index.ts';
-import { capitalize } from '../case-ops/index.ts';
+import { capitalize, uncapitalize } from '../case-ops/index.ts';
 import { remapFromGraphQLCore, remapToGraphQLArrayOutput } from '../data-mappers/index.ts';
 import { drizzleColumnToGraphQLType } from '../type-converter/index.ts';
 import type {
@@ -1414,6 +1414,69 @@ export const prepareMutationRelationColumns = (params: {
   const columns = hasRelations ? withPrimaryKeyColumns(baseColumns, table, pkNames) : baseColumns;
   return { columns, hasRelations, withParams };
 };
+
+/** Wraps a thrown Error as a (message-only) GraphQLError; passes non-Errors through unchanged. */
+export const toGraphQLError = (e: unknown): unknown => (e instanceof Error ? new GraphQLError(e.message) : e);
+
+/**
+ * Derives the generated query/mutation field names for a table from the naming config
+ * (typeNameMapper + prefixes/suffixes). Shared by all three dialect builders.
+ */
+export const computeResolverFieldNames = (
+  tableName: string,
+  typeNameMapper: TypeNameMapper | undefined,
+  prefixes: { insert: string; update: string; delete: string },
+  suffixes: { list: string; single: string },
+): {
+  typeName: string;
+  listFieldName: string;
+  singleFieldName: string;
+  createArrayFieldName: string;
+  createSingleFieldName: string;
+  updateFieldName: string;
+  deleteFieldName: string;
+} => {
+  const mapped = typeNameMapper?.(tableName);
+  const typeName = mapped ? capitalize(mapped.singular) : capitalize(tableName);
+  const listFieldName = (mapped?.plural ?? uncapitalize(tableName)) + suffixes.list;
+  const singleFieldName = mapped?.singular ?? uncapitalize(tableName) + suffixes.single;
+  const createArrayFieldName = `${prefixes.insert}${mapped ? capitalize(mapped.plural) : capitalize(tableName)}`;
+  const createSingleFieldName = mapped
+    ? `${prefixes.insert}${capitalize(mapped.singular)}`
+    : `${prefixes.insert}${capitalize(tableName)}${suffixes.single}`;
+  const updateFieldName = `${prefixes.update}${mapped ? capitalize(mapped.singular) : capitalize(tableName)}`;
+  const deleteFieldName = `${prefixes.delete}${mapped ? capitalize(mapped.singular) : capitalize(tableName)}`;
+  return {
+    typeName,
+    listFieldName,
+    singleFieldName,
+    createArrayFieldName,
+    createSingleFieldName,
+    updateFieldName,
+    deleteFieldName,
+  };
+};
+
+/** GraphQL argument map for a list/array select field. */
+export const selectArrayArgs = (
+  orderArgs: GraphQLInputObjectType,
+  filterArgs: GraphQLInputObjectType,
+): Record<string, { type: any }> => ({
+  offset: { type: GraphQLInt },
+  limit: { type: GraphQLInt },
+  orderBy: { type: orderArgs },
+  where: { type: filterArgs },
+});
+
+/** GraphQL argument map for a single-row select field (no `limit`). */
+export const selectSingleArgs = (
+  orderArgs: GraphQLInputObjectType,
+  filterArgs: GraphQLInputObjectType,
+): Record<string, { type: any }> => ({
+  offset: { type: GraphQLInt },
+  orderBy: { type: orderArgs },
+  where: { type: filterArgs },
+});
 
 /**
  * After a mutation, re-fetch the mutated rows through the relational query builder so the

--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -252,37 +252,38 @@ const batchedPaginatedRelationQuery = async (
   // Always tiebreak the window by the target's primary key so per-parent limit/offset
   // slices are deterministic even when the client supplies no (or a non-unique) orderBy.
   // pkNames is resolved at build time and includes composite keys.
-  const pkOrderExprs = pkNames
-    .map((n) => cols[n])
-    .filter(Boolean)
-    .map((col) => asc(col!));
-  const orderExprs = [...(orderByArg ? extractOrderBy(targetTable, orderByArg) : []), ...pkOrderExprs];
+  const orderExprs = [
+    ...(orderByArg ? extractOrderBy(targetTable, orderByArg) : []),
+    ...primaryKeyOrderExprs(targetTable, pkNames),
+  ];
   const orderClause = orderExprs.length ? sql` order by ${sql.join(orderExprs, sql`, `)}` : sql``;
-  const rowNumber = sql`row_number() over (partition by ${foreignCol}${orderClause})`.as('__rn');
+  // Namespaced alias so it can't collide with a real column on the target table.
+  const RN = '__drizzle_graphql_rn';
+  const rowNumber = sql`row_number() over (partition by ${foreignCol}${orderClause})`.as(RN);
 
   // Subquery: every target column plus a per-partition row number.
   const sub = db
-    .select({ ...cols, __rn: rowNumber })
+    .select({ ...cols, [RN]: rowNumber })
     .from(targetTable)
     .where(whereCondition)
     .as('__paginated');
 
   // Outer: keep only the rows that fall inside each parent's window.
   const lower = offset ?? 0;
-  const windowConds: any[] = [gt(sub.__rn, lower)];
+  const windowConds: any[] = [gt(sub[RN], lower)];
   if (limit != null) {
-    windowConds.push(lte(sub.__rn, lower + limit));
+    windowConds.push(lte(sub[RN], lower + limit));
   }
 
   const rows: any[] = await db
     .select()
     .from(sub)
     .where(and(...windowConds))
-    .orderBy(sub.__rn);
+    .orderBy(sub[RN]);
 
   // Strip the helper column so it doesn't leak into remapping/output.
   for (const row of rows) {
-    delete row.__rn;
+    delete row[RN];
   }
   return rows;
 };
@@ -1248,13 +1249,7 @@ const extractRelationsParamsInner = (
     thisRecord.orderBy = relationArgs?.orderBy
       ? (aliasedTable: Table) => extractOrderBy(aliasedTable, relationArgs.orderBy!)
       : hasPagination && pkNames.length
-        ? (aliasedTable: Table) => {
-            const aliasedCols = getColumns(aliasedTable);
-            return pkNames
-              .map((n) => aliasedCols[n])
-              .filter(Boolean)
-              .map((col) => asc(col!));
-          }
+        ? (aliasedTable: Table) => primaryKeyOrderExprs(aliasedTable, pkNames)
         : undefined;
     thisRecord.offset = offset;
     thisRecord.limit = limit;
@@ -1361,6 +1356,63 @@ export const withPrimaryKeyColumns = <T extends Record<string, any>>(
     }
   }
   return columns;
+};
+
+/**
+ * Resolves a table's primary-key property names using a dialect's `getTableConfig` to
+ * surface table-level composite keys (whose member columns aren't flagged `.primary`).
+ * Each dialect builder binds this with its own getTableConfig and reuses the binding for
+ * both relation pagination and mutation re-fetch keying.
+ */
+export const getPrimaryKeyPropNamesFromConfig = (
+  table: Table,
+  getTableConfig: (table: Table) => { primaryKeys: { columns: { name: string }[] }[] },
+): string[] => {
+  const compositePkColumnNames = getTableConfig(table).primaryKeys.flatMap((pk) => pk.columns.map((c) => c.name));
+  return getPrimaryKeyPropNames(table, compositePkColumnNames);
+};
+
+/**
+ * Ascending order expressions for a table's primary key — the deterministic tiebreak for
+ * paginated relations. Shared by the window-function batch path and the eager `with:`
+ * orderBy default so both order identically. `table` may be the aliased RQB proxy.
+ */
+export const primaryKeyOrderExprs = (table: Table, pkNames: readonly string[]): any[] => {
+  const cols = getColumns(table);
+  return pkNames
+    .map((n) => cols[n])
+    .filter(Boolean)
+    .map((col) => asc(col!));
+};
+
+/**
+ * Computes the RETURNING columns and relation selection for a mutation resolver: extracts
+ * the selected scalar columns, determines whether any relations were selected, and only
+ * then forces the primary key into the column set (so the post-mutation eager-load can
+ * re-key rows). Returns everything the resolver needs to decide whether to eager-load.
+ */
+export const prepareMutationRelationColumns = (params: {
+  relationMap: Record<string, Record<string, TableNamedRelations>>;
+  tables: Record<string, Table>;
+  tableName: string;
+  typeName: string;
+  typeNameMapper: TypeNameMapper | undefined;
+  table: Table;
+  pkNames: readonly string[];
+  parsedInfo: ResolveTree;
+}): {
+  columns: Record<string, Column>;
+  hasRelations: boolean;
+  withParams: Record<string, Partial<ProcessedTableSelectArgs>> | undefined;
+} => {
+  const { relationMap, tables, tableName, typeName, typeNameMapper, table, pkNames, parsedInfo } = params;
+  const withParams = relationMap[tableName]
+    ? extractRelationsParams(relationMap, tables, tableName, parsedInfo, typeName, typeNameMapper)
+    : undefined;
+  const hasRelations = !!(withParams && Object.keys(withParams).length);
+  const baseColumns = extractSelectedColumnsFromTreeSQLFormat(parsedInfo.fieldsByTypeName[typeName]!, table);
+  const columns = hasRelations ? withPrimaryKeyColumns(baseColumns, table, pkNames) : baseColumns;
+  return { columns, hasRelations, withParams };
 };
 
 /**

--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -218,7 +218,13 @@ const batchedPaginatedRelationQuery = async (
 ): Promise<any[]> => {
   const cols = getColumns(targetTable);
 
-  const orderExprs = orderByArg ? extractOrderBy(targetTable, orderByArg) : [];
+  // Always tiebreak the window by the target's primary key so per-parent limit/offset
+  // slices are deterministic even when the client supplies no (or a non-unique) orderBy.
+  const pkOrderExprs = getPrimaryKeyPropNames(targetTable)
+    .map((n) => cols[n])
+    .filter(Boolean)
+    .map((col) => asc(col!));
+  const orderExprs = [...(orderByArg ? extractOrderBy(targetTable, orderByArg) : []), ...pkOrderExprs];
   const orderClause = orderExprs.length ? sql` order by ${sql.join(orderExprs, sql`, `)}` : sql``;
   const rowNumber = sql`row_number() over (partition by ${foreignCol}${orderClause})`.as('__rn');
 
@@ -1197,9 +1203,21 @@ const extractRelationsParamsInner = (
     thisRecord.where = relWhere
       ? { RAW: (aliasedTable: Table) => extractFilters(aliasedTable, relName, relWhere) }
       : undefined;
+    // When a relation is paginated (limit/offset) but unordered, default to the target's
+    // primary key so the per-parent slice is deterministic. Drizzle's RQB calls orderBy
+    // with the aliased table proxy, so resolve the PK columns from it.
+    const hasPagination = offset != null || limit != null;
     thisRecord.orderBy = relationArgs?.orderBy
       ? (aliasedTable: Table) => extractOrderBy(aliasedTable, relationArgs.orderBy!)
-      : undefined;
+      : hasPagination
+        ? (aliasedTable: Table) => {
+            const aliasedCols = getColumns(aliasedTable);
+            return getPrimaryKeyPropNames(tables[targetTableName]!)
+              .map((n) => aliasedCols[n])
+              .filter(Boolean)
+              .map((col) => asc(col!));
+          }
+        : undefined;
     thisRecord.offset = offset;
     thisRecord.limit = limit;
 

--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -1372,12 +1372,14 @@ export const eagerLoadMutationRelations = async (
     return rows;
   }
 
-  // Re-fetch the columns the client selected, plus the PK so enriched rows can be
-  // mapped back to the mutated rows.
-  const selectedColumns = extractSelectedColumnsFromTree(parsedInfo.fieldsByTypeName[typeName]!, table);
+  // Re-fetch ONLY the primary key + relations: the scalar columns are already present
+  // on `rows` from RETURNING, so re-selecting them would transfer them a second time
+  // (and would lose them on the fallback path). We merge the fetched relations back in.
+  const pkColumns: Record<string, true> = {};
   for (const pk of pkNames) {
-    selectedColumns[pk] = true;
+    pkColumns[pk] = true;
   }
+  const relationNames = Object.keys(withParams);
 
   // Normalize bigint PK values to strings: JSON.stringify throws on bigint, and a
   // bigint and its string form never collide within a single column's values.
@@ -1399,7 +1401,7 @@ export const eagerLoadMutationRelations = async (
   let enriched: any[];
   try {
     enriched = await queryBase.findMany({
-      columns: selectedColumns,
+      columns: pkColumns,
       where: { RAW: whereRaw },
       with: withParams,
     });
@@ -1410,9 +1412,18 @@ export const eagerLoadMutationRelations = async (
     return rows;
   }
 
-  // Map enriched rows back onto the mutated rows, preserving original order. A row the
-  // re-fetch didn't return (e.g. deleted concurrently) keeps its original value rather
-  // than being dropped, so the result never reports fewer rows than were mutated.
-  const byKey = new Map(enriched.map((r) => [keyOf(r), r]));
-  return rows.map((r) => byKey.get(keyOf(r)) ?? r);
+  // Merge the fetched relations onto the RETURNING rows in place, preserving order. A row
+  // the re-fetch didn't return (e.g. deleted concurrently) keeps its scalar columns and
+  // its relations resolve lazily, so the result never reports fewer rows than were mutated.
+  const byKey = new Map(enriched.map((e) => [keyOf(e), e]));
+  for (const row of rows) {
+    const match = byKey.get(keyOf(row));
+    if (!match) {
+      continue;
+    }
+    for (const rel of relationNames) {
+      row[rel] = match[rel];
+    }
+  }
+  return rows;
 };

--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -54,7 +54,7 @@ import {
 import type { ResolveTree } from 'graphql-parse-resolve-info';
 import { getOrCreateLoader } from '../batch-loader/index.ts';
 import { capitalize, uncapitalize } from '../case-ops/index.ts';
-import { remapFromGraphQLCore, remapToGraphQLArrayOutput } from '../data-mappers/index.ts';
+import { remapFromGraphQLCore, remapToGraphQLArrayOutput, remapToGraphQLSingleOutput } from '../data-mappers/index.ts';
 import { drizzleColumnToGraphQLType } from '../type-converter/index.ts';
 import type {
   ConvertedColumn,
@@ -1477,6 +1477,64 @@ export const selectSingleArgs = (
   orderBy: { type: orderArgs },
   where: { type: filterArgs },
 });
+
+/**
+ * Runs the relational-query-builder select shared by every dialect's `generateSelect*`
+ * resolver: selected columns + offset/limit + aliased orderBy/where callbacks + the eager
+ * `with:` relation params, then remaps the result. `single` switches between
+ * findFirst/findMany (and the single path omits `limit`). The PG fallback for tables
+ * without RQB support stays in pg.ts; this covers the common RQB path for all three.
+ */
+export const runRelationalSelect = async (opts: {
+  queryBase: any;
+  tables: Record<string, Table>;
+  tableName: string;
+  table: Table;
+  relationMap: Record<string, Record<string, TableNamedRelations>>;
+  typeName: string;
+  typeNameMapper: TypeNameMapper | undefined;
+  parsedInfo: ResolveTree;
+  offset?: number;
+  limit?: number;
+  orderBy?: any;
+  where?: any;
+  single: boolean;
+}): Promise<any> => {
+  const {
+    queryBase,
+    tables,
+    tableName,
+    table,
+    relationMap,
+    typeName,
+    typeNameMapper,
+    parsedInfo,
+    offset,
+    orderBy,
+    where,
+    single,
+  } = opts;
+  const params: any = {
+    columns: extractSelectedColumnsFromTree(parsedInfo.fieldsByTypeName[typeName]!, table),
+    offset,
+    // drizzle-orm v1 RQB calls orderBy/where with the aliased table proxy — use it
+    // directly so column refs match the CTE alias.
+    orderBy: orderBy ? (aliasedTable: Table) => extractOrderBy(aliasedTable, orderBy) : undefined,
+    where: where ? { RAW: (aliasedTable: Table) => extractFilters(aliasedTable, tableName, where) } : undefined,
+    with: relationMap[tableName]
+      ? extractRelationsParams(relationMap, tables, tableName, parsedInfo, typeName, typeNameMapper)
+      : undefined,
+  };
+
+  if (single) {
+    const result = await queryBase.findFirst(params);
+    return result ? remapToGraphQLSingleOutput(result, tableName, table, relationMap) : undefined;
+  }
+
+  params.limit = opts.limit;
+  const result = await queryBase.findMany(params);
+  return remapToGraphQLArrayOutput(result, tableName, table, relationMap);
+};
 
 /**
  * After a mutation, re-fetch the mutated rows through the relational query builder so the

--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -1228,3 +1228,105 @@ export const extractRelationsParams = (
 
   return extractRelationsParamsInner(relationMap, tables, tableName, typeName, info, typeNameMapper, true);
 };
+
+/**
+ * Returns the property names of a table's primary key column(s).
+ *
+ * drizzle-orm marks inline `.primaryKey()` columns with `column.primary === true`,
+ * but table-level composite keys (`primaryKey({ columns })`) leave `column.primary`
+ * false on each member — those are only visible via the per-dialect `getTableConfig`.
+ * Dialect builders pass the composite members' DB column names in via
+ * `compositePkColumnNames`; we map them back to property names here.
+ *
+ * Resolution order: inline PK columns → composite PK columns → a column literally
+ * named `id` → empty (caller falls back to the BatchLoader).
+ */
+export const getPrimaryKeyPropNames = (table: Table, compositePkColumnNames?: readonly string[]): string[] => {
+  const cols = getColumns(table);
+  const entries = Object.entries(cols);
+
+  // Inline single `.primaryKey()` columns.
+  const inlinePks = entries.filter(([, c]) => (c as any).primary).map(([k]) => k);
+  if (inlinePks.length) {
+    return inlinePks;
+  }
+
+  // Composite primary key (DB column names supplied by the dialect builder).
+  if (compositePkColumnNames?.length) {
+    const wanted = new Set(compositePkColumnNames);
+    const fromComposite = entries.filter(([, c]) => wanted.has((c as any).name)).map(([k]) => k);
+    if (fromComposite.length) {
+      return fromComposite;
+    }
+  }
+
+  // Last resort: a column conventionally named `id`.
+  return cols.id ? ['id'] : [];
+};
+
+/**
+ * After a mutation, if the GraphQL selection includes relation fields, re-fetch the
+ * mutated rows through the relational query builder so relations are eagerly loaded
+ * in a single query — making the per-field BatchLoader fallback unnecessary for
+ * mutation results.
+ *
+ * Falls back to the original `.returning()` rows (relations then resolve via the
+ * field-level BatchLoader) when no relations are selected, when the table has no RQB
+ * support, or when no primary key columns can be determined.
+ *
+ * Supports single- and multi-column primary keys.
+ */
+export const eagerLoadMutationRelations = async (
+  db: any,
+  tableName: string,
+  table: Table,
+  tables: Record<string, Table>,
+  relationMap: Record<string, Record<string, TableNamedRelations>>,
+  typeName: string,
+  typeNameMapper: TypeNameMapper | undefined,
+  parsedInfo: ResolveTree,
+  rows: any[],
+  pkNames: string[],
+): Promise<any[]> => {
+  if (!rows.length || !pkNames.length) {
+    return rows;
+  }
+
+  const withParams = relationMap[tableName]
+    ? extractRelationsParams(relationMap, tables, tableName, parsedInfo, typeName, typeNameMapper)
+    : undefined;
+  // No relations requested — nothing to eager-load.
+  if (!withParams || !Object.keys(withParams).length) {
+    return rows;
+  }
+
+  const queryBase = db.query?.[tableName];
+  if (!queryBase) {
+    return rows;
+  }
+
+  const selectedColumns = extractSelectedColumnsFromTree(parsedInfo.fieldsByTypeName[typeName]!, table);
+  const keyOf = (row: any) => JSON.stringify(pkNames.map((n) => row[n]));
+
+  let whereRaw: (aliased: any) => SQL | undefined;
+  if (pkNames.length === 1) {
+    const pkName = pkNames[0]!;
+    const ids = rows.map((r) => r[pkName]);
+    // drizzle-orm v1 RQB calls the where callback with the aliased table proxy;
+    // reference the PK through it so the column ref matches the CTE alias.
+    whereRaw = (aliased: any) => inArray(aliased[pkName], ids);
+  } else {
+    // Composite PK: OR together one equality-tuple per mutated row.
+    whereRaw = (aliased: any) => or(...rows.map((row) => and(...pkNames.map((n) => eq(aliased[n], row[n])))));
+  }
+
+  const enriched: any[] = await queryBase.findMany({
+    columns: selectedColumns,
+    where: { RAW: whereRaw },
+    with: withParams,
+  });
+
+  // Preserve the mutation's original row order.
+  const byKey = new Map(enriched.map((r) => [keyOf(r), r]));
+  return rows.map((r) => byKey.get(keyOf(r))).filter((r) => r !== undefined);
+};

--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -1364,37 +1364,26 @@ export const withPrimaryKeyColumns = <T extends Record<string, any>>(
 };
 
 /**
- * After a mutation, if the GraphQL selection includes relation fields, re-fetch the
- * mutated rows through the relational query builder so relations are eagerly loaded
- * in a single query — making the per-field BatchLoader fallback unnecessary for
- * mutation results.
+ * After a mutation, re-fetch the mutated rows through the relational query builder so the
+ * selected relations are eagerly loaded in a single query, then merge those relations onto
+ * the `.returning()` rows — making the per-field BatchLoader fallback unnecessary.
+ *
+ * `withParams` is the pre-computed relation selection (from extractRelationsParams); the
+ * caller only invokes this when relations are actually selected, so it also gates whether
+ * the PK was forced into RETURNING.
  *
  * Falls back to the original `.returning()` rows (relations then resolve via the
- * field-level BatchLoader) when no relations are selected, when the table has no RQB
- * support, or when no primary key columns can be determined.
- *
- * Supports single- and multi-column primary keys.
+ * field-level BatchLoader) when the table has no RQB support, no primary key columns can be
+ * determined, or the re-fetch fails. Supports single- and multi-column primary keys.
  */
 export const eagerLoadMutationRelations = async (
   db: any,
   tableName: string,
-  tables: Record<string, Table>,
-  relationMap: Record<string, Record<string, TableNamedRelations>>,
-  typeName: string,
-  typeNameMapper: TypeNameMapper | undefined,
-  parsedInfo: ResolveTree,
   rows: any[],
-  pkNames: string[],
+  pkNames: readonly string[],
+  withParams: Record<string, Partial<ProcessedTableSelectArgs>> | undefined,
 ): Promise<any[]> => {
-  if (!rows.length || !pkNames.length) {
-    return rows;
-  }
-
-  const withParams = relationMap[tableName]
-    ? extractRelationsParams(relationMap, tables, tableName, parsedInfo, typeName, typeNameMapper)
-    : undefined;
-  // No relations requested — nothing to eager-load.
-  if (!withParams || !Object.keys(withParams).length) {
+  if (!rows.length || !pkNames.length || !withParams || !Object.keys(withParams).length) {
     return rows;
   }
 
@@ -1463,10 +1452,16 @@ export const eagerLoadMutationRelations = async (
       where: { RAW: whereRaw },
       with: withParams,
     });
-  } catch {
+  } catch (err) {
     // The write has already committed; a re-fetch failure (e.g. an RQB-incompatible
     // column or relation) must not turn a successful mutation into an error. Fall back
-    // to the raw rows — relations then resolve lazily via the batch loader.
+    // to the raw rows — relations then resolve lazily via the batch loader — but surface
+    // the cause so a genuine misconfiguration isn't silently hidden.
+    console.warn(
+      `[drizzle-graphql] eager-loading relations for a "${tableName}" mutation failed; ` +
+        'falling back to lazy resolution.',
+      err,
+    );
     return rows;
   }
 

--- a/src/util/builders/mysql.ts
+++ b/src/util/builders/mysql.ts
@@ -24,6 +24,7 @@ import {
   extractRelationsParams,
   extractSelectedColumnsFromTree,
   generateTableTypes,
+  pruneNonEagerRelations,
   type RelationResolverFactory,
   type TablesRelationalConfig,
   type TypeCacheCtx,
@@ -359,6 +360,7 @@ export const generateSchemaData = <
   prefixes: MakeRequired<MakeRequired<BuildSchemaConfig>['prefixes']>,
   suffixes: MakeRequired<MakeRequired<BuildSchemaConfig>['suffixes']>,
   typeNameMapper?: TypeNameMapper,
+  shouldEagerLoad: (tableName: string, relationName: string) => boolean = () => true,
 ): GeneratedEntities<TDrizzleInstance, TSchema> => {
   const rawSchema = schema;
   const schemaEntries = Object.entries(rawSchema);
@@ -374,6 +376,8 @@ export const generateSchemaData = <
 
   // Build namedRelations from the drizzle-orm v1 relations config.
   const namedRelations = buildNamedRelations(relations ?? {}, tableEntries);
+  // Pruned map for query resolvers' `with:`; type generation keeps the full map.
+  const eagerRelations = pruneNonEagerRelations(namedRelations, shouldEagerLoad);
 
   const resolverFactory: RelationResolverFactory = createRelationResolverFactory(db, tables);
 
@@ -443,7 +447,7 @@ export const generateSchemaData = <
       db,
       tableName,
       tables,
-      namedRelations,
+      eagerRelations,
       tableOrder,
       tableFilters,
       listFieldName,
@@ -454,7 +458,7 @@ export const generateSchemaData = <
       db,
       tableName,
       tables,
-      namedRelations,
+      eagerRelations,
       tableOrder,
       tableFilters,
       singleFieldName,

--- a/src/util/builders/mysql.ts
+++ b/src/util/builders/mysql.ts
@@ -21,13 +21,11 @@ import {
   computeResolverFieldNames,
   createRelationResolverFactory,
   extractFilters,
-  extractOrderBy,
-  extractRelationsParams,
-  extractSelectedColumnsFromTree,
   generateTableTypes,
   getPrimaryKeyPropNamesFromConfig,
   pruneNonEagerRelations,
   type RelationResolverFactory,
+  runRelationalSelect,
   selectArrayArgs,
   selectSingleArgs,
   type TablesRelationalConfig,
@@ -36,12 +34,7 @@ import {
   toGraphQLError,
 } from '../builders/common.ts';
 
-import {
-  remapFromGraphQLArrayInput,
-  remapFromGraphQLSingleInput,
-  remapToGraphQLArrayOutput,
-  remapToGraphQLSingleOutput,
-} from '../data-mappers/index.ts';
+import { remapFromGraphQLArrayInput, remapFromGraphQLSingleInput } from '../data-mappers/index.ts';
 import type { CreatedResolver, Filters, TableNamedRelations, TableSelectArgs } from './types.ts';
 
 const generateSelectArray = (
@@ -72,34 +65,21 @@ const generateSelectArray = (
     name: fieldName,
     resolver: async (_source, args: Partial<TableSelectArgs>, _context, info) => {
       try {
-        const { offset, limit, orderBy, where } = args;
-
-        const parsedInfo = parseResolveInfo(info, {
-          deep: true,
-        }) as ResolveTree;
-
-        const query = queryBase.findMany({
-          columns: extractSelectedColumnsFromTree(parsedInfo.fieldsByTypeName[typeName]!, table),
-          offset,
-          limit,
-          // drizzle-orm v1 RQB calls orderBy with the aliased table proxy —
-          // use it directly so column refs match the CTE alias.
-          orderBy: orderBy ? (aliasedTable: Table) => extractOrderBy(aliasedTable, orderBy) : undefined,
-          where: where ? { RAW: (aliased: Table) => extractFilters(aliased, tableName, where) } : undefined,
-          with: relationMap[tableName]
-            ? extractRelationsParams(relationMap, tables, tableName, parsedInfo, typeName, typeNameMapper)
-            : undefined,
+        const parsedInfo = parseResolveInfo(info, { deep: true }) as ResolveTree;
+        return await runRelationalSelect({
+          queryBase,
+          tables,
+          tableName,
+          table,
+          relationMap,
+          typeName,
+          typeNameMapper,
+          parsedInfo,
+          ...args,
+          single: false,
         });
-
-        const result = await query;
-
-        return remapToGraphQLArrayOutput(result, tableName, table, relationMap);
       } catch (e) {
-        if (e instanceof Error) {
-          throw new GraphQLError((e as any).message);
-        }
-
-        throw e;
+        throw toGraphQLError(e);
       }
     },
     args: queryArgs,
@@ -134,36 +114,21 @@ const generateSelectSingle = (
     name: fieldName,
     resolver: async (_source, args: Partial<TableSelectArgs>, _context, info) => {
       try {
-        const { offset, orderBy, where } = args;
-
-        const parsedInfo = parseResolveInfo(info, {
-          deep: true,
-        }) as ResolveTree;
-
-        const query = queryBase.findFirst({
-          columns: extractSelectedColumnsFromTree(parsedInfo.fieldsByTypeName[typeName]!, table),
-          offset,
-          // drizzle-orm v1 RQB calls orderBy with the aliased table proxy —
-          // use it directly so column refs match the CTE alias.
-          orderBy: orderBy ? (aliasedTable: Table) => extractOrderBy(aliasedTable, orderBy) : undefined,
-          where: where ? { RAW: (aliased: Table) => extractFilters(aliased, tableName, where) } : undefined,
-          with: relationMap[tableName]
-            ? extractRelationsParams(relationMap, tables, tableName, parsedInfo, typeName, typeNameMapper)
-            : undefined,
+        const parsedInfo = parseResolveInfo(info, { deep: true }) as ResolveTree;
+        return await runRelationalSelect({
+          queryBase,
+          tables,
+          tableName,
+          table,
+          relationMap,
+          typeName,
+          typeNameMapper,
+          parsedInfo,
+          ...args,
+          single: true,
         });
-
-        const result = await query;
-        if (!result) {
-          return undefined;
-        }
-
-        return remapToGraphQLSingleOutput(result, tableName, table, relationMap);
       } catch (e) {
-        if (e instanceof Error) {
-          throw new GraphQLError((e as any).message);
-        }
-
-        throw e;
+        throw toGraphQLError(e);
       }
     },
     args: queryArgs,

--- a/src/util/builders/mysql.ts
+++ b/src/util/builders/mysql.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck — vendored file, drizzle-orm 1.0 type compat not guaranteed
 import { is, One, type Table } from 'drizzle-orm';
-import { type MySqlDatabase, MySqlTable } from 'drizzle-orm/mysql-core';
+import { getTableConfig, type MySqlDatabase, MySqlTable } from 'drizzle-orm/mysql-core';
 import type { RelationalQueryBuilder } from 'drizzle-orm/mysql-core/query-builders/query';
 import type { GraphQLFieldConfig, GraphQLFieldConfigArgumentMap, ThunkObjMap } from 'graphql';
 import {
@@ -17,6 +17,7 @@ import { parseResolveInfo } from 'graphql-parse-resolve-info';
 
 import type { BuildSchemaConfig, GeneratedEntities, MakeRequired } from '../../types.ts';
 import {
+  attachTargetPrimaryKeys,
   buildNamedRelations,
   createRelationResolverFactory,
   extractFilters,
@@ -24,6 +25,7 @@ import {
   extractRelationsParams,
   extractSelectedColumnsFromTree,
   generateTableTypes,
+  getPrimaryKeyPropNames,
   pruneNonEagerRelations,
   type RelationResolverFactory,
   type TablesRelationalConfig,
@@ -349,6 +351,14 @@ const generateDelete = (
   };
 };
 
+/** Primary-key property names for a MySQL table, including table-level composite keys. */
+const mysqlPrimaryKeyPropNames = (table: MySqlTable): string[] => {
+  const compositePkColumnNames = getTableConfig(table).primaryKeys.flatMap((pk: any) =>
+    pk.columns.map((c: any) => c.name),
+  );
+  return getPrimaryKeyPropNames(table, compositePkColumnNames);
+};
+
 export const generateSchemaData = <
   TDrizzleInstance extends MySqlDatabase<any, any, any, any>,
   TSchema extends Record<string, Table | unknown>,
@@ -376,6 +386,9 @@ export const generateSchemaData = <
 
   // Build namedRelations from the drizzle-orm v1 relations config.
   const namedRelations = buildNamedRelations(relations ?? {}, tableEntries);
+  // Record each relation target's (composite-aware) primary key for deterministic
+  // paginated ordering. Must run before pruning / type generation (shared entry objects).
+  attachTargetPrimaryKeys(namedRelations, tables, mysqlPrimaryKeyPropNames);
   // Pruned map for query resolvers' `with:`; type generation keeps the full map.
   const eagerRelations = pruneNonEagerRelations(namedRelations, shouldEagerLoad);
 

--- a/src/util/builders/mysql.ts
+++ b/src/util/builders/mysql.ts
@@ -25,7 +25,7 @@ import {
   extractRelationsParams,
   extractSelectedColumnsFromTree,
   generateTableTypes,
-  getPrimaryKeyPropNames,
+  getPrimaryKeyPropNamesFromConfig,
   pruneNonEagerRelations,
   type RelationResolverFactory,
   type TablesRelationalConfig,
@@ -352,12 +352,8 @@ const generateDelete = (
 };
 
 /** Primary-key property names for a MySQL table, including table-level composite keys. */
-const mysqlPrimaryKeyPropNames = (table: MySqlTable): string[] => {
-  const compositePkColumnNames = getTableConfig(table).primaryKeys.flatMap((pk: any) =>
-    pk.columns.map((c: any) => c.name),
-  );
-  return getPrimaryKeyPropNames(table, compositePkColumnNames);
-};
+const mysqlPrimaryKeyPropNames = (table: MySqlTable): string[] =>
+  getPrimaryKeyPropNamesFromConfig(table, getTableConfig);
 
 export const generateSchemaData = <
   TDrizzleInstance extends MySqlDatabase<any, any, any, any>,

--- a/src/util/builders/mysql.ts
+++ b/src/util/builders/mysql.ts
@@ -7,7 +7,6 @@ import {
   GraphQLBoolean,
   GraphQLError,
   type GraphQLInputObjectType,
-  GraphQLInt,
   GraphQLList,
   GraphQLNonNull,
   GraphQLObjectType,
@@ -19,6 +18,7 @@ import type { BuildSchemaConfig, GeneratedEntities, MakeRequired } from '../../t
 import {
   attachTargetPrimaryKeys,
   buildNamedRelations,
+  computeResolverFieldNames,
   createRelationResolverFactory,
   extractFilters,
   extractOrderBy,
@@ -28,11 +28,13 @@ import {
   getPrimaryKeyPropNamesFromConfig,
   pruneNonEagerRelations,
   type RelationResolverFactory,
+  selectArrayArgs,
+  selectSingleArgs,
   type TablesRelationalConfig,
   type TypeCacheCtx,
   type TypeNameMapper,
+  toGraphQLError,
 } from '../builders/common.ts';
-import { capitalize, uncapitalize } from '../case-ops/index.ts';
 
 import {
   remapFromGraphQLArrayInput,
@@ -62,20 +64,7 @@ const generateSelectArray = (
     );
   }
 
-  const queryArgs = {
-    offset: {
-      type: GraphQLInt,
-    },
-    limit: {
-      type: GraphQLInt,
-    },
-    orderBy: {
-      type: orderArgs,
-    },
-    where: {
-      type: filterArgs,
-    },
-  } as GraphQLFieldConfigArgumentMap;
+  const queryArgs = selectArrayArgs(orderArgs, filterArgs);
 
   const table = tables[tableName]!;
 
@@ -137,17 +126,7 @@ const generateSelectSingle = (
     );
   }
 
-  const queryArgs = {
-    offset: {
-      type: GraphQLInt,
-    },
-    orderBy: {
-      type: orderArgs,
-    },
-    where: {
-      type: filterArgs,
-    },
-  } as GraphQLFieldConfigArgumentMap;
+  const queryArgs = selectSingleArgs(orderArgs, filterArgs);
 
   const table = tables[tableName]!;
 
@@ -217,11 +196,7 @@ const generateInsertArray = (
 
         return { isSuccess: true };
       } catch (e) {
-        if (e instanceof Error) {
-          throw new GraphQLError(e.message);
-        }
-
-        throw e;
+        throw toGraphQLError(e);
       }
     },
     args: queryArgs,
@@ -251,11 +226,7 @@ const generateInsertSingle = (
 
         return { isSuccess: true };
       } catch (e) {
-        if (e instanceof Error) {
-          throw new GraphQLError(e.message);
-        }
-
-        throw e;
+        throw toGraphQLError(e);
       }
     },
     args: queryArgs,
@@ -300,11 +271,7 @@ const generateUpdate = (
 
         return { isSuccess: true };
       } catch (e) {
-        if (e instanceof Error) {
-          throw new GraphQLError(e.message);
-        }
-
-        throw e;
+        throw toGraphQLError(e);
       }
     },
     args: queryArgs,
@@ -340,11 +307,7 @@ const generateDelete = (
 
         return { isSuccess: true };
       } catch (e) {
-        if (e instanceof Error) {
-          throw new GraphQLError(e.message);
-        }
-
-        throw e;
+        throw toGraphQLError(e);
       }
     },
     args: queryArgs,
@@ -441,16 +404,15 @@ export const generateSchemaData = <
     const { selectSingleOutput, selectArrOutput } = tableTypes.outputs;
 
     // Compute field names using the mapper logic
-    const mapped = typeNameMapper?.(tableName);
-    const typeName = mapped ? capitalize(mapped.singular) : capitalize(tableName);
-    const listFieldName = (mapped?.plural ?? uncapitalize(tableName)) + suffixes.list;
-    const singleFieldName = mapped?.singular ?? uncapitalize(tableName) + suffixes.single;
-    const createArrayFieldName = `${prefixes.insert}${mapped ? capitalize(mapped.plural) : capitalize(tableName)}`;
-    const createSingleFieldName = mapped
-      ? `${prefixes.insert}${capitalize(mapped.singular)}`
-      : `${prefixes.insert}${capitalize(tableName)}${suffixes.single}`;
-    const updateFieldName = `${prefixes.update}${mapped ? capitalize(mapped.singular) : capitalize(tableName)}`;
-    const deleteFieldName = `${prefixes.delete}${mapped ? capitalize(mapped.singular) : capitalize(tableName)}`;
+    const {
+      typeName,
+      listFieldName,
+      singleFieldName,
+      createArrayFieldName,
+      createSingleFieldName,
+      updateFieldName,
+      deleteFieldName,
+    } = computeResolverFieldNames(tableName, typeNameMapper, prefixes, suffixes);
 
     const selectArrGenerated = generateSelectArray(
       db,

--- a/src/util/builders/pg.ts
+++ b/src/util/builders/pg.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck — vendored file, drizzle-orm 1.0 type compat not guaranteed
 import { is, One, type Table, type View } from 'drizzle-orm';
 import type { RelationalQueryBuilder } from 'drizzle-orm/mysql-core/query-builders/query';
-import { type PgAsyncDatabase, type PgColumn, PgTable } from 'drizzle-orm/pg-core';
+import { getTableConfig, type PgAsyncDatabase, type PgColumn, PgTable } from 'drizzle-orm/pg-core';
 import type { GraphQLFieldConfig, GraphQLFieldConfigArgumentMap, ThunkObjMap } from 'graphql';
 import {
   GraphQLError,
@@ -17,12 +17,14 @@ import type { BuildSchemaConfig, GeneratedEntities, MakeRequired } from '../../t
 import {
   buildNamedRelations,
   createRelationResolverFactory,
+  eagerLoadMutationRelations,
   extractFilters,
   extractOrderBy,
   extractRelationsParams,
   extractSelectedColumnsFromTree,
   extractSelectedColumnsFromTreeSQLFormat,
   generateTableTypes,
+  getPrimaryKeyPropNames,
   type RelationResolverFactory,
   type TablesRelationalConfig,
   type TypeCacheCtx,
@@ -227,13 +229,24 @@ const generateSelectSingle = (
   };
 };
 
+/** Primary-key property names for a PG table, including table-level composite keys. */
+const pgPrimaryKeyPropNames = (table: PgTable): string[] => {
+  const compositePkColumnNames = getTableConfig(table).primaryKeys.flatMap((pk: any) =>
+    pk.columns.map((c: any) => c.name),
+  );
+  return getPrimaryKeyPropNames(table, compositePkColumnNames);
+};
+
 const generateInsertArray = (
   db: PgAsyncDatabase<any, any, any>,
   tableName: string,
   table: PgTable,
+  tables: Record<string, Table>,
+  relationMap: Record<string, Record<string, TableNamedRelations>>,
   baseType: GraphQLInputObjectType,
   fieldName: string,
   typeName: string,
+  typeNameMapper?: TypeNameMapper,
   conflictDoNothing: boolean = false,
 ): CreatedResolver => {
   const queryArgs: GraphQLFieldConfigArgumentMap = {
@@ -266,7 +279,20 @@ const generateInsertArray = (
         }
         const result = await query;
 
-        return remapToGraphQLArrayOutput(result, tableName, table);
+        const enriched = await eagerLoadMutationRelations(
+          db,
+          tableName,
+          table,
+          tables,
+          relationMap,
+          typeName,
+          typeNameMapper,
+          parsedInfo,
+          result,
+          pgPrimaryKeyPropNames(table),
+        );
+
+        return remapToGraphQLArrayOutput(enriched, tableName, table, relationMap);
       } catch (e) {
         if (e instanceof Error) {
           throw new GraphQLError(e.message);
@@ -283,9 +309,12 @@ const generateInsertSingle = (
   db: PgAsyncDatabase<any, any, any>,
   tableName: string,
   table: PgTable,
+  tables: Record<string, Table>,
+  relationMap: Record<string, Record<string, TableNamedRelations>>,
   baseType: GraphQLInputObjectType,
   fieldName: string,
   typeName: string,
+  typeNameMapper?: TypeNameMapper,
   conflictDoNothing: boolean = false,
 ): CreatedResolver => {
   const queryArgs: GraphQLFieldConfigArgumentMap = {
@@ -319,7 +348,20 @@ const generateInsertSingle = (
           return undefined;
         }
 
-        return remapToGraphQLSingleOutput(result[0], tableName, table);
+        const enriched = await eagerLoadMutationRelations(
+          db,
+          tableName,
+          table,
+          tables,
+          relationMap,
+          typeName,
+          typeNameMapper,
+          parsedInfo,
+          result,
+          pgPrimaryKeyPropNames(table),
+        );
+
+        return remapToGraphQLSingleOutput(enriched[0], tableName, table, relationMap);
       } catch (e) {
         if (e instanceof Error) {
           throw new GraphQLError(e.message);
@@ -336,10 +378,13 @@ const generateUpdate = (
   db: PgAsyncDatabase<any, any, any>,
   tableName: string,
   table: PgTable,
+  tables: Record<string, Table>,
+  relationMap: Record<string, Record<string, TableNamedRelations>>,
   setArgs: GraphQLInputObjectType,
   filterArgs: GraphQLInputObjectType,
   fieldName: string,
   typeName: string,
+  typeNameMapper?: TypeNameMapper,
 ): CreatedResolver => {
   const queryArgs = {
     set: {
@@ -380,7 +425,20 @@ const generateUpdate = (
 
         const result = await query;
 
-        return remapToGraphQLArrayOutput(result, tableName, table);
+        const enriched = await eagerLoadMutationRelations(
+          db,
+          tableName,
+          table,
+          tables,
+          relationMap,
+          typeName,
+          typeNameMapper,
+          parsedInfo,
+          result,
+          pgPrimaryKeyPropNames(table),
+        );
+
+        return remapToGraphQLArrayOutput(enriched, tableName, table, relationMap);
       } catch (e) {
         if (e instanceof Error) {
           throw new GraphQLError(e.message);
@@ -555,28 +613,37 @@ export function generateSchemaData<
       db,
       tableName,
       schema[tableName] as PgTable,
+      tables,
+      namedRelations,
       insertInput,
       createArrayFieldName,
       typeName,
+      typeNameMapper,
       conflictDoNothing,
     );
     const insertSingleGenerated = generateInsertSingle(
       db,
       tableName,
       schema[tableName] as PgTable,
+      tables,
+      namedRelations,
       insertInput,
       createSingleFieldName,
       typeName,
+      typeNameMapper,
       conflictDoNothing,
     );
     const updateGenerated = generateUpdate(
       db,
       tableName,
       schema[tableName] as PgTable,
+      tables,
+      namedRelations,
       updateInput,
       tableFilters,
       updateFieldName,
       typeName,
+      typeNameMapper,
     );
     const deleteGenerated = generateDelete(
       db,

--- a/src/util/builders/pg.ts
+++ b/src/util/builders/pg.ts
@@ -275,11 +275,18 @@ const generateInsertArray = (
           deep: true,
         }) as ResolveTree;
 
-        const columns = withPrimaryKeyColumns(
-          extractSelectedColumnsFromTreeSQLFormat<PgColumn>(parsedInfo.fieldsByTypeName[typeName]!, table),
+        // Resolve the relation selection once: it gates whether we force the PK into
+        // RETURNING and whether a relation re-fetch is needed at all.
+        const withParams = relationMap[tableName]
+          ? extractRelationsParams(relationMap, tables, tableName, parsedInfo, typeName, typeNameMapper)
+          : undefined;
+        const hasRelations = !!(withParams && Object.keys(withParams).length);
+
+        const baseColumns = extractSelectedColumnsFromTreeSQLFormat<PgColumn>(
+          parsedInfo.fieldsByTypeName[typeName]!,
           table,
-          pkNames,
         );
+        const columns = hasRelations ? withPrimaryKeyColumns(baseColumns, table, pkNames) : baseColumns;
 
         let query = db.insert(table).values(input).returning(columns);
         if (conflictDoNothing) {
@@ -287,17 +294,9 @@ const generateInsertArray = (
         }
         const result = await query;
 
-        const enriched = await eagerLoadMutationRelations(
-          db,
-          tableName,
-          tables,
-          relationMap,
-          typeName,
-          typeNameMapper,
-          parsedInfo,
-          result,
-          pkNames,
-        );
+        const enriched = hasRelations
+          ? await eagerLoadMutationRelations(db, tableName, result, pkNames, withParams)
+          : result;
 
         return remapToGraphQLArrayOutput(enriched, tableName, table, relationMap);
       } catch (e) {
@@ -343,11 +342,16 @@ const generateInsertSingle = (
           deep: true,
         }) as ResolveTree;
 
-        const columns = withPrimaryKeyColumns(
-          extractSelectedColumnsFromTreeSQLFormat<PgColumn>(parsedInfo.fieldsByTypeName[typeName]!, table),
+        const withParams = relationMap[tableName]
+          ? extractRelationsParams(relationMap, tables, tableName, parsedInfo, typeName, typeNameMapper)
+          : undefined;
+        const hasRelations = !!(withParams && Object.keys(withParams).length);
+
+        const baseColumns = extractSelectedColumnsFromTreeSQLFormat<PgColumn>(
+          parsedInfo.fieldsByTypeName[typeName]!,
           table,
-          pkNames,
         );
+        const columns = hasRelations ? withPrimaryKeyColumns(baseColumns, table, pkNames) : baseColumns;
 
         let query = db.insert(table).values(input).returning(columns);
         if (conflictDoNothing) {
@@ -359,17 +363,9 @@ const generateInsertSingle = (
           return undefined;
         }
 
-        const enriched = await eagerLoadMutationRelations(
-          db,
-          tableName,
-          tables,
-          relationMap,
-          typeName,
-          typeNameMapper,
-          parsedInfo,
-          result,
-          pkNames,
-        );
+        const enriched = hasRelations
+          ? await eagerLoadMutationRelations(db, tableName, result, pkNames, withParams)
+          : result;
 
         return remapToGraphQLSingleOutput(enriched[0], tableName, table, relationMap);
       } catch (e) {
@@ -418,11 +414,16 @@ const generateUpdate = (
           deep: true,
         }) as ResolveTree;
 
-        const columns = withPrimaryKeyColumns(
-          extractSelectedColumnsFromTreeSQLFormat<PgColumn>(parsedInfo.fieldsByTypeName[typeName]!, table),
+        const withParams = relationMap[tableName]
+          ? extractRelationsParams(relationMap, tables, tableName, parsedInfo, typeName, typeNameMapper)
+          : undefined;
+        const hasRelations = !!(withParams && Object.keys(withParams).length);
+
+        const baseColumns = extractSelectedColumnsFromTreeSQLFormat<PgColumn>(
+          parsedInfo.fieldsByTypeName[typeName]!,
           table,
-          pkNames,
         );
+        const columns = hasRelations ? withPrimaryKeyColumns(baseColumns, table, pkNames) : baseColumns;
 
         const input = remapFromGraphQLSingleInput(set, table);
         if (!Object.keys(input).length) {
@@ -439,17 +440,9 @@ const generateUpdate = (
 
         const result = await query;
 
-        const enriched = await eagerLoadMutationRelations(
-          db,
-          tableName,
-          tables,
-          relationMap,
-          typeName,
-          typeNameMapper,
-          parsedInfo,
-          result,
-          pkNames,
-        );
+        const enriched = hasRelations
+          ? await eagerLoadMutationRelations(db, tableName, result, pkNames, withParams)
+          : result;
 
         return remapToGraphQLArrayOutput(enriched, tableName, table, relationMap);
       } catch (e) {

--- a/src/util/builders/pg.ts
+++ b/src/util/builders/pg.ts
@@ -257,6 +257,10 @@ const generateInsertArray = (
     },
   };
 
+  // Primary-key prop names are constant per table — derive them once at build time
+  // rather than re-running getTableConfig on every mutation request.
+  const pkNames = pgPrimaryKeyPropNames(table);
+
   return {
     name: fieldName,
     resolver: async (_source, args: { values: Record<string, any>[] }, _context, info) => {
@@ -270,7 +274,6 @@ const generateInsertArray = (
           deep: true,
         }) as ResolveTree;
 
-        const pkNames = pgPrimaryKeyPropNames(table);
         const columns = withPrimaryKeyColumns(
           extractSelectedColumnsFromTreeSQLFormat<PgColumn>(parsedInfo.fieldsByTypeName[typeName]!, table),
           table,
@@ -327,6 +330,9 @@ const generateInsertSingle = (
     },
   };
 
+  // Derived once at build time — PK prop names don't change per request.
+  const pkNames = pgPrimaryKeyPropNames(table);
+
   return {
     name: fieldName,
     resolver: async (_source, args: { values: Record<string, any> }, _context, info) => {
@@ -337,7 +343,6 @@ const generateInsertSingle = (
           deep: true,
         }) as ResolveTree;
 
-        const pkNames = pgPrimaryKeyPropNames(table);
         const columns = withPrimaryKeyColumns(
           extractSelectedColumnsFromTreeSQLFormat<PgColumn>(parsedInfo.fieldsByTypeName[typeName]!, table),
           table,
@@ -401,6 +406,9 @@ const generateUpdate = (
     },
   } as const satisfies GraphQLFieldConfigArgumentMap;
 
+  // Derived once at build time — PK prop names don't change per request.
+  const pkNames = pgPrimaryKeyPropNames(table);
+
   return {
     name: fieldName,
     resolver: async (_source, args: { where?: Filters<Table>; set: Record<string, any> }, _context, info) => {
@@ -411,7 +419,6 @@ const generateUpdate = (
           deep: true,
         }) as ResolveTree;
 
-        const pkNames = pgPrimaryKeyPropNames(table);
         const columns = withPrimaryKeyColumns(
           extractSelectedColumnsFromTreeSQLFormat<PgColumn>(parsedInfo.fieldsByTypeName[typeName]!, table),
           table,

--- a/src/util/builders/pg.ts
+++ b/src/util/builders/pg.ts
@@ -21,14 +21,13 @@ import {
   eagerLoadMutationRelations,
   extractFilters,
   extractOrderBy,
-  extractRelationsParams,
-  extractSelectedColumnsFromTree,
   extractSelectedColumnsFromTreeSQLFormat,
   generateTableTypes,
   getPrimaryKeyPropNamesFromConfig,
   prepareMutationRelationColumns,
   pruneNonEagerRelations,
   type RelationResolverFactory,
+  runRelationalSelect,
   selectArrayArgs,
   selectSingleArgs,
   type TablesRelationalConfig,
@@ -69,54 +68,44 @@ const generateSelectArray = (
     name: fieldName,
     resolver: async (_source, args: Partial<TableSelectArgs>, _context, info) => {
       try {
-        const { offset, limit, orderBy, where } = args;
+        const parsedInfo = parseResolveInfo(info, { deep: true }) as ResolveTree;
 
-        const parsedInfo = parseResolveInfo(info, {
-          deep: true,
-        }) as ResolveTree;
-
-        const selectedColumns = extractSelectedColumnsFromTree(parsedInfo.fieldsByTypeName[typeName]!, table);
-
-        let result: any[];
         if (queryBase) {
-          const withParams = relationMap[tableName]
-            ? extractRelationsParams(relationMap, tables, tableName, parsedInfo, typeName, typeNameMapper)
-            : undefined;
-
-          result = await queryBase.findMany({
-            columns: selectedColumns,
-            offset,
-            limit,
-            // drizzle-orm v1 RQB calls orderBy with the aliased table proxy (e.g.
-            // d0, d1) — use it directly so column refs match the CTE alias.
-            orderBy: orderBy ? (aliasedTable: Table) => extractOrderBy(aliasedTable, orderBy) : undefined,
-            where: where ? { RAW: (aliased) => extractFilters(aliased, tableName, where) } : undefined,
-            with: withParams,
-          });
-        } else {
-          // Fallback for tables without relational query builder support.
-          // Use SQL column objects (not Record<string,true>) so db.select() receives valid expressions.
-          const selectedColumnsSql = extractSelectedColumnsFromTreeSQLFormat<PgColumn>(
-            parsedInfo.fieldsByTypeName[typeName]!,
+          return await runRelationalSelect({
+            queryBase,
+            tables,
+            tableName,
             table,
-          );
-          let q = db.select(selectedColumnsSql).from(table);
-          if (where) {
-            q = q.where(extractFilters(table, tableName, where)) as any;
-          }
-          if (orderBy) {
-            q = q.orderBy(...extractOrderBy(table, orderBy)) as any;
-          }
-          if (offset) {
-            q = q.offset(offset) as any;
-          }
-          if (limit) {
-            q = q.limit(limit) as any;
-          }
-          result = await q;
+            relationMap,
+            typeName,
+            typeNameMapper,
+            parsedInfo,
+            ...args,
+            single: false,
+          });
         }
 
-        return remapToGraphQLArrayOutput(result, tableName, table, relationMap);
+        // Fallback for tables without relational query builder support.
+        // Use SQL column objects (not Record<string,true>) so db.select() receives valid expressions.
+        const { offset, limit, orderBy, where } = args;
+        const selectedColumnsSql = extractSelectedColumnsFromTreeSQLFormat<PgColumn>(
+          parsedInfo.fieldsByTypeName[typeName]!,
+          table,
+        );
+        let q = db.select(selectedColumnsSql).from(table);
+        if (where) {
+          q = q.where(extractFilters(table, tableName, where)) as any;
+        }
+        if (orderBy) {
+          q = q.orderBy(...extractOrderBy(table, orderBy)) as any;
+        }
+        if (offset) {
+          q = q.offset(offset) as any;
+        }
+        if (limit) {
+          q = q.limit(limit) as any;
+        }
+        return remapToGraphQLArrayOutput(await q, tableName, table, relationMap);
       } catch (e) {
         throw toGraphQLError(e);
       }
@@ -149,52 +138,42 @@ const generateSelectSingle = (
     name: fieldName,
     resolver: async (_source, args: Partial<TableSelectArgs>, _context, info) => {
       try {
-        const { offset, orderBy, where } = args;
+        const parsedInfo = parseResolveInfo(info, { deep: true }) as ResolveTree;
 
-        const parsedInfo = parseResolveInfo(info, {
-          deep: true,
-        }) as ResolveTree;
-
-        const selectedColumns = extractSelectedColumnsFromTree(parsedInfo.fieldsByTypeName[typeName]!, table);
-
-        let result: any;
         if (queryBase) {
-          result = await queryBase.findFirst({
-            columns: selectedColumns,
-            offset,
-            // drizzle-orm v1 RQB calls orderBy with the aliased table proxy (e.g.
-            // d0, d1) — use it directly so column refs match the CTE alias.
-            orderBy: orderBy ? (aliasedTable: Table) => extractOrderBy(aliasedTable, orderBy) : undefined,
-            where: where ? { RAW: (aliased) => extractFilters(aliased, tableName, where) } : undefined,
-            with: relationMap[tableName]
-              ? extractRelationsParams(relationMap, tables, tableName, parsedInfo, typeName, typeNameMapper)
-              : undefined,
-          });
-        } else {
-          // Fallback for tables without relational query builder support.
-          const selectedColumnsSql = extractSelectedColumnsFromTreeSQLFormat<PgColumn>(
-            parsedInfo.fieldsByTypeName[typeName]!,
+          return await runRelationalSelect({
+            queryBase,
+            tables,
+            tableName,
             table,
-          );
-          let q = db.select(selectedColumnsSql).from(table);
-          if (where) {
-            q = q.where(extractFilters(table, tableName, where)) as any;
-          }
-          if (orderBy) {
-            q = q.orderBy(...extractOrderBy(table, orderBy)) as any;
-          }
-          if (offset) {
-            q = q.offset(offset) as any;
-          }
-          const rows = await q.limit(1);
-          result = rows[0];
+            relationMap,
+            typeName,
+            typeNameMapper,
+            parsedInfo,
+            ...args,
+            single: true,
+          });
         }
 
-        if (!result) {
-          return undefined;
+        // Fallback for tables without relational query builder support.
+        const { offset, orderBy, where } = args;
+        const selectedColumnsSql = extractSelectedColumnsFromTreeSQLFormat<PgColumn>(
+          parsedInfo.fieldsByTypeName[typeName]!,
+          table,
+        );
+        let q = db.select(selectedColumnsSql).from(table);
+        if (where) {
+          q = q.where(extractFilters(table, tableName, where)) as any;
         }
-
-        return remapToGraphQLSingleOutput(result, tableName, table, relationMap);
+        if (orderBy) {
+          q = q.orderBy(...extractOrderBy(table, orderBy)) as any;
+        }
+        if (offset) {
+          q = q.offset(offset) as any;
+        }
+        const rows = await q.limit(1);
+        const result = rows[0];
+        return result ? remapToGraphQLSingleOutput(result, tableName, table, relationMap) : undefined;
       } catch (e) {
         throw toGraphQLError(e);
       }

--- a/src/util/builders/pg.ts
+++ b/src/util/builders/pg.ts
@@ -6,7 +6,6 @@ import type { GraphQLFieldConfig, GraphQLFieldConfigArgumentMap, ThunkObjMap } f
 import {
   GraphQLError,
   type GraphQLInputObjectType,
-  GraphQLInt,
   GraphQLList,
   GraphQLNonNull,
   type GraphQLObjectType,
@@ -17,6 +16,7 @@ import type { BuildSchemaConfig, GeneratedEntities, MakeRequired } from '../../t
 import {
   attachTargetPrimaryKeys,
   buildNamedRelations,
+  computeResolverFieldNames,
   createRelationResolverFactory,
   eagerLoadMutationRelations,
   extractFilters,
@@ -29,11 +29,13 @@ import {
   prepareMutationRelationColumns,
   pruneNonEagerRelations,
   type RelationResolverFactory,
+  selectArrayArgs,
+  selectSingleArgs,
   type TablesRelationalConfig,
   type TypeCacheCtx,
   type TypeNameMapper,
+  toGraphQLError,
 } from '../builders/common.ts';
-import { capitalize, uncapitalize } from '../case-ops/index.ts';
 
 import {
   remapFromGraphQLArrayInput,
@@ -59,20 +61,7 @@ const generateSelectArray = (
     | undefined;
   // Tables without relations won't have db.query support — fall back to basic select.
 
-  const queryArgs = {
-    offset: {
-      type: GraphQLInt,
-    },
-    limit: {
-      type: GraphQLInt,
-    },
-    orderBy: {
-      type: orderArgs,
-    },
-    where: {
-      type: filterArgs,
-    },
-  } as GraphQLFieldConfigArgumentMap;
+  const queryArgs = selectArrayArgs(orderArgs, filterArgs);
 
   const table = tables[tableName]!;
 
@@ -129,11 +118,7 @@ const generateSelectArray = (
 
         return remapToGraphQLArrayOutput(result, tableName, table, relationMap);
       } catch (e) {
-        if (e instanceof Error) {
-          throw new GraphQLError(e.message);
-        }
-
-        throw e;
+        throw toGraphQLError(e);
       }
     },
     args: queryArgs,
@@ -156,17 +141,7 @@ const generateSelectSingle = (
     | undefined;
   // Tables without relations won't have db.query support — fall back to basic select.
 
-  const queryArgs = {
-    offset: {
-      type: GraphQLInt,
-    },
-    orderBy: {
-      type: orderArgs,
-    },
-    where: {
-      type: filterArgs,
-    },
-  } as GraphQLFieldConfigArgumentMap;
+  const queryArgs = selectSingleArgs(orderArgs, filterArgs);
 
   const table = tables[tableName]!;
 
@@ -221,11 +196,7 @@ const generateSelectSingle = (
 
         return remapToGraphQLSingleOutput(result, tableName, table, relationMap);
       } catch (e) {
-        if (e instanceof Error) {
-          throw new GraphQLError(e.message);
-        }
-
-        throw e;
+        throw toGraphQLError(e);
       }
     },
     args: queryArgs,
@@ -293,11 +264,7 @@ const generateInsertArray = (
 
         return remapToGraphQLArrayOutput(enriched, tableName, table, relationMap);
       } catch (e) {
-        if (e instanceof Error) {
-          throw new GraphQLError(e.message);
-        }
-
-        throw e;
+        throw toGraphQLError(e);
       }
     },
     args: queryArgs,
@@ -362,11 +329,7 @@ const generateInsertSingle = (
 
         return remapToGraphQLSingleOutput(enriched[0], tableName, table, relationMap);
       } catch (e) {
-        if (e instanceof Error) {
-          throw new GraphQLError(e.message);
-        }
-
-        throw e;
+        throw toGraphQLError(e);
       }
     },
     args: queryArgs,
@@ -439,11 +402,7 @@ const generateUpdate = (
 
         return remapToGraphQLArrayOutput(enriched, tableName, table, relationMap);
       } catch (e) {
-        if (e instanceof Error) {
-          throw new GraphQLError(e.message);
-        }
-
-        throw e;
+        throw toGraphQLError(e);
       }
     },
     args: queryArgs,
@@ -491,11 +450,7 @@ const generateDelete = (
 
         return remapToGraphQLArrayOutput(result, tableName, table);
       } catch (e) {
-        if (e instanceof Error) {
-          throw new GraphQLError(e.message);
-        }
-
-        throw e;
+        throw toGraphQLError(e);
       }
     },
     args: queryArgs,
@@ -584,16 +539,15 @@ export function generateSchemaData<
     const { selectSingleOutput, selectArrOutput, singleTableItemOutput, arrTableItemOutput } = tableTypes.outputs;
 
     // Compute field names using the mapper logic
-    const mapped = typeNameMapper?.(tableName);
-    const typeName = mapped ? capitalize(mapped.singular) : capitalize(tableName);
-    const listFieldName = (mapped?.plural ?? uncapitalize(tableName)) + suffixes.list;
-    const singleFieldName = mapped?.singular ?? uncapitalize(tableName) + suffixes.single;
-    const createArrayFieldName = `${prefixes.insert}${mapped ? capitalize(mapped.plural) : capitalize(tableName)}`;
-    const createSingleFieldName = mapped
-      ? `${prefixes.insert}${capitalize(mapped.singular)}`
-      : `${prefixes.insert}${capitalize(tableName)}${suffixes.single}`;
-    const updateFieldName = `${prefixes.update}${mapped ? capitalize(mapped.singular) : capitalize(tableName)}`;
-    const deleteFieldName = `${prefixes.delete}${mapped ? capitalize(mapped.singular) : capitalize(tableName)}`;
+    const {
+      typeName,
+      listFieldName,
+      singleFieldName,
+      createArrayFieldName,
+      createSingleFieldName,
+      updateFieldName,
+      deleteFieldName,
+    } = computeResolverFieldNames(tableName, typeNameMapper, prefixes, suffixes);
 
     const selectArrGenerated = generateSelectArray(
       db,

--- a/src/util/builders/pg.ts
+++ b/src/util/builders/pg.ts
@@ -15,6 +15,7 @@ import type { ResolveTree } from 'graphql-parse-resolve-info';
 import { parseResolveInfo } from 'graphql-parse-resolve-info';
 import type { BuildSchemaConfig, GeneratedEntities, MakeRequired } from '../../types.ts';
 import {
+  attachTargetPrimaryKeys,
   buildNamedRelations,
   createRelationResolverFactory,
   eagerLoadMutationRelations,
@@ -289,7 +290,6 @@ const generateInsertArray = (
         const enriched = await eagerLoadMutationRelations(
           db,
           tableName,
-          table,
           tables,
           relationMap,
           typeName,
@@ -362,7 +362,6 @@ const generateInsertSingle = (
         const enriched = await eagerLoadMutationRelations(
           db,
           tableName,
-          table,
           tables,
           relationMap,
           typeName,
@@ -443,7 +442,6 @@ const generateUpdate = (
         const enriched = await eagerLoadMutationRelations(
           db,
           tableName,
-          table,
           tables,
           relationMap,
           typeName,
@@ -548,6 +546,10 @@ export function generateSchemaData<
   // Flatten drizzle-orm v1 TablesRelationalConfig into the canonical shape
   // used throughout common.ts: Record<tableName, Record<relName, TableNamedRelations>>
   const namedRelations = buildNamedRelations(relations ?? {}, tableEntries);
+  // Record each relation target's primary key (composite-aware) so paginated relations
+  // default to a deterministic PK order. Must run before pruning / type generation, which
+  // share these entry objects.
+  attachTargetPrimaryKeys(namedRelations, tables, pgPrimaryKeyPropNames);
   // Relations to eager-load via `with:`. Query/mutation resolvers use this pruned map so
   // opted-out relations never overfetch; type generation keeps the full map so their
   // fields still exist and resolve lazily.

--- a/src/util/builders/pg.ts
+++ b/src/util/builders/pg.ts
@@ -25,6 +25,7 @@ import {
   extractSelectedColumnsFromTreeSQLFormat,
   generateTableTypes,
   getPrimaryKeyPropNames,
+  pruneNonEagerRelations,
   type RelationResolverFactory,
   type TablesRelationalConfig,
   type TypeCacheCtx,
@@ -518,6 +519,7 @@ export function generateSchemaData<
   suffixes: MakeRequired<MakeRequired<BuildSchemaConfig>['suffixes']>,
   conflictDoNothing: boolean = false,
   typeNameMapper?: TypeNameMapper,
+  shouldEagerLoad: (tableName: string, relationName: string) => boolean = () => true,
 ): GeneratedEntities<TDrizzleInstance, TSchema> {
   const schemaEntries = Object.entries(schema);
   const tableEntries = schemaEntries.filter(([_key, value]) => is(value, PgTable)) as [string, PgTable][];
@@ -532,6 +534,10 @@ export function generateSchemaData<
   // Flatten drizzle-orm v1 TablesRelationalConfig into the canonical shape
   // used throughout common.ts: Record<tableName, Record<relName, TableNamedRelations>>
   const namedRelations = buildNamedRelations(relations ?? {}, tableEntries);
+  // Relations to eager-load via `with:`. Query/mutation resolvers use this pruned map so
+  // opted-out relations never overfetch; type generation keeps the full map so their
+  // fields still exist and resolve lazily.
+  const eagerRelations = pruneNonEagerRelations(namedRelations, shouldEagerLoad);
 
   const resolverFactory: RelationResolverFactory = createRelationResolverFactory(db, tables);
 
@@ -591,7 +597,7 @@ export function generateSchemaData<
       db,
       tableName,
       tables,
-      namedRelations,
+      eagerRelations,
       tableOrder,
       tableFilters,
       listFieldName,
@@ -602,7 +608,7 @@ export function generateSchemaData<
       db,
       tableName,
       tables,
-      namedRelations,
+      eagerRelations,
       tableOrder,
       tableFilters,
       singleFieldName,
@@ -614,7 +620,7 @@ export function generateSchemaData<
       tableName,
       schema[tableName] as PgTable,
       tables,
-      namedRelations,
+      eagerRelations,
       insertInput,
       createArrayFieldName,
       typeName,
@@ -626,7 +632,7 @@ export function generateSchemaData<
       tableName,
       schema[tableName] as PgTable,
       tables,
-      namedRelations,
+      eagerRelations,
       insertInput,
       createSingleFieldName,
       typeName,
@@ -638,7 +644,7 @@ export function generateSchemaData<
       tableName,
       schema[tableName] as PgTable,
       tables,
-      namedRelations,
+      eagerRelations,
       updateInput,
       tableFilters,
       updateFieldName,

--- a/src/util/builders/pg.ts
+++ b/src/util/builders/pg.ts
@@ -30,6 +30,7 @@ import {
   type TablesRelationalConfig,
   type TypeCacheCtx,
   type TypeNameMapper,
+  withPrimaryKeyColumns,
 } from '../builders/common.ts';
 import { capitalize, uncapitalize } from '../case-ops/index.ts';
 
@@ -269,9 +270,11 @@ const generateInsertArray = (
           deep: true,
         }) as ResolveTree;
 
-        const columns = extractSelectedColumnsFromTreeSQLFormat<PgColumn>(
-          parsedInfo.fieldsByTypeName[typeName]!,
+        const pkNames = pgPrimaryKeyPropNames(table);
+        const columns = withPrimaryKeyColumns(
+          extractSelectedColumnsFromTreeSQLFormat<PgColumn>(parsedInfo.fieldsByTypeName[typeName]!, table),
           table,
+          pkNames,
         );
 
         let query = db.insert(table).values(input).returning(columns);
@@ -290,7 +293,7 @@ const generateInsertArray = (
           typeNameMapper,
           parsedInfo,
           result,
-          pgPrimaryKeyPropNames(table),
+          pkNames,
         );
 
         return remapToGraphQLArrayOutput(enriched, tableName, table, relationMap);
@@ -334,9 +337,11 @@ const generateInsertSingle = (
           deep: true,
         }) as ResolveTree;
 
-        const columns = extractSelectedColumnsFromTreeSQLFormat<PgColumn>(
-          parsedInfo.fieldsByTypeName[typeName]!,
+        const pkNames = pgPrimaryKeyPropNames(table);
+        const columns = withPrimaryKeyColumns(
+          extractSelectedColumnsFromTreeSQLFormat<PgColumn>(parsedInfo.fieldsByTypeName[typeName]!, table),
           table,
+          pkNames,
         );
 
         let query = db.insert(table).values(input).returning(columns);
@@ -359,7 +364,7 @@ const generateInsertSingle = (
           typeNameMapper,
           parsedInfo,
           result,
-          pgPrimaryKeyPropNames(table),
+          pkNames,
         );
 
         return remapToGraphQLSingleOutput(enriched[0], tableName, table, relationMap);
@@ -406,9 +411,11 @@ const generateUpdate = (
           deep: true,
         }) as ResolveTree;
 
-        const columns = extractSelectedColumnsFromTreeSQLFormat<PgColumn>(
-          parsedInfo.fieldsByTypeName[typeName]!,
+        const pkNames = pgPrimaryKeyPropNames(table);
+        const columns = withPrimaryKeyColumns(
+          extractSelectedColumnsFromTreeSQLFormat<PgColumn>(parsedInfo.fieldsByTypeName[typeName]!, table),
           table,
+          pkNames,
         );
 
         const input = remapFromGraphQLSingleInput(set, table);
@@ -436,7 +443,7 @@ const generateUpdate = (
           typeNameMapper,
           parsedInfo,
           result,
-          pgPrimaryKeyPropNames(table),
+          pkNames,
         );
 
         return remapToGraphQLArrayOutput(enriched, tableName, table, relationMap);

--- a/src/util/builders/pg.ts
+++ b/src/util/builders/pg.ts
@@ -25,13 +25,13 @@ import {
   extractSelectedColumnsFromTree,
   extractSelectedColumnsFromTreeSQLFormat,
   generateTableTypes,
-  getPrimaryKeyPropNames,
+  getPrimaryKeyPropNamesFromConfig,
+  prepareMutationRelationColumns,
   pruneNonEagerRelations,
   type RelationResolverFactory,
   type TablesRelationalConfig,
   type TypeCacheCtx,
   type TypeNameMapper,
-  withPrimaryKeyColumns,
 } from '../builders/common.ts';
 import { capitalize, uncapitalize } from '../case-ops/index.ts';
 
@@ -233,12 +233,7 @@ const generateSelectSingle = (
 };
 
 /** Primary-key property names for a PG table, including table-level composite keys. */
-const pgPrimaryKeyPropNames = (table: PgTable): string[] => {
-  const compositePkColumnNames = getTableConfig(table).primaryKeys.flatMap((pk: any) =>
-    pk.columns.map((c: any) => c.name),
-  );
-  return getPrimaryKeyPropNames(table, compositePkColumnNames);
-};
+const pgPrimaryKeyPropNames = (table: PgTable): string[] => getPrimaryKeyPropNamesFromConfig(table, getTableConfig);
 
 const generateInsertArray = (
   db: PgAsyncDatabase<any, any, any>,
@@ -275,18 +270,16 @@ const generateInsertArray = (
           deep: true,
         }) as ResolveTree;
 
-        // Resolve the relation selection once: it gates whether we force the PK into
-        // RETURNING and whether a relation re-fetch is needed at all.
-        const withParams = relationMap[tableName]
-          ? extractRelationsParams(relationMap, tables, tableName, parsedInfo, typeName, typeNameMapper)
-          : undefined;
-        const hasRelations = !!(withParams && Object.keys(withParams).length);
-
-        const baseColumns = extractSelectedColumnsFromTreeSQLFormat<PgColumn>(
-          parsedInfo.fieldsByTypeName[typeName]!,
+        const { columns, hasRelations, withParams } = prepareMutationRelationColumns({
+          relationMap,
+          tables,
+          tableName,
+          typeName,
+          typeNameMapper,
           table,
-        );
-        const columns = hasRelations ? withPrimaryKeyColumns(baseColumns, table, pkNames) : baseColumns;
+          pkNames,
+          parsedInfo,
+        });
 
         let query = db.insert(table).values(input).returning(columns);
         if (conflictDoNothing) {
@@ -342,16 +335,16 @@ const generateInsertSingle = (
           deep: true,
         }) as ResolveTree;
 
-        const withParams = relationMap[tableName]
-          ? extractRelationsParams(relationMap, tables, tableName, parsedInfo, typeName, typeNameMapper)
-          : undefined;
-        const hasRelations = !!(withParams && Object.keys(withParams).length);
-
-        const baseColumns = extractSelectedColumnsFromTreeSQLFormat<PgColumn>(
-          parsedInfo.fieldsByTypeName[typeName]!,
+        const { columns, hasRelations, withParams } = prepareMutationRelationColumns({
+          relationMap,
+          tables,
+          tableName,
+          typeName,
+          typeNameMapper,
           table,
-        );
-        const columns = hasRelations ? withPrimaryKeyColumns(baseColumns, table, pkNames) : baseColumns;
+          pkNames,
+          parsedInfo,
+        });
 
         let query = db.insert(table).values(input).returning(columns);
         if (conflictDoNothing) {
@@ -414,16 +407,16 @@ const generateUpdate = (
           deep: true,
         }) as ResolveTree;
 
-        const withParams = relationMap[tableName]
-          ? extractRelationsParams(relationMap, tables, tableName, parsedInfo, typeName, typeNameMapper)
-          : undefined;
-        const hasRelations = !!(withParams && Object.keys(withParams).length);
-
-        const baseColumns = extractSelectedColumnsFromTreeSQLFormat<PgColumn>(
-          parsedInfo.fieldsByTypeName[typeName]!,
+        const { columns, hasRelations, withParams } = prepareMutationRelationColumns({
+          relationMap,
+          tables,
+          tableName,
+          typeName,
+          typeNameMapper,
           table,
-        );
-        const columns = hasRelations ? withPrimaryKeyColumns(baseColumns, table, pkNames) : baseColumns;
+          pkNames,
+          parsedInfo,
+        });
 
         const input = remapFromGraphQLSingleInput(set, table);
         if (!Object.keys(input).length) {

--- a/src/util/builders/sqlite.ts
+++ b/src/util/builders/sqlite.ts
@@ -16,6 +16,7 @@ import { parseResolveInfo } from 'graphql-parse-resolve-info';
 
 import type { BuildSchemaConfig, GeneratedEntities, MakeRequired } from '../../types.ts';
 import {
+  attachTargetPrimaryKeys,
   buildNamedRelations,
   createRelationResolverFactory,
   eagerLoadMutationRelations,
@@ -245,7 +246,6 @@ const generateInsertArray = (
         const enriched = await eagerLoadMutationRelations(
           db,
           tableName,
-          table,
           tables,
           relationMap,
           typeName,
@@ -312,7 +312,6 @@ const generateInsertSingle = (
         const enriched = await eagerLoadMutationRelations(
           db,
           tableName,
-          table,
           tables,
           relationMap,
           typeName,
@@ -393,7 +392,6 @@ const generateUpdate = (
         const enriched = await eagerLoadMutationRelations(
           db,
           tableName,
-          table,
           tables,
           relationMap,
           typeName,
@@ -495,6 +493,9 @@ export const generateSchemaData = <
 
   // Build namedRelations from the drizzle-orm v1 relations config.
   const namedRelations = buildNamedRelations(relations ?? {}, tableEntries);
+  // Record each relation target's (composite-aware) primary key for deterministic
+  // paginated ordering. Must run before pruning / type generation (shared entry objects).
+  attachTargetPrimaryKeys(namedRelations, tables, sqlitePrimaryKeyPropNames);
   // Pruned map for query/mutation resolvers' `with:`; type generation keeps the full map.
   const eagerRelations = pruneNonEagerRelations(namedRelations, shouldEagerLoad);
 

--- a/src/util/builders/sqlite.ts
+++ b/src/util/builders/sqlite.ts
@@ -26,13 +26,13 @@ import {
   extractSelectedColumnsFromTree,
   extractSelectedColumnsFromTreeSQLFormat,
   generateTableTypes,
-  getPrimaryKeyPropNames,
+  getPrimaryKeyPropNamesFromConfig,
+  prepareMutationRelationColumns,
   pruneNonEagerRelations,
   type RelationResolverFactory,
   type TablesRelationalConfig,
   type TypeCacheCtx,
   type TypeNameMapper,
-  withPrimaryKeyColumns,
 } from '../builders/common.ts';
 import { capitalize, uncapitalize } from '../case-ops/index.ts';
 
@@ -194,12 +194,8 @@ const generateSelectSingle = (
 };
 
 /** Primary-key property names for a SQLite table, including table-level composite keys. */
-const sqlitePrimaryKeyPropNames = (table: SQLiteTable): string[] => {
-  const compositePkColumnNames = getTableConfig(table).primaryKeys.flatMap((pk: any) =>
-    pk.columns.map((c: any) => c.name),
-  );
-  return getPrimaryKeyPropNames(table, compositePkColumnNames);
-};
+const sqlitePrimaryKeyPropNames = (table: SQLiteTable): string[] =>
+  getPrimaryKeyPropNamesFromConfig(table, getTableConfig);
 
 const generateInsertArray = (
   db: BaseSQLiteDatabase<any, any, any, any>,
@@ -235,16 +231,16 @@ const generateInsertArray = (
           deep: true,
         }) as ResolveTree;
 
-        const withParams = relationMap[tableName]
-          ? extractRelationsParams(relationMap, tables, tableName, parsedInfo, typeName, typeNameMapper)
-          : undefined;
-        const hasRelations = !!(withParams && Object.keys(withParams).length);
-
-        const baseColumns = extractSelectedColumnsFromTreeSQLFormat<SQLiteColumn>(
-          parsedInfo.fieldsByTypeName[typeName]!,
+        const { columns, hasRelations, withParams } = prepareMutationRelationColumns({
+          relationMap,
+          tables,
+          tableName,
+          typeName,
+          typeNameMapper,
           table,
-        );
-        const columns = hasRelations ? withPrimaryKeyColumns(baseColumns, table, pkNames) : baseColumns;
+          pkNames,
+          parsedInfo,
+        });
 
         const result = await db.insert(table).values(input).returning(columns).onConflictDoNothing();
 
@@ -295,16 +291,16 @@ const generateInsertSingle = (
           deep: true,
         }) as ResolveTree;
 
-        const withParams = relationMap[tableName]
-          ? extractRelationsParams(relationMap, tables, tableName, parsedInfo, typeName, typeNameMapper)
-          : undefined;
-        const hasRelations = !!(withParams && Object.keys(withParams).length);
-
-        const baseColumns = extractSelectedColumnsFromTreeSQLFormat<SQLiteColumn>(
-          parsedInfo.fieldsByTypeName[typeName]!,
+        const { columns, hasRelations, withParams } = prepareMutationRelationColumns({
+          relationMap,
+          tables,
+          tableName,
+          typeName,
+          typeNameMapper,
           table,
-        );
-        const columns = hasRelations ? withPrimaryKeyColumns(baseColumns, table, pkNames) : baseColumns;
+          pkNames,
+          parsedInfo,
+        });
         const result = await db.insert(table).values(input).returning(columns).onConflictDoNothing();
 
         if (!result[0]) {
@@ -362,16 +358,16 @@ const generateUpdate = (
           deep: true,
         }) as ResolveTree;
 
-        const withParams = relationMap[tableName]
-          ? extractRelationsParams(relationMap, tables, tableName, parsedInfo, typeName, typeNameMapper)
-          : undefined;
-        const hasRelations = !!(withParams && Object.keys(withParams).length);
-
-        const baseColumns = extractSelectedColumnsFromTreeSQLFormat<SQLiteColumn>(
-          parsedInfo.fieldsByTypeName[typeName]!,
+        const { columns, hasRelations, withParams } = prepareMutationRelationColumns({
+          relationMap,
+          tables,
+          tableName,
+          typeName,
+          typeNameMapper,
           table,
-        );
-        const columns = hasRelations ? withPrimaryKeyColumns(baseColumns, table, pkNames) : baseColumns;
+          pkNames,
+          parsedInfo,
+        });
 
         const input = remapFromGraphQLSingleInput(set, table);
         if (!Object.keys(input).length) {

--- a/src/util/builders/sqlite.ts
+++ b/src/util/builders/sqlite.ts
@@ -26,6 +26,7 @@ import {
   extractSelectedColumnsFromTreeSQLFormat,
   generateTableTypes,
   getPrimaryKeyPropNames,
+  pruneNonEagerRelations,
   type RelationResolverFactory,
   type TablesRelationalConfig,
   type TypeCacheCtx,
@@ -464,6 +465,7 @@ export const generateSchemaData = <
   prefixes: MakeRequired<MakeRequired<BuildSchemaConfig>['prefixes']>,
   suffixes: MakeRequired<MakeRequired<BuildSchemaConfig>['suffixes']>,
   typeNameMapper?: TypeNameMapper,
+  shouldEagerLoad: (tableName: string, relationName: string) => boolean = () => true,
 ): GeneratedEntities<TDrizzleInstance, TSchema> => {
   const rawSchema = schema;
   const schemaEntries = Object.entries(rawSchema);
@@ -479,6 +481,8 @@ export const generateSchemaData = <
 
   // Build namedRelations from the drizzle-orm v1 relations config.
   const namedRelations = buildNamedRelations(relations ?? {}, tableEntries);
+  // Pruned map for query/mutation resolvers' `with:`; type generation keeps the full map.
+  const eagerRelations = pruneNonEagerRelations(namedRelations, shouldEagerLoad);
 
   const resolverFactory: RelationResolverFactory = createRelationResolverFactory(db, tables);
 
@@ -537,7 +541,7 @@ export const generateSchemaData = <
       db,
       tableName,
       tables,
-      namedRelations,
+      eagerRelations,
       tableOrder,
       tableFilters,
       listFieldName,
@@ -548,7 +552,7 @@ export const generateSchemaData = <
       db,
       tableName,
       tables,
-      namedRelations,
+      eagerRelations,
       tableOrder,
       tableFilters,
       singleFieldName,
@@ -560,7 +564,7 @@ export const generateSchemaData = <
       tableName,
       schema[tableName] as SQLiteTable,
       tables,
-      namedRelations,
+      eagerRelations,
       insertInput,
       createArrayFieldName,
       typeName,
@@ -571,7 +575,7 @@ export const generateSchemaData = <
       tableName,
       schema[tableName] as SQLiteTable,
       tables,
-      namedRelations,
+      eagerRelations,
       insertInput,
       createSingleFieldName,
       typeName,
@@ -582,7 +586,7 @@ export const generateSchemaData = <
       tableName,
       schema[tableName] as SQLiteTable,
       tables,
-      namedRelations,
+      eagerRelations,
       updateInput,
       tableFilters,
       updateFieldName,

--- a/src/util/builders/sqlite.ts
+++ b/src/util/builders/sqlite.ts
@@ -217,6 +217,10 @@ const generateInsertArray = (
     },
   };
 
+  // Primary-key prop names are constant per table — derive them once at build time
+  // rather than re-running getTableConfig on every mutation request.
+  const pkNames = sqlitePrimaryKeyPropNames(table);
+
   return {
     name: fieldName,
     resolver: async (_source, args: { values: Record<string, any>[] }, _context, info) => {
@@ -230,7 +234,6 @@ const generateInsertArray = (
           deep: true,
         }) as ResolveTree;
 
-        const pkNames = sqlitePrimaryKeyPropNames(table);
         const columns = withPrimaryKeyColumns(
           extractSelectedColumnsFromTreeSQLFormat<SQLiteColumn>(parsedInfo.fieldsByTypeName[typeName]!, table),
           table,
@@ -282,6 +285,9 @@ const generateInsertSingle = (
     },
   };
 
+  // Derived once at build time — PK prop names don't change per request.
+  const pkNames = sqlitePrimaryKeyPropNames(table);
+
   return {
     name: fieldName,
     resolver: async (_source, args: { values: Record<string, any> }, _context, info) => {
@@ -292,7 +298,6 @@ const generateInsertSingle = (
           deep: true,
         }) as ResolveTree;
 
-        const pkNames = sqlitePrimaryKeyPropNames(table);
         const columns = withPrimaryKeyColumns(
           extractSelectedColumnsFromTreeSQLFormat<SQLiteColumn>(parsedInfo.fieldsByTypeName[typeName]!, table),
           table,
@@ -351,6 +356,9 @@ const generateUpdate = (
     },
   } as const satisfies GraphQLFieldConfigArgumentMap;
 
+  // Derived once at build time — PK prop names don't change per request.
+  const pkNames = sqlitePrimaryKeyPropNames(table);
+
   return {
     name: fieldName,
     resolver: async (_source, args: { where?: Filters<Table>; set: Record<string, any> }, _context, info) => {
@@ -361,7 +369,6 @@ const generateUpdate = (
           deep: true,
         }) as ResolveTree;
 
-        const pkNames = sqlitePrimaryKeyPropNames(table);
         const columns = withPrimaryKeyColumns(
           extractSelectedColumnsFromTreeSQLFormat<SQLiteColumn>(parsedInfo.fieldsByTypeName[typeName]!, table),
           table,

--- a/src/util/builders/sqlite.ts
+++ b/src/util/builders/sqlite.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck — vendored file, drizzle-orm 1.0 type compat not guaranteed
 import { is, One, type Table } from 'drizzle-orm';
 import type { RelationalQueryBuilder } from 'drizzle-orm/mysql-core/query-builders/query';
-import { type BaseSQLiteDatabase, type SQLiteColumn, SQLiteTable } from 'drizzle-orm/sqlite-core';
+import { type BaseSQLiteDatabase, getTableConfig, type SQLiteColumn, SQLiteTable } from 'drizzle-orm/sqlite-core';
 import type { GraphQLFieldConfig, GraphQLFieldConfigArgumentMap, GraphQLResolveInfo, ThunkObjMap } from 'graphql';
 import {
   GraphQLError,
@@ -18,12 +18,14 @@ import type { BuildSchemaConfig, GeneratedEntities, MakeRequired } from '../../t
 import {
   buildNamedRelations,
   createRelationResolverFactory,
+  eagerLoadMutationRelations,
   extractFilters,
   extractOrderBy,
   extractRelationsParams,
   extractSelectedColumnsFromTree,
   extractSelectedColumnsFromTreeSQLFormat,
   generateTableTypes,
+  getPrimaryKeyPropNames,
   type RelationResolverFactory,
   type TablesRelationalConfig,
   type TypeCacheCtx,
@@ -188,13 +190,24 @@ const generateSelectSingle = (
   };
 };
 
+/** Primary-key property names for a SQLite table, including table-level composite keys. */
+const sqlitePrimaryKeyPropNames = (table: SQLiteTable): string[] => {
+  const compositePkColumnNames = getTableConfig(table).primaryKeys.flatMap((pk: any) =>
+    pk.columns.map((c: any) => c.name),
+  );
+  return getPrimaryKeyPropNames(table, compositePkColumnNames);
+};
+
 const generateInsertArray = (
   db: BaseSQLiteDatabase<any, any, any, any>,
   tableName: string,
   table: SQLiteTable,
+  tables: Record<string, Table>,
+  relationMap: Record<string, Record<string, TableNamedRelations>>,
   baseType: GraphQLInputObjectType,
   fieldName: string,
   typeName: string,
+  typeNameMapper?: TypeNameMapper,
 ): CreatedResolver => {
   const queryArgs: GraphQLFieldConfigArgumentMap = {
     values: {
@@ -222,7 +235,20 @@ const generateInsertArray = (
 
         const result = await db.insert(table).values(input).returning(columns).onConflictDoNothing();
 
-        return remapToGraphQLArrayOutput(result, tableName, table);
+        const enriched = await eagerLoadMutationRelations(
+          db,
+          tableName,
+          table,
+          tables,
+          relationMap,
+          typeName,
+          typeNameMapper,
+          parsedInfo,
+          result,
+          sqlitePrimaryKeyPropNames(table),
+        );
+
+        return remapToGraphQLArrayOutput(enriched, tableName, table, relationMap);
       } catch (e) {
         if (e instanceof Error) {
           throw new GraphQLError(e.message);
@@ -239,9 +265,12 @@ const generateInsertSingle = (
   db: BaseSQLiteDatabase<any, any, any, any>,
   tableName: string,
   table: SQLiteTable,
+  tables: Record<string, Table>,
+  relationMap: Record<string, Record<string, TableNamedRelations>>,
   baseType: GraphQLInputObjectType,
   fieldName: string,
   typeName: string,
+  typeNameMapper?: TypeNameMapper,
 ): CreatedResolver => {
   const queryArgs: GraphQLFieldConfigArgumentMap = {
     values: {
@@ -269,7 +298,20 @@ const generateInsertSingle = (
           return undefined;
         }
 
-        return remapToGraphQLSingleOutput(result[0], tableName, table);
+        const enriched = await eagerLoadMutationRelations(
+          db,
+          tableName,
+          table,
+          tables,
+          relationMap,
+          typeName,
+          typeNameMapper,
+          parsedInfo,
+          result,
+          sqlitePrimaryKeyPropNames(table),
+        );
+
+        return remapToGraphQLSingleOutput(enriched[0], tableName, table, relationMap);
       } catch (e) {
         if (e instanceof Error) {
           throw new GraphQLError(e.message);
@@ -286,10 +328,13 @@ const generateUpdate = (
   db: BaseSQLiteDatabase<any, any, any, any>,
   tableName: string,
   table: SQLiteTable,
+  tables: Record<string, Table>,
+  relationMap: Record<string, Record<string, TableNamedRelations>>,
   setArgs: GraphQLInputObjectType,
   filterArgs: GraphQLInputObjectType,
   fieldName: string,
   typeName: string,
+  typeNameMapper?: TypeNameMapper,
 ): CreatedResolver => {
   const queryArgs = {
     set: {
@@ -330,7 +375,20 @@ const generateUpdate = (
 
         const result = await query;
 
-        return remapToGraphQLArrayOutput(result, tableName, table);
+        const enriched = await eagerLoadMutationRelations(
+          db,
+          tableName,
+          table,
+          tables,
+          relationMap,
+          typeName,
+          typeNameMapper,
+          parsedInfo,
+          result,
+          sqlitePrimaryKeyPropNames(table),
+        );
+
+        return remapToGraphQLArrayOutput(enriched, tableName, table, relationMap);
       } catch (e) {
         if (e instanceof Error) {
           throw new GraphQLError(e.message);
@@ -501,26 +559,35 @@ export const generateSchemaData = <
       db,
       tableName,
       schema[tableName] as SQLiteTable,
+      tables,
+      namedRelations,
       insertInput,
       createArrayFieldName,
       typeName,
+      typeNameMapper,
     );
     const insertSingleGenerated = generateInsertSingle(
       db,
       tableName,
       schema[tableName] as SQLiteTable,
+      tables,
+      namedRelations,
       insertInput,
       createSingleFieldName,
       typeName,
+      typeNameMapper,
     );
     const updateGenerated = generateUpdate(
       db,
       tableName,
       schema[tableName] as SQLiteTable,
+      tables,
+      namedRelations,
       updateInput,
       tableFilters,
       updateFieldName,
       typeName,
+      typeNameMapper,
     );
     const deleteGenerated = generateDelete(
       db,

--- a/src/util/builders/sqlite.ts
+++ b/src/util/builders/sqlite.ts
@@ -235,25 +235,22 @@ const generateInsertArray = (
           deep: true,
         }) as ResolveTree;
 
-        const columns = withPrimaryKeyColumns(
-          extractSelectedColumnsFromTreeSQLFormat<SQLiteColumn>(parsedInfo.fieldsByTypeName[typeName]!, table),
+        const withParams = relationMap[tableName]
+          ? extractRelationsParams(relationMap, tables, tableName, parsedInfo, typeName, typeNameMapper)
+          : undefined;
+        const hasRelations = !!(withParams && Object.keys(withParams).length);
+
+        const baseColumns = extractSelectedColumnsFromTreeSQLFormat<SQLiteColumn>(
+          parsedInfo.fieldsByTypeName[typeName]!,
           table,
-          pkNames,
         );
+        const columns = hasRelations ? withPrimaryKeyColumns(baseColumns, table, pkNames) : baseColumns;
 
         const result = await db.insert(table).values(input).returning(columns).onConflictDoNothing();
 
-        const enriched = await eagerLoadMutationRelations(
-          db,
-          tableName,
-          tables,
-          relationMap,
-          typeName,
-          typeNameMapper,
-          parsedInfo,
-          result,
-          pkNames,
-        );
+        const enriched = hasRelations
+          ? await eagerLoadMutationRelations(db, tableName, result, pkNames, withParams)
+          : result;
 
         return remapToGraphQLArrayOutput(enriched, tableName, table, relationMap);
       } catch (e) {
@@ -298,28 +295,25 @@ const generateInsertSingle = (
           deep: true,
         }) as ResolveTree;
 
-        const columns = withPrimaryKeyColumns(
-          extractSelectedColumnsFromTreeSQLFormat<SQLiteColumn>(parsedInfo.fieldsByTypeName[typeName]!, table),
+        const withParams = relationMap[tableName]
+          ? extractRelationsParams(relationMap, tables, tableName, parsedInfo, typeName, typeNameMapper)
+          : undefined;
+        const hasRelations = !!(withParams && Object.keys(withParams).length);
+
+        const baseColumns = extractSelectedColumnsFromTreeSQLFormat<SQLiteColumn>(
+          parsedInfo.fieldsByTypeName[typeName]!,
           table,
-          pkNames,
         );
+        const columns = hasRelations ? withPrimaryKeyColumns(baseColumns, table, pkNames) : baseColumns;
         const result = await db.insert(table).values(input).returning(columns).onConflictDoNothing();
 
         if (!result[0]) {
           return undefined;
         }
 
-        const enriched = await eagerLoadMutationRelations(
-          db,
-          tableName,
-          tables,
-          relationMap,
-          typeName,
-          typeNameMapper,
-          parsedInfo,
-          result,
-          pkNames,
-        );
+        const enriched = hasRelations
+          ? await eagerLoadMutationRelations(db, tableName, result, pkNames, withParams)
+          : result;
 
         return remapToGraphQLSingleOutput(enriched[0], tableName, table, relationMap);
       } catch (e) {
@@ -368,11 +362,16 @@ const generateUpdate = (
           deep: true,
         }) as ResolveTree;
 
-        const columns = withPrimaryKeyColumns(
-          extractSelectedColumnsFromTreeSQLFormat<SQLiteColumn>(parsedInfo.fieldsByTypeName[typeName]!, table),
+        const withParams = relationMap[tableName]
+          ? extractRelationsParams(relationMap, tables, tableName, parsedInfo, typeName, typeNameMapper)
+          : undefined;
+        const hasRelations = !!(withParams && Object.keys(withParams).length);
+
+        const baseColumns = extractSelectedColumnsFromTreeSQLFormat<SQLiteColumn>(
+          parsedInfo.fieldsByTypeName[typeName]!,
           table,
-          pkNames,
         );
+        const columns = hasRelations ? withPrimaryKeyColumns(baseColumns, table, pkNames) : baseColumns;
 
         const input = remapFromGraphQLSingleInput(set, table);
         if (!Object.keys(input).length) {
@@ -389,17 +388,9 @@ const generateUpdate = (
 
         const result = await query;
 
-        const enriched = await eagerLoadMutationRelations(
-          db,
-          tableName,
-          tables,
-          relationMap,
-          typeName,
-          typeNameMapper,
-          parsedInfo,
-          result,
-          pkNames,
-        );
+        const enriched = hasRelations
+          ? await eagerLoadMutationRelations(db, tableName, result, pkNames, withParams)
+          : result;
 
         return remapToGraphQLArrayOutput(enriched, tableName, table, relationMap);
       } catch (e) {

--- a/src/util/builders/sqlite.ts
+++ b/src/util/builders/sqlite.ts
@@ -6,7 +6,6 @@ import type { GraphQLFieldConfig, GraphQLFieldConfigArgumentMap, GraphQLResolveI
 import {
   GraphQLError,
   type GraphQLInputObjectType,
-  GraphQLInt,
   GraphQLList,
   GraphQLNonNull,
   type GraphQLObjectType,
@@ -18,6 +17,7 @@ import type { BuildSchemaConfig, GeneratedEntities, MakeRequired } from '../../t
 import {
   attachTargetPrimaryKeys,
   buildNamedRelations,
+  computeResolverFieldNames,
   createRelationResolverFactory,
   eagerLoadMutationRelations,
   extractFilters,
@@ -30,11 +30,13 @@ import {
   prepareMutationRelationColumns,
   pruneNonEagerRelations,
   type RelationResolverFactory,
+  selectArrayArgs,
+  selectSingleArgs,
   type TablesRelationalConfig,
   type TypeCacheCtx,
   type TypeNameMapper,
+  toGraphQLError,
 } from '../builders/common.ts';
-import { capitalize, uncapitalize } from '../case-ops/index.ts';
 
 import {
   remapFromGraphQLArrayInput,
@@ -64,20 +66,7 @@ const generateSelectArray = (
     );
   }
 
-  const queryArgs = {
-    offset: {
-      type: GraphQLInt,
-    },
-    limit: {
-      type: GraphQLInt,
-    },
-    orderBy: {
-      type: orderArgs,
-    },
-    where: {
-      type: filterArgs,
-    },
-  } as GraphQLFieldConfigArgumentMap;
+  const queryArgs = selectArrayArgs(orderArgs, filterArgs);
 
   const table = tables[tableName]!;
 
@@ -108,11 +97,7 @@ const generateSelectArray = (
 
         return remapToGraphQLArrayOutput(result, tableName, table, relationMap);
       } catch (e) {
-        if (e instanceof Error) {
-          throw new GraphQLError(e.message);
-        }
-
-        throw e;
+        throw toGraphQLError(e);
       }
     },
     args: queryArgs,
@@ -139,17 +124,7 @@ const generateSelectSingle = (
     );
   }
 
-  const queryArgs = {
-    offset: {
-      type: GraphQLInt,
-    },
-    orderBy: {
-      type: orderArgs,
-    },
-    where: {
-      type: filterArgs,
-    },
-  } as GraphQLFieldConfigArgumentMap;
+  const queryArgs = selectSingleArgs(orderArgs, filterArgs);
 
   const table = tables[tableName]!;
 
@@ -182,11 +157,7 @@ const generateSelectSingle = (
 
         return remapToGraphQLSingleOutput(result, tableName, table, relationMap);
       } catch (e) {
-        if (e instanceof Error) {
-          throw new GraphQLError(e.message);
-        }
-
-        throw e;
+        throw toGraphQLError(e);
       }
     },
     args: queryArgs,
@@ -250,11 +221,7 @@ const generateInsertArray = (
 
         return remapToGraphQLArrayOutput(enriched, tableName, table, relationMap);
       } catch (e) {
-        if (e instanceof Error) {
-          throw new GraphQLError(e.message);
-        }
-
-        throw e;
+        throw toGraphQLError(e);
       }
     },
     args: queryArgs,
@@ -313,11 +280,7 @@ const generateInsertSingle = (
 
         return remapToGraphQLSingleOutput(enriched[0], tableName, table, relationMap);
       } catch (e) {
-        if (e instanceof Error) {
-          throw new GraphQLError(e.message);
-        }
-
-        throw e;
+        throw toGraphQLError(e);
       }
     },
     args: queryArgs,
@@ -390,11 +353,7 @@ const generateUpdate = (
 
         return remapToGraphQLArrayOutput(enriched, tableName, table, relationMap);
       } catch (e) {
-        if (e instanceof Error) {
-          throw new GraphQLError(e.message);
-        }
-
-        throw e;
+        throw toGraphQLError(e);
       }
     },
     args: queryArgs,
@@ -442,11 +401,7 @@ const generateDelete = (
 
         return remapToGraphQLArrayOutput(result, tableName, table);
       } catch (e) {
-        if (e instanceof Error) {
-          throw new GraphQLError(e.message);
-        }
-
-        throw e;
+        throw toGraphQLError(e);
       }
     },
     args: queryArgs,
@@ -528,16 +483,15 @@ export const generateSchemaData = <
     const { selectSingleOutput, selectArrOutput, singleTableItemOutput, arrTableItemOutput } = tableTypes.outputs;
 
     // Compute field names using the mapper logic
-    const mapped = typeNameMapper?.(tableName);
-    const typeName = mapped ? capitalize(mapped.singular) : capitalize(tableName);
-    const listFieldName = (mapped?.plural ?? uncapitalize(tableName)) + suffixes.list;
-    const singleFieldName = mapped?.singular ?? uncapitalize(tableName) + suffixes.single;
-    const createArrayFieldName = `${prefixes.insert}${mapped ? capitalize(mapped.plural) : capitalize(tableName)}`;
-    const createSingleFieldName = mapped
-      ? `${prefixes.insert}${capitalize(mapped.singular)}`
-      : `${prefixes.insert}${capitalize(tableName)}${suffixes.single}`;
-    const updateFieldName = `${prefixes.update}${mapped ? capitalize(mapped.singular) : capitalize(tableName)}`;
-    const deleteFieldName = `${prefixes.delete}${mapped ? capitalize(mapped.singular) : capitalize(tableName)}`;
+    const {
+      typeName,
+      listFieldName,
+      singleFieldName,
+      createArrayFieldName,
+      createSingleFieldName,
+      updateFieldName,
+      deleteFieldName,
+    } = computeResolverFieldNames(tableName, typeNameMapper, prefixes, suffixes);
 
     const selectArrGenerated = generateSelectArray(
       db,

--- a/src/util/builders/sqlite.ts
+++ b/src/util/builders/sqlite.ts
@@ -21,15 +21,13 @@ import {
   createRelationResolverFactory,
   eagerLoadMutationRelations,
   extractFilters,
-  extractOrderBy,
-  extractRelationsParams,
-  extractSelectedColumnsFromTree,
   extractSelectedColumnsFromTreeSQLFormat,
   generateTableTypes,
   getPrimaryKeyPropNamesFromConfig,
   prepareMutationRelationColumns,
   pruneNonEagerRelations,
   type RelationResolverFactory,
+  runRelationalSelect,
   selectArrayArgs,
   selectSingleArgs,
   type TablesRelationalConfig,
@@ -74,28 +72,19 @@ const generateSelectArray = (
     name: fieldName,
     resolver: async (_source: any, args: Partial<TableSelectArgs>, _context: any, info: GraphQLResolveInfo) => {
       try {
-        const { offset, limit, orderBy, where } = args;
-
-        const parsedInfo = parseResolveInfo(info, {
-          deep: true,
-        }) as ResolveTree;
-
-        const query = queryBase.findMany({
-          columns: extractSelectedColumnsFromTree(parsedInfo.fieldsByTypeName[typeName]!, table),
-          offset,
-          limit,
-          // drizzle-orm v1 RQB calls orderBy with the aliased table proxy —
-          // use it directly so column refs match the CTE alias.
-          orderBy: orderBy ? (aliasedTable: Table) => extractOrderBy(aliasedTable, orderBy) : undefined,
-          where: where ? { RAW: (aliased: Table) => extractFilters(aliased, tableName, where) } : undefined,
-          with: relationMap[tableName]
-            ? extractRelationsParams(relationMap, tables, tableName, parsedInfo, typeName, typeNameMapper)
-            : undefined,
+        const parsedInfo = parseResolveInfo(info, { deep: true }) as ResolveTree;
+        return await runRelationalSelect({
+          queryBase,
+          tables,
+          tableName,
+          table,
+          relationMap,
+          typeName,
+          typeNameMapper,
+          parsedInfo,
+          ...args,
+          single: false,
         });
-
-        const result = await query;
-
-        return remapToGraphQLArrayOutput(result, tableName, table, relationMap);
       } catch (e) {
         throw toGraphQLError(e);
       }
@@ -132,30 +121,19 @@ const generateSelectSingle = (
     name: fieldName,
     resolver: async (_source, args: Partial<TableSelectArgs>, _context, info) => {
       try {
-        const { offset, orderBy, where } = args;
-
-        const parsedInfo = parseResolveInfo(info, {
-          deep: true,
-        }) as ResolveTree;
-
-        const query = queryBase.findFirst({
-          columns: extractSelectedColumnsFromTree(parsedInfo.fieldsByTypeName[typeName]!, table),
-          offset,
-          // drizzle-orm v1 RQB calls orderBy with the aliased table proxy —
-          // use it directly so column refs match the CTE alias.
-          orderBy: orderBy ? (aliasedTable: Table) => extractOrderBy(aliasedTable, orderBy) : undefined,
-          where: where ? { RAW: (aliased: Table) => extractFilters(aliased, tableName, where) } : undefined,
-          with: relationMap[tableName]
-            ? extractRelationsParams(relationMap, tables, tableName, parsedInfo, typeName, typeNameMapper)
-            : undefined,
+        const parsedInfo = parseResolveInfo(info, { deep: true }) as ResolveTree;
+        return await runRelationalSelect({
+          queryBase,
+          tables,
+          tableName,
+          table,
+          relationMap,
+          typeName,
+          typeNameMapper,
+          parsedInfo,
+          ...args,
+          single: true,
         });
-
-        const result = await query;
-        if (!result) {
-          return undefined;
-        }
-
-        return remapToGraphQLSingleOutput(result, tableName, table, relationMap);
       } catch (e) {
         throw toGraphQLError(e);
       }

--- a/src/util/builders/sqlite.ts
+++ b/src/util/builders/sqlite.ts
@@ -31,6 +31,7 @@ import {
   type TablesRelationalConfig,
   type TypeCacheCtx,
   type TypeNameMapper,
+  withPrimaryKeyColumns,
 } from '../builders/common.ts';
 import { capitalize, uncapitalize } from '../case-ops/index.ts';
 
@@ -229,9 +230,11 @@ const generateInsertArray = (
           deep: true,
         }) as ResolveTree;
 
-        const columns = extractSelectedColumnsFromTreeSQLFormat<SQLiteColumn>(
-          parsedInfo.fieldsByTypeName[typeName]!,
+        const pkNames = sqlitePrimaryKeyPropNames(table);
+        const columns = withPrimaryKeyColumns(
+          extractSelectedColumnsFromTreeSQLFormat<SQLiteColumn>(parsedInfo.fieldsByTypeName[typeName]!, table),
           table,
+          pkNames,
         );
 
         const result = await db.insert(table).values(input).returning(columns).onConflictDoNothing();
@@ -246,7 +249,7 @@ const generateInsertArray = (
           typeNameMapper,
           parsedInfo,
           result,
-          sqlitePrimaryKeyPropNames(table),
+          pkNames,
         );
 
         return remapToGraphQLArrayOutput(enriched, tableName, table, relationMap);
@@ -289,9 +292,11 @@ const generateInsertSingle = (
           deep: true,
         }) as ResolveTree;
 
-        const columns = extractSelectedColumnsFromTreeSQLFormat<SQLiteColumn>(
-          parsedInfo.fieldsByTypeName[typeName]!,
+        const pkNames = sqlitePrimaryKeyPropNames(table);
+        const columns = withPrimaryKeyColumns(
+          extractSelectedColumnsFromTreeSQLFormat<SQLiteColumn>(parsedInfo.fieldsByTypeName[typeName]!, table),
           table,
+          pkNames,
         );
         const result = await db.insert(table).values(input).returning(columns).onConflictDoNothing();
 
@@ -309,7 +314,7 @@ const generateInsertSingle = (
           typeNameMapper,
           parsedInfo,
           result,
-          sqlitePrimaryKeyPropNames(table),
+          pkNames,
         );
 
         return remapToGraphQLSingleOutput(enriched[0], tableName, table, relationMap);
@@ -356,9 +361,11 @@ const generateUpdate = (
           deep: true,
         }) as ResolveTree;
 
-        const columns = extractSelectedColumnsFromTreeSQLFormat<SQLiteColumn>(
-          parsedInfo.fieldsByTypeName[typeName]!,
+        const pkNames = sqlitePrimaryKeyPropNames(table);
+        const columns = withPrimaryKeyColumns(
+          extractSelectedColumnsFromTreeSQLFormat<SQLiteColumn>(parsedInfo.fieldsByTypeName[typeName]!, table),
           table,
+          pkNames,
         );
 
         const input = remapFromGraphQLSingleInput(set, table);
@@ -386,7 +393,7 @@ const generateUpdate = (
           typeNameMapper,
           parsedInfo,
           result,
-          sqlitePrimaryKeyPropNames(table),
+          pkNames,
         );
 
         return remapToGraphQLArrayOutput(enriched, tableName, table, relationMap);

--- a/src/util/builders/types.ts
+++ b/src/util/builders/types.ts
@@ -18,6 +18,12 @@ import type { ConvertedColumn, ConvertedRelationColumnWithArgs } from '../type-c
 export type TableNamedRelations = {
   relation: Relation;
   targetTableName: string;
+  /**
+   * Property names of the target table's primary key, resolved at build time (composite
+   * keys included, via the dialect's getTableConfig). Used to default paginated relations
+   * to a deterministic PK order. Empty when the target has no detectable primary key.
+   */
+  targetPkNames?: readonly string[];
 };
 
 export type TableSelectArgs = {

--- a/src/util/data-mappers/index.ts
+++ b/src/util/data-mappers/index.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck — vendored file, drizzle-orm 1.0 type compat not guaranteed
-import { type Column, getTableColumns, type Table } from 'drizzle-orm';
+import { type Column, getTableColumns, is, One, type Table } from 'drizzle-orm';
 import { GraphQLError } from 'graphql';
 import type { TableNamedRelations } from '../builders/index.ts';
 
@@ -83,11 +83,13 @@ export const remapToGraphQLSingleOutput = (
 ) => {
   for (const [key, value] of Object.entries(queryOutput)) {
     if (value === undefined || value === null) {
-      // Preserve an explicitly-null relation field (a to-one relation that was
-      // eager-loaded with no related row) as null, so the relation's field resolver
-      // returns null directly instead of re-querying it through the batch loader.
-      // Scalar null/undefined columns are still dropped.
-      if (value === null && relationMap?.[tableName]?.[key]) {
+      // Preserve an explicitly-null TO-ONE relation field (eager-loaded with no related
+      // row) as null, so the relation's field resolver returns null directly instead of
+      // re-querying it through the batch loader. Only to-one relations are nullable; a
+      // to-many relation is a non-null list, so a null there must fall through to deletion
+      // (the field resolver then resolves it to []) rather than be emitted as null.
+      const relEntry = value === null ? relationMap?.[tableName]?.[key] : undefined;
+      if (relEntry && is(relEntry.relation, One)) {
         queryOutput[key] = null;
         continue;
       }

--- a/src/util/data-mappers/index.ts
+++ b/src/util/data-mappers/index.ts
@@ -83,6 +83,14 @@ export const remapToGraphQLSingleOutput = (
 ) => {
   for (const [key, value] of Object.entries(queryOutput)) {
     if (value === undefined || value === null) {
+      // Preserve an explicitly-null relation field (a to-one relation that was
+      // eager-loaded with no related row) as null, so the relation's field resolver
+      // returns null directly instead of re-querying it through the batch loader.
+      // Scalar null/undefined columns are still dropped.
+      if (value === null && relationMap?.[tableName]?.[key]) {
+        queryOutput[key] = null;
+        continue;
+      }
       delete queryOutput[key];
       continue;
     }

--- a/tests/mysql-custom.test.ts
+++ b/tests/mysql-custom.test.ts
@@ -3,7 +3,7 @@ import Docker from 'dockerode';
 import { eq, inArray, sql } from 'drizzle-orm';
 import { drizzle, type MySql2Database } from 'drizzle-orm/mysql2';
 import getPort from 'get-port';
-import { GraphQLObjectType, GraphQLSchema } from 'graphql';
+import { GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLSchema, graphql } from 'graphql';
 import { createYoga } from 'graphql-yoga';
 import * as mysql from 'mysql2/promise';
 import { v4 as uuid } from 'uuid';
@@ -126,7 +126,7 @@ beforeAll(async (_t) => {
   });
   const server = createServer(yoga);
 
-  const port = 5001;
+  const port = 5002;
   server.listen(port);
   const gql = new GraphQLClient(`http://localhost:${port}/graphql`);
 
@@ -2008,5 +2008,58 @@ describe.sequential('Arguments tests', async () => {
         ],
       },
     });
+  });
+});
+
+describe.sequential('Window-function relation pagination (lazy fieldResolvers path)', () => {
+  // The standalone fieldResolvers batch loader applies per-parent limit/offset via a
+  // `ROW_NUMBER() OVER (PARTITION BY ...)` window function — exercised here on real
+  // MySQL 8 to confirm the engine accepts the generated SQL. A custom root resolver
+  // returns bare rows so the relation resolves lazily (no `with:` pre-fetch).
+  const allTypes = () => ctx.entities.types as Record<string, GraphQLObjectType>;
+  const lazySchema = () => {
+    const UsersType = allTypes()['User'] ?? allTypes()['Users'];
+    return new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: {
+          users: {
+            type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(UsersType!))) as any,
+            resolve: () => ctx.db.select().from(schema.Users),
+          },
+        },
+      }),
+    });
+  };
+
+  it('applies per-parent limit across a batched query', async () => {
+    // user 1 has 4 posts, user 5 has 2 — limit:2 must cap EACH parent at 2.
+    const result = await graphql({
+      schema: lazySchema(),
+      source: `{ users { id posts(limit: 2) { id } } }`,
+      contextValue: {},
+    });
+    expect(result.errors).toBeUndefined();
+    const users: any[] = (result.data as any)?.users ?? [];
+    expect(users.find((u) => u.id === 1)?.posts).toHaveLength(2);
+    expect(users.find((u) => u.id === 5)?.posts).toHaveLength(2);
+  });
+
+  it('applies per-parent offset+limit deterministically with orderBy', async () => {
+    // user 1 posts ids 1,2,3,6 → offset 1 limit 2 → [2,3]; user 5 posts 4,5 → [5].
+    const result = await graphql({
+      schema: lazySchema(),
+      source: `{
+        users {
+          id
+          posts(orderBy: { id: { priority: 1, direction: asc } }, offset: 1, limit: 2) { id }
+        }
+      }`,
+      contextValue: {},
+    });
+    expect(result.errors).toBeUndefined();
+    const users: any[] = (result.data as any)?.users ?? [];
+    expect(users.find((u) => u.id === 1)?.posts.map((p: any) => p.id)).toEqual([2, 3]);
+    expect(users.find((u) => u.id === 5)?.posts.map((p: any) => p.id)).toEqual([5]);
   });
 });

--- a/tests/pg-custom.test.ts
+++ b/tests/pg-custom.test.ts
@@ -1,9 +1,10 @@
 import { createServer, type Server } from 'node:http';
+import { addResolversToSchema } from '@graphql-tools/schema';
 import Docker from 'dockerode';
 import { sql } from 'drizzle-orm';
 import { drizzle, type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import getPort from 'get-port';
-import { GraphQLObjectType, GraphQLSchema } from 'graphql';
+import { GraphQLObjectType, GraphQLSchema, graphql } from 'graphql';
 import { createYoga } from 'graphql-yoga';
 import postgres, { type Sql } from 'postgres';
 import { v4 as uuid } from 'uuid';
@@ -2053,5 +2054,36 @@ describe.sequential('Arguments tests', async () => {
         ],
       },
     });
+  });
+});
+
+describe.sequential('eagerLoadRelations override (entities use case)', () => {
+  it('opting a relation out of eager loading lets a graphql-tools resolver override it', async () => {
+    // Build a schema where Users.posts is excluded from the `with:` pre-fetch, then
+    // override its resolver via @graphql-tools/schema — the documented pattern for
+    // overriding a relation without the eager query also fetching it.
+    const { schema: gqlSchema } = buildSchema(ctx.db, {
+      eagerLoadRelations: (table, relation) => !(table === 'Users' && relation === 'posts'),
+    });
+
+    const overridden = addResolversToSchema({
+      schema: gqlSchema,
+      resolvers: {
+        Users: {
+          posts: (parent: any) => [{ id: 999, content: `override-for-${parent.id}` }],
+        },
+      },
+    });
+
+    const result = await graphql({
+      schema: overridden,
+      source: `{ users { id posts { id content } } }`,
+      contextValue: {},
+    });
+
+    expect(result.errors).toBeUndefined();
+    const user1 = (result.data as any)?.users?.find((u: any) => u.id === 1);
+    // The custom resolver's value is returned, not the database posts.
+    expect(user1?.posts).toEqual([{ id: 999, content: 'override-for-1' }]);
   });
 });

--- a/tests/pglite/composite-pk.test.ts
+++ b/tests/pglite/composite-pk.test.ts
@@ -1,0 +1,139 @@
+import { PGlite } from '@electric-sql/pglite';
+import { buildRelations, createRelationsHelper, sql } from 'drizzle-orm';
+import { integer, pgTable, primaryKey, text } from 'drizzle-orm/pg-core';
+import { drizzle } from 'drizzle-orm/pglite';
+import { GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLSchema, graphql } from 'graphql';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildSchema } from '@/index';
+
+// ── Composite-PK schema ───────────────────────────────────────────────────────
+const Orgs = pgTable('orgs', { id: integer('id').primaryKey(), name: text('name') });
+const Memberships = pgTable(
+  'memberships',
+  {
+    orgId: integer('org_id').notNull(),
+    userId: integer('user_id').notNull(),
+    role: text('role'),
+  },
+  (t) => [primaryKey({ columns: [t.orgId, t.userId] })],
+);
+const r = createRelationsHelper({ Orgs, Memberships });
+const relations = buildRelations(
+  { Orgs, Memberships },
+  {
+    Orgs: { members: r.many.Memberships({ from: r.Orgs.id, to: r.Memberships.orgId }) },
+    Memberships: { org: r.one.Orgs({ from: r.Memberships.orgId, to: r.Orgs.id }) },
+  },
+);
+const schema = { Orgs, Memberships, relations };
+
+const DATA_DIR = `./tests/.temp/pgdata-composite-pk-${Date.now()}`;
+let pglite: PGlite;
+let db: any;
+let gqlSchema: GraphQLSchema;
+let entities: any;
+
+const runCapturing = async (s: GraphQLSchema, source: string) => {
+  const orig = pglite.query.bind(pglite);
+  const sqls: string[] = [];
+  (pglite as any).query = (text: string, ...rest: any[]) => {
+    sqls.push(text.replace(/\s+/g, ' '));
+    return orig(text, ...rest);
+  };
+  try {
+    const result = await graphql({ schema: s, source, contextValue: {} });
+    return { result, sqls };
+  } finally {
+    (pglite as any).query = orig;
+  }
+};
+
+beforeAll(async () => {
+  pglite = new PGlite(DATA_DIR);
+  await pglite.waitReady;
+  db = (drizzle as any)({ client: pglite, schema, relations, logger: !!process.env['LOG_SQL'] });
+
+  await db.execute(sql`CREATE TABLE "orgs" ("id" integer PRIMARY KEY NOT NULL, "name" text);`);
+  await db.execute(
+    sql`CREATE TABLE "memberships" ("org_id" integer NOT NULL, "user_id" integer NOT NULL, "role" text, PRIMARY KEY ("org_id", "user_id"));`,
+  );
+  await db.insert(Orgs).values([
+    { id: 1, name: 'A' },
+    { id: 2, name: 'B' },
+  ]);
+  // Insert in scrambled userId order so a missing PK tiebreaker would NOT happen to look sorted.
+  await db.insert(Memberships).values([
+    { orgId: 1, userId: 40, role: 'm' },
+    { orgId: 1, userId: 10, role: 'm' },
+    { orgId: 1, userId: 30, role: 'm' },
+    { orgId: 1, userId: 20, role: 'm' },
+    { orgId: 2, userId: 6, role: 'm' },
+    { orgId: 2, userId: 5, role: 'm' },
+  ]);
+
+  const built = buildSchema(db);
+  gqlSchema = built.schema;
+  entities = built.entities;
+});
+
+afterAll(async () => {
+  await pglite?.close().catch(() => {});
+});
+
+describe.sequential('composite primary key', () => {
+  it('eager paginated relation to a composite-PK target orders by the composite PK', async () => {
+    const { result, sqls } = await runCapturing(gqlSchema, `{ orgs { id members(limit: 2) { userId } } }`);
+    expect(result.errors).toBeUndefined();
+    const orgs: any[] = (result.data as any)?.orgs ?? [];
+    // Deterministic: the two lowest (orgId,userId) per org, despite scrambled insert order.
+    expect(orgs.find((o) => o.id === 1)?.members.map((m: any) => m.userId)).toEqual([10, 20]);
+    expect(orgs.find((o) => o.id === 2)?.members.map((m: any) => m.userId)).toEqual([5, 6]);
+    // The lateral subquery orders by the composite PK columns (not just org_id).
+    expect(sqls.some((q) => /order by .*"user_id"/i.test(q))).toBe(true);
+  });
+
+  it('lazy (window-function) paginated relation orders by the composite PK', async () => {
+    const allTypes = entities.types as Record<string, GraphQLObjectType>;
+    const OrgsType = allTypes['Orgs']!;
+    const lazySchema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: {
+          orgs: {
+            type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(OrgsType))) as any,
+            resolve: () => db.select().from(Orgs),
+          },
+        },
+      }),
+    });
+    const { result, sqls } = await runCapturing(lazySchema, `{ orgs { id members(limit: 2) { userId } } }`);
+    expect(result.errors).toBeUndefined();
+    const orgs: any[] = (result.data as any)?.orgs ?? [];
+    expect(orgs.find((o) => o.id === 1)?.members.map((m: any) => m.userId)).toEqual([10, 20]);
+    // The window function partitions and orders by the composite PK.
+    expect(sqls.some((q) => /row_number\(\) over \(partition by.*order by.*"user_id"/i.test(q))).toBe(true);
+  });
+
+  it('composite-PK mutation re-fetches relations with a row-value IN (not an OR explosion)', async () => {
+    const { result, sqls } = await runCapturing(
+      gqlSchema,
+      `mutation {
+        createMemberships(values: [
+          { orgId: 1, userId: 99, role: "x" },
+          { orgId: 2, userId: 98, role: "y" }
+        ]) { role org { id name } }
+      }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const created: any[] = (result.data as any)?.createMemberships ?? [];
+    expect(created).toHaveLength(2);
+    expect(created.find((m) => m.role === 'x')?.org).toEqual({ id: 1, name: 'A' });
+    expect(created.find((m) => m.role === 'y')?.org).toEqual({ id: 2, name: 'B' });
+
+    // The relation re-fetch keys the two mutated rows with a single row-value IN,
+    // e.g. (... "org_id", ... "user_id") in (($1,$2),($3,$4)) — no per-row OR/AND chain.
+    const refetch = sqls.find((q) => /from "memberships".*in \(\(/i.test(q));
+    expect(refetch).toBeDefined();
+    expect(refetch).not.toMatch(/ or /i);
+  });
+});

--- a/tests/pglite/eager-load-opt-out.test.ts
+++ b/tests/pglite/eager-load-opt-out.test.ts
@@ -1,0 +1,108 @@
+import { PGlite } from '@electric-sql/pglite';
+import { sql } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/pglite';
+import { type GraphQLSchema, graphql } from 'graphql';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildSchema } from '@/index';
+import * as schema from '../schema/pg';
+import { setupTables } from './common';
+
+// A db whose query method we can spy on to count the SQL actually issued.
+const DATA_DIR = `./tests/.temp/pgdata-eager-optout-${Date.now()}`;
+let pglite: PGlite;
+let db: any;
+
+const typeNameMapper = (name: string) =>
+  (
+    ({
+      Users: { singular: 'user', plural: 'users' },
+      Posts: { singular: 'post', plural: 'posts' },
+      Customers: { singular: 'customer', plural: 'customers' },
+      Tags: { singular: 'tag', plural: 'tags' },
+    }) as Record<string, { singular: string; plural: string }>
+  )[name];
+
+const buildWith = (eagerLoadRelations: any): GraphQLSchema =>
+  buildSchema(db, {
+    typeNameMapper,
+    prefixes: { insert: 'create', delete: 'delete' },
+    suffixes: { single: '', list: '' },
+    eagerLoadRelations,
+  }).schema;
+
+// Run a query while capturing the SQL the driver sees.
+const runCapturing = async (gqlSchema: GraphQLSchema, source: string) => {
+  const orig = pglite.query.bind(pglite);
+  const sqls: string[] = [];
+  (pglite as any).query = (text: string, ...rest: any[]) => {
+    sqls.push(text.replace(/\s+/g, ' '));
+    return orig(text, ...rest);
+  };
+  try {
+    // A shared context object lets the request-scoped batch loaders batch sibling calls.
+    const result = await graphql({ schema: gqlSchema, source, contextValue: {} });
+    return { result, sqls };
+  } finally {
+    (pglite as any).query = orig;
+  }
+};
+
+beforeAll(async () => {
+  pglite = new PGlite(DATA_DIR);
+  await pglite.waitReady;
+  db = (drizzle as any)({ client: pglite, schema, relations: schema.relations, logger: !!process.env['LOG_SQL'] });
+  await db.execute(
+    sql`DO $$ BEGIN CREATE TYPE "role" AS ENUM('admin', 'user');
+        EXCEPTION WHEN duplicate_object THEN null; END $$;`,
+  );
+  await setupTables({ db } as any);
+});
+
+afterAll(async () => {
+  await pglite?.close().catch(() => {});
+});
+
+describe.sequential('eagerLoadRelations opt-out', () => {
+  const QUERY = `{ users { id posts { id } } }`;
+  // A root users query that eager-loads posts uses a lateral join on "posts".
+  const isEagerPostsJoin = (q: string) => /from "users".*left join lateral.*"posts"/i.test(q);
+  // The lazy batch loader fetches posts with a standalone IN query.
+  const isPostsBatch = (q: string) => /from "posts" where "posts"\."author_id" in/i.test(q);
+
+  it('default: relation is eager-loaded in the parent query (no separate posts query)', async () => {
+    const gqlSchema = buildWith(undefined);
+    const { result, sqls } = await runCapturing(gqlSchema, QUERY);
+
+    expect(result.errors).toBeUndefined();
+    const users = (result.data as any)?.users ?? [];
+    expect(users.find((u: any) => u.id === 1)?.posts).toHaveLength(4);
+
+    expect(sqls.filter(isEagerPostsJoin)).toHaveLength(1);
+    expect(sqls.filter(isPostsBatch)).toHaveLength(0);
+  });
+
+  it('opted out: parent query does NOT fetch posts; they resolve via one batched query', async () => {
+    const gqlSchema = buildWith((t: string, r: string) => !(t === 'Users' && r === 'posts'));
+    const { result, sqls } = await runCapturing(gqlSchema, QUERY);
+
+    // Same data — the field still resolves, just lazily.
+    expect(result.errors).toBeUndefined();
+    const users = (result.data as any)?.users ?? [];
+    expect(users.find((u: any) => u.id === 1)?.posts).toHaveLength(4);
+    expect(users.find((u: any) => u.id === 5)?.posts).toHaveLength(2);
+
+    // No overfetch: the parent users query never joined posts...
+    expect(sqls.filter(isEagerPostsJoin)).toHaveLength(0);
+    // ...and posts came from a single batched IN query (not N+1).
+    expect(sqls.filter(isPostsBatch)).toHaveLength(1);
+  });
+
+  it('eagerLoadRelations: false disables eager loading for every relation', async () => {
+    const gqlSchema = buildWith(false);
+    const { result, sqls } = await runCapturing(gqlSchema, QUERY);
+
+    expect(result.errors).toBeUndefined();
+    expect(sqls.filter(isEagerPostsJoin)).toHaveLength(0);
+    expect(sqls.filter(isPostsBatch)).toHaveLength(1);
+  });
+});

--- a/tests/pglite/primary-key.test.ts
+++ b/tests/pglite/primary-key.test.ts
@@ -37,12 +37,12 @@ describe('getPrimaryKeyPropNames', () => {
     expect(pgPk(t)).toEqual(['orgId', 'userId']);
   });
 
-  it('falls back to a column named `id` when no primary key is declared', () => {
-    const t = pgTable('id_fallback', { id: integer('id'), name: text('name') });
-    expect(getPrimaryKeyPropNames(t)).toEqual(['id']);
+  it('does NOT guess a column named `id` that is not a declared primary key', () => {
+    const t = pgTable('id_not_pk', { id: integer('id'), name: text('name') });
+    expect(getPrimaryKeyPropNames(t)).toEqual([]);
   });
 
-  it('returns empty when no primary key and no `id` column exist', () => {
+  it('returns empty when no primary key is declared', () => {
     const t = pgTable('no_pk', { name: text('name'), value: integer('value') });
     expect(getPrimaryKeyPropNames(t)).toEqual([]);
   });

--- a/tests/pglite/primary-key.test.ts
+++ b/tests/pglite/primary-key.test.ts
@@ -1,0 +1,49 @@
+import { getTableConfig, integer, pgTable, primaryKey, text } from 'drizzle-orm/pg-core';
+import { describe, expect, it } from 'vitest';
+import { getPrimaryKeyPropNames } from '@/util/builders/common';
+
+// Mirrors the per-dialect helpers (pgPrimaryKeyPropNames / sqlitePrimaryKeyPropNames):
+// composite primary keys are only visible through getTableConfig, so the dialect layer
+// feeds their column names into the shared getPrimaryKeyPropNames().
+const pgPk = (table: any): string[] => {
+  const compositePkColumnNames = getTableConfig(table).primaryKeys.flatMap((pk: any) =>
+    pk.columns.map((c: any) => c.name),
+  );
+  return getPrimaryKeyPropNames(table, compositePkColumnNames);
+};
+
+describe('getPrimaryKeyPropNames', () => {
+  it('detects an inline single-column primary key', () => {
+    const t = pgTable('inline_pk', { id: integer('id').primaryKey(), name: text('name') });
+    expect(pgPk(t)).toEqual(['id']);
+  });
+
+  it('detects a table-level composite primary key by property name', () => {
+    const t = pgTable(
+      'composite_pk',
+      { a: integer('a').notNull(), b: integer('b').notNull(), name: text('name') },
+      (cols) => [primaryKey({ columns: [cols.a, cols.b] })],
+    );
+    // Property names, even though the inline `.primary` flag is false on composite members.
+    expect(pgPk(t)).toEqual(['a', 'b']);
+  });
+
+  it('maps composite PK DB column names back to differing property names', () => {
+    const t = pgTable(
+      'snake_pk',
+      { orgId: integer('org_id').notNull(), userId: integer('user_id').notNull() },
+      (cols) => [primaryKey({ columns: [cols.orgId, cols.userId] })],
+    );
+    expect(pgPk(t)).toEqual(['orgId', 'userId']);
+  });
+
+  it('falls back to a column named `id` when no primary key is declared', () => {
+    const t = pgTable('id_fallback', { id: integer('id'), name: text('name') });
+    expect(getPrimaryKeyPropNames(t)).toEqual(['id']);
+  });
+
+  it('returns empty when no primary key and no `id` column exist', () => {
+    const t = pgTable('no_pk', { name: text('name'), value: integer('value') });
+    expect(getPrimaryKeyPropNames(t)).toEqual([]);
+  });
+});

--- a/tests/pglite/relation-field-resolvers.test.ts
+++ b/tests/pglite/relation-field-resolvers.test.ts
@@ -151,6 +151,39 @@ describe.sequential('relation field resolvers — eager path (standard schema)',
     expect(batchLoaderLoads).toHaveLength(0);
   });
 
+  it('mutation selecting a relation but NOT the primary key still resolves the relation', async () => {
+    // The selection omits `id`; the PK must be force-included in RETURNING so the eager
+    // re-fetch can key on it. Before the fix this returned a null/empty relation (the
+    // re-fetch keyed on an undefined PK and matched nothing).
+    const result = await ctx.gql.queryGql(`mutation {
+      createPost(values: { id: 9100, authorId: 1, content: "NOPK" }) {
+        content
+        author { id name }
+      }
+    }`);
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.createPost?.content).toBe('NOPK');
+    expect(result.data?.createPost?.author).toEqual({ id: 1, name: 'FirstUser' });
+  });
+
+  it('bulk insert selecting a relation but NOT the primary key returns every row with its relation', async () => {
+    const result = await ctx.gql.queryGql(`mutation {
+      createPosts(values: [
+        { id: 9201, authorId: 1, content: "A" },
+        { id: 9202, authorId: 5, content: "B" }
+      ]) {
+        content
+        author { id name }
+      }
+    }`);
+    expect(result.errors).toBeUndefined();
+    const posts: any[] = result.data?.createPosts ?? [];
+    // No rows dropped, each mapped to the correct author.
+    expect(posts).toHaveLength(2);
+    expect(posts.find((p) => p.content === 'A')?.author?.name).toBe('FirstUser');
+    expect(posts.find((p) => p.content === 'B')?.author?.id).toBe(5);
+  });
+
   it('relation field args (where) work via the generated schema', async () => {
     const result = await ctx.gql.queryGql(`{
       users { id posts(where: { content: { eq: "1MESSAGE" } }) { id content } }

--- a/tests/pglite/relation-field-resolvers.test.ts
+++ b/tests/pglite/relation-field-resolvers.test.ts
@@ -194,6 +194,49 @@ describe.sequential('relation field resolvers — eager path (standard schema)',
     expect(user1?.posts[0]?.content).toBe('1MESSAGE');
   });
 
+  it('mutation selecting NO relations does not force the primary key into RETURNING', async () => {
+    const orig = ctx.pglite.query.bind(ctx.pglite);
+    const seen: string[] = [];
+    (ctx.pglite as any).query = (text: string, ...rest: any[]) => {
+      seen.push(text.replace(/\s+/g, ' '));
+      return orig(text, ...rest);
+    };
+    let result: any;
+    try {
+      result = await ctx.gql.queryGql(`mutation {
+        createPost(values: { id: 9300, authorId: 1, content: "NOREL" }) { content }
+      }`);
+    } finally {
+      (ctx.pglite as any).query = orig;
+    }
+    expect(result.errors).toBeUndefined();
+    const insertSql = seen.find((q) => /insert into "posts"/i.test(q))!;
+    const returningClause = insertSql.split(/returning/i)[1] ?? '';
+    // No relations selected → no eager re-fetch → no need to force the PK into RETURNING.
+    expect(returningClause).toMatch(/"content"/);
+    expect(returningClause).not.toMatch(/"id"/);
+  });
+
+  it('eager-loaded null to-one relation resolves to null without a redundant batch query', async () => {
+    const orig = ctx.pglite.query.bind(ctx.pglite);
+    const seen: string[] = [];
+    (ctx.pglite as any).query = (text: string, ...rest: any[]) => {
+      seen.push(text.replace(/\s+/g, ' '));
+      return orig(text, ...rest);
+    };
+    let result: any;
+    try {
+      result = await ctx.gql.queryGql(`{ users { id customer { id } } }`);
+    } finally {
+      (ctx.pglite as any).query = orig;
+    }
+    expect(result.errors).toBeUndefined();
+    // user 5 has no customer — the eager null must be returned directly, not re-queried.
+    expect(result.data?.users?.find((u: any) => u.id === 5)?.customer).toBeNull();
+    const customerBatch = seen.filter((q) => /from "customers" where "customers"\."user_id" in/i.test(q));
+    expect(customerBatch).toHaveLength(0);
+  });
+
   it('paginated relation without orderBy is deterministic (primary-key ordered)', async () => {
     // user 1 has posts 1,2,3,6 — limit:2 with no orderBy must deterministically yield
     // the two lowest primary keys, not an engine-arbitrary pair.

--- a/tests/pglite/relation-field-resolvers.test.ts
+++ b/tests/pglite/relation-field-resolvers.test.ts
@@ -191,13 +191,66 @@ describe.sequential('relation field resolvers — lazy path (custom root resolve
     expect(user1?.posts[0]?.content).toBe('1MESSAGE');
   });
 
-  it('relation field limit arg triggers direct query path', async () => {
+  it('relation field limit arg applies per-parent across a batched query', async () => {
+    // user 1 has 4 posts, user 5 has 2 — limit:2 must cap EACH parent at 2,
+    // not the whole result set, and must do so in a single batched query.
     const result = await lazyGql.queryGql(`{
       users { id posts(limit: 2) { id } }
     }`);
     expect(result.errors).toBeUndefined();
     const user1 = result.data?.users?.find((u: any) => u.id === 1);
+    const user5 = result.data?.users?.find((u: any) => u.id === 5);
     expect(user1?.posts).toHaveLength(2);
+    expect(user5?.posts).toHaveLength(2);
+  });
+
+  it('paginated relation issues a SINGLE batched query (no N+1)', async () => {
+    // Count SELECTs against the posts table issued to the driver during the request.
+    const orig = minCtx.pglite.query.bind(minCtx.pglite);
+    let postSelects = 0;
+    (minCtx.pglite as any).query = (text: string, ...rest: any[]) => {
+      if (/select/i.test(text) && /"posts"/i.test(text)) {
+        postSelects++;
+      }
+      return orig(text, ...rest);
+    };
+    try {
+      const result = await lazyGql.queryGql(`{
+        users { id posts(limit: 2) { id } }
+      }`);
+      expect(result.errors).toBeUndefined();
+    } finally {
+      (minCtx.pglite as any).query = orig;
+    }
+    // Pre-fix this was one query per user (true N+1). Now exactly one for the batch.
+    expect(postSelects).toBe(1);
+  });
+
+  it('relation field offset arg applies per-parent across a batched query', async () => {
+    // Order by id so the window is deterministic. user 1 posts: 1,2,3,6.
+    // offset:1 limit:2 → ids 2,3 for user 1; user 5 posts: 4,5 → offset:1 → id 5.
+    const result = await lazyGql.queryGql(`{
+      users {
+        id
+        posts(orderBy: { id: { priority: 1, direction: asc } }, offset: 1, limit: 2) { id }
+      }
+    }`);
+    expect(result.errors).toBeUndefined();
+    const user1 = result.data?.users?.find((u: any) => u.id === 1);
+    const user5 = result.data?.users?.find((u: any) => u.id === 5);
+    expect(user1?.posts.map((p: any) => p.id)).toEqual([2, 3]);
+    expect(user5?.posts.map((p: any) => p.id)).toEqual([5]);
+  });
+
+  it('limit combined with where applies per-parent in one batched query', async () => {
+    const result = await lazyGql.queryGql(`{
+      users { id posts(where: { content: { eq: "1MESSAGE" } }, limit: 5) { id content } }
+    }`);
+    expect(result.errors).toBeUndefined();
+    const user1 = result.data?.users?.find((u: any) => u.id === 1);
+    const user5 = result.data?.users?.find((u: any) => u.id === 5);
+    expect(user1?.posts).toHaveLength(1);
+    expect(user5?.posts).toHaveLength(1);
   });
 
   it('user with no related records returns empty array for many and null for one', async () => {

--- a/tests/pglite/relation-field-resolvers.test.ts
+++ b/tests/pglite/relation-field-resolvers.test.ts
@@ -193,6 +193,27 @@ describe.sequential('relation field resolvers — eager path (standard schema)',
     expect(user1?.posts).toHaveLength(1);
     expect(user1?.posts[0]?.content).toBe('1MESSAGE');
   });
+
+  it('paginated relation without orderBy is deterministic (primary-key ordered)', async () => {
+    // user 1 has posts 1,2,3,6 — limit:2 with no orderBy must deterministically yield
+    // the two lowest primary keys, not an engine-arbitrary pair.
+    const result = await ctx.gql.queryGql(`{
+      users { id posts(limit: 2) { id } }
+    }`);
+    expect(result.errors).toBeUndefined();
+    const user1 = result.data?.users?.find((u: any) => u.id === 1);
+    expect(user1?.posts.map((p: any) => p.id)).toEqual([1, 2]);
+  });
+
+  it('paginated relation with offset but no orderBy pages deterministically by primary key', async () => {
+    const result = await ctx.gql.queryGql(`{
+      users { id posts(offset: 1, limit: 2) { id } }
+    }`);
+    expect(result.errors).toBeUndefined();
+    const user1 = result.data?.users?.find((u: any) => u.id === 1);
+    // posts 1,2,3,6 → offset 1, limit 2 → [2, 3].
+    expect(user1?.posts.map((p: any) => p.id)).toEqual([2, 3]);
+  });
 });
 
 describe.sequential('relation field resolvers — lazy path (custom root resolver)', () => {
@@ -257,14 +278,16 @@ describe.sequential('relation field resolvers — lazy path (custom root resolve
   it('relation field limit arg applies per-parent across a batched query', async () => {
     // user 1 has 4 posts, user 5 has 2 — limit:2 must cap EACH parent at 2,
     // not the whole result set, and must do so in a single batched query.
+    // With no orderBy the window tiebreaks by primary key, so the slice is
+    // deterministic (the two lowest post ids per parent).
     const result = await lazyGql.queryGql(`{
       users { id posts(limit: 2) { id } }
     }`);
     expect(result.errors).toBeUndefined();
     const user1 = result.data?.users?.find((u: any) => u.id === 1);
     const user5 = result.data?.users?.find((u: any) => u.id === 5);
-    expect(user1?.posts).toHaveLength(2);
-    expect(user5?.posts).toHaveLength(2);
+    expect(user1?.posts.map((p: any) => p.id)).toEqual([1, 2]);
+    expect(user5?.posts.map((p: any) => p.id)).toEqual([4, 5]);
   });
 
   it('paginated relation issues a SINGLE batched query (no N+1)', async () => {

--- a/tests/pglite/relation-field-resolvers.test.ts
+++ b/tests/pglite/relation-field-resolvers.test.ts
@@ -121,6 +121,36 @@ describe.sequential('relation field resolvers — eager path (standard schema)',
     expect(user2?.customer?.id).toBe(2);
   });
 
+  it('mutation selecting a relation eager-loads it (no BatchLoader fallback)', async () => {
+    const orig = ctx.pglite.query.bind(ctx.pglite);
+    const seen: string[] = [];
+    (ctx.pglite as any).query = (text: string, ...rest: any[]) => {
+      seen.push(text.replace(/\s+/g, ' '));
+      return orig(text, ...rest);
+    };
+    let result: any;
+    try {
+      result = await ctx.gql.queryGql(`mutation {
+        createPost(values: { id: 9001, authorId: 1, content: "EAGER" }) {
+          id content author { id name }
+        }
+      }`);
+    } finally {
+      (ctx.pglite as any).query = orig;
+    }
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.createPost?.author).toEqual({ id: 1, name: 'FirstUser' });
+
+    // The relation must be eager-loaded via a lateral join on the re-fetch,
+    // NOT via the field-level BatchLoader (which issues a plain
+    // `select ... from "users" where "users"."id" in (...)`).
+    const lateralLoads = seen.filter((q) => /from "posts".*left join lateral.*"users"/i.test(q));
+    const batchLoaderLoads = seen.filter((q) => /from "users" where "users"\."id" in/i.test(q));
+    expect(lateralLoads).toHaveLength(1);
+    expect(batchLoaderLoads).toHaveLength(0);
+  });
+
   it('relation field args (where) work via the generated schema', async () => {
     const result = await ctx.gql.queryGql(`{
       users { id posts(where: { content: { eq: "1MESSAGE" } }) { id content } }

--- a/tests/sqlite-custom.test.ts
+++ b/tests/sqlite-custom.test.ts
@@ -93,7 +93,7 @@ beforeAll(async () => {
   });
   const server = createServer(yoga);
 
-  const port = 5001;
+  const port = 5003;
   server.listen(port);
   const gql = new GraphQLClient(`http://localhost:${port}/graphql`);
 

--- a/tests/sqlite.test.ts
+++ b/tests/sqlite.test.ts
@@ -3749,3 +3749,44 @@ describe.sequential('__typename with data tests', async () => {
     });
   });
 });
+
+describe.sequential('Mutation relation eager-load tests', () => {
+  it('insert single selecting a relation but NOT the primary key resolves the relation', async () => {
+    // Selection omits `id`; the PK must be force-included in RETURNING so the eager
+    // re-fetch keys on it. Before the fix this returned a null relation.
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+      mutation {
+        createPostsSingle(values: { id: 9100, authorId: 1, content: "NOPK" }) {
+          content
+          author { id name }
+        }
+      }
+    `);
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data?.createPostsSingle).toStrictEqual({
+      content: 'NOPK',
+      author: { id: 1, name: 'FirstUser' },
+    });
+  });
+
+  it('insert array selecting a relation but NOT the primary key returns every row with its relation', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+      mutation {
+        createPosts(values: [
+          { id: 9201, authorId: 1, content: "A" },
+          { id: 9202, authorId: 5, content: "B" }
+        ]) {
+          content
+          author { id name }
+        }
+      }
+    `);
+
+    expect(res.errors).toBeUndefined();
+    const posts: any[] = res.data?.createPosts ?? [];
+    expect(posts).toHaveLength(2);
+    expect(posts.find((p) => p.content === 'A')?.author?.name).toBe('FirstUser');
+    expect(posts.find((p) => p.content === 'B')?.author?.id).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary

This branch makes relation resolution efficient and correct end-to-end, then hardens and consolidates it across PostgreSQL, MySQL, and SQLite. It began as an investigation of where the request-scoped batch loader was used vs. where Drizzle's relational `with:` joins would be more performant, and grew into a full pass over the relation/N+1 surface (driven by several rounds of `/code-review`).

All changes are behind the existing generated-schema API; the one new public option is `eagerLoadRelations`.

## What changed

**Queries** — root queries already eager-load relations via Drizzle's `with:` (one round-trip). 

**Per-parent paginated relations** — a to-many relation with `limit`/`offset` previously fell back to one query *per parent* (true N+1). It now resolves the whole batch in a single query via `ROW_NUMBER() OVER (PARTITION BY fk …)`, tiebroken by the target's primary key so slices are deterministic even without an `orderBy`.

**Mutations (PG/SQLite)** — insert/update results that select relation fields are re-fetched by primary key through one relational query and merged onto the `RETURNING` rows, instead of N+1 batch-loading. The re-fetch fetches only the PK + relations (scalars come from `RETURNING`); single- and composite-column PKs are supported (composite uses a row-value `IN`). MySQL mutations return only `{ isSuccess }`, so this step doesn't apply there.

**`eagerLoadRelations` (new config)** — `boolean | (table, relation) => boolean`. Opting a relation out excludes it from the `with:` prefetch (and the mutation re-fetch) so you can override its resolver via `@graphql-tools/schema`'s `addResolversToSchema` without the eager query also fetching it. The field still resolves lazily by default.

## Correctness hardening (from review)

- Force the PK into `RETURNING` only when relations are selected, so a relation-selecting mutation that omits the PK still resolves correctly — and relation-less mutations don't overfetch.
- bigint-safe re-fetch keying; re-fetch failures fall back to lazy resolution (with a logged warning) instead of erroring a committed write; rows the re-fetch misses keep their scalars rather than being dropped.
- Composite-PK relation targets get a deterministic pagination tiebreak (resolved at build time via each dialect's `getTableConfig`).
- `remap` preserves an eager-loaded **to-one** relation that's `null` (so its resolver returns null instead of redundantly re-querying), while leaving to-many lists untouched.
- Dropped the "guess a column named `id`" PK fallback in favor of real PK metadata only.

## Consolidation (behavior-preserving)

Extracted the cross-dialect duplication into shared helpers in `common.ts`: `runRelationalSelect`, `prepareMutationRelationColumns`, `getPrimaryKeyPropNamesFromConfig`, `primaryKeyOrderExprs`, `computeResolverFieldNames`, `selectArrayArgs`/`selectSingleArgs`, and `toGraphQLError` (collapsing 18 identical `catch` blocks). The three dialect builders shrank ~205 lines with logic centralized.

## Docs & tests

- README gains a "Relations & N+1 handling" section, the `eagerLoadRelations` override pattern, and a window-function DB-version note (PostgreSQL / MySQL 8.0+ / SQLite 3.25+).
- New PGlite tests for the lazy/eager paths, the `eagerLoadRelations` opt-out, composite-PK determinism + mutation, and PK detection; per-engine coverage added to the SQLite and MySQL(-custom) suites; an incidental pre-existing port collision in the custom test servers fixed.

## Validation

348 tests pass across all four backends (PGlite, PostgreSQL, MySQL 8, SQLite); build and lint clean. Window-function pagination requires **PostgreSQL, MySQL 8.0+, or SQLite 3.25+** (noted in the README).

🤖 Generated with [Claude Code](https://claude.com/claude-code)