### PR TITLE
feat: aggregates, relation filters, scalars, error handling, features map and upsert

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,49 @@ supplies no `orderBy`:
 An explicit `orderBy` always takes precedence, composite primary keys are ordered by every
 key column, and an unpaginated list query is left unordered so no sort is paid for.
 
+## Error handling
+
+Database drivers put a lot into an error message. Drizzle rethrows them with the full SQL
+statement and its bound parameters attached, and Postgres itself names the table, the column
+and the constraint that was violated. None of that belongs in a GraphQL response, so by
+default every error a generated resolver throws is passed through a sanitizer:
+
+-   errors drizzle-graphql raises itself (`Unable to update with no values specified!`,
+    `Field 'x' is not a valid date!`, filter misuse, …) are written for the client and pass
+    through unchanged
+-   anything else becomes `Internal server error` with `extensions.code:
+    "INTERNAL_SERVER_ERROR"`, and the original is kept on the error's `originalError` so a
+    server-side logger can still see it
+
+`onError` overrides this. Return an error to surface that one, or return nothing to let the
+default apply — which makes it a pure logging hook:
+
+```Typescript
+const { schema } = buildSchema(db, {
+    onError: (error) => {
+        logger.error({ err: error }, 'drizzle-graphql resolver failed')
+        // no return value — the default sanitizing still applies
+    },
+})
+```
+
+```Typescript
+// Surface raw database errors, e.g. in development
+buildSchema(db, { onError: (error) => error as Error })
+
+// Or map them yourself
+buildSchema(db, {
+    onError: (error) =>
+        isUniqueViolation(error)
+            ? new GraphQLError('That record already exists', { extensions: { code: 'CONFLICT' } })
+            : undefined,
+})
+```
+
+The hook covers root queries and mutations, relation and aggregate fields, and the
+standalone `entities.fieldResolvers`. The default is exported as `defaultErrorMapper` if you
+want to fall back to it explicitly.
+
 ## Relations & N+1 handling
 
 Generated schemas resolve nested relations without N+1 query explosions:

--- a/README.md
+++ b/README.md
@@ -175,6 +175,42 @@ single `SELECT`, and on an empty result set `count` is `0` while the other value
 
 Grouping (`groupBy`) is not supported yet.
 
+## Relation aggregates
+
+Every to-many relation also gets an `<relationName>Aggregate` field on the parent type, so you
+can count or summarise related rows without fetching them:
+
+```graphql
+{
+    users {
+        id
+        postsAggregate {
+            count
+        }
+        publishedPosts: postsAggregate(where: { published: { eq: true } }) {
+            count
+            max {
+                createdAt
+            }
+        }
+    }
+}
+```
+
+-   The field returns the target table's own `<Type>Aggregate` type — the same one the root
+    `<tableName>Aggregate` query returns, so `count` / `avg` / `sum` / `min` / `max` behave
+    identically
+-   `where` takes the target table's filter input, including [relation filters](#relation-filters),
+    and applies only to the related rows
+-   A parent with no related rows gets `count: 0` and `null` for every other aggregate
+-   To-one relations get no aggregate field — there is nothing to aggregate over
+-   The field is skipped if its name would collide with a column or another relation
+
+All parents in a selection are aggregated with a single
+`SELECT <fk>, … WHERE <fk> IN (…) GROUP BY <fk>` per request, so `postsAggregate` on a list of
+users is one extra query, not one per user. Differently-aliased selections with different
+`where` arguments are batched separately.
+
 ## Relations & N+1 handling
 
 Generated schemas resolve nested relations without N+1 query explosions:

--- a/README.md
+++ b/README.md
@@ -85,6 +85,34 @@ Automatically create GraphQL schema or customizable schema config fields from Dr
     })
     ```
 
+## Choosing what gets generated
+
+Every generated operation is on by default. `features` turns individual ones off, which
+keeps them out of the schema, out of `entities`, and out of the type map — a schema for a
+read-only API, or one that never exposes aggregates, does not pay for types nobody can
+reach:
+
+```Typescript
+const { schema } = buildSchema(db, {
+    features: {
+        aggregates: false,        // <plural>Aggregate root queries
+        relationAggregates: false, // <relation>Aggregate fields on object types
+        distinct: false,          // the `distinct` argument on list queries
+        insert: false,            // create<Table> / create<Table>Single mutations
+        update: false,            // update<Table> mutations
+        delete: false,            // delete<Table> mutations
+    },
+})
+```
+
+-   Any flag left out keeps its default of `true`, so `{ features: { delete: false } }`
+    changes nothing else
+-   Turning off `insert` or `update` also drops the input type that only that mutation
+    used (`Create<Type>Input` / `Update<Type>Input`)
+-   Turning off all three mutation features omits the `Mutation` type entirely, the same as
+    `mutations: false`
+-   List and single queries are always generated, so `Query` is never empty
+
 ## Scalars
 
 Columns whose values don't fit a built-in GraphQL scalar get a named custom scalar, so the
@@ -345,6 +373,41 @@ buildSchema(db, {
 The hook covers root queries and mutations, relation and aggregate fields, and the
 standalone `entities.fieldResolvers`. The default is exported as `defaultErrorMapper` if you
 want to fall back to it explicitly.
+
+## Transactions
+
+Each resolver runs its statements on the database the schema was built from. A request that
+fires several mutations therefore commits each one separately, and a failure halfway leaves
+the earlier ones in place. To run a whole request as one unit, open a transaction yourself
+and put it on the GraphQL context under the exported `drizzleExecutorKey`:
+
+```Typescript
+import { buildSchema, drizzleExecutorKey } from 'drizzle-graphql'
+
+const { schema } = buildSchema(db)
+
+await db.transaction(async (tx) => {
+    const result = await graphql({
+        schema,
+        source: request.query,
+        variableValues: request.variables,
+        contextValue: { [drizzleExecutorKey]: tx },
+    })
+
+    if (result.errors?.length) throw new Error('rolling back')
+    return result
+})
+```
+
+Every generated resolver reads the key at resolve time, so queries, mutations, aggregates
+and relation field resolvers all run on the executor you supply and see its uncommitted
+rows. With no key on the context, everything falls back to the build-time database, which
+is what an ordinary request does.
+
+The value does not have to be a transaction — any object with the same interface works, for
+example a pooled connection bound to a tenant, or a logging proxy around `db`. Because the
+key is created with `Symbol.for`, the ESM and CJS builds of this package agree on it when
+both end up loaded in one process.
 
 ## Relations & N+1 handling
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ following the same naming rules as the other generated queries:
             createdAt
             title
         }
+        countNonNull {
+            publishedAt
+        }
+        countDistinct {
+            authorId
+        }
     }
 }
 ```
@@ -164,6 +170,10 @@ following the same naming rules as the other generated queries:
 -   `avg` / `sum` — one nullable `Float` field per numeric column
 -   `min` / `max` — one field per orderable column (numbers, strings, enums, dates, bigints),
     typed exactly like that column is in the table's own type
+-   `countNonNull` — `Int!` per column: how many matching rows have a non-null value there.
+    Every column qualifies, since `count(col)` is valid whatever the type
+-   `countDistinct` — `Int!` per column: how many distinct non-null values there are. Limited to
+    the same columns as `min` / `max`, because counting distinct values needs an equality operator
 
 Columns that have no meaningful ordering — booleans, arrays, JSON, buffers, and geometry —
 are left out of these types, and the `avg` / `sum` / `min` / `max` fields themselves are

--- a/README.md
+++ b/README.md
@@ -85,6 +85,47 @@ Automatically create GraphQL schema or customizable schema config fields from Dr
     })
     ```
 
+## Aggregate queries
+
+Every table also gets an aggregate query field — `<tableName>Aggregate` (e.g. `usersAggregate`),
+following the same naming rules as the other generated queries:
+
+```graphql
+{
+    postsAggregate(where: { authorId: { eq: 1 } }) {
+        count
+        avg {
+            views
+        }
+        sum {
+            views
+        }
+        min {
+            createdAt
+        }
+        max {
+            createdAt
+            title
+        }
+    }
+}
+```
+
+-   `count` — number of matching rows (`Int!`)
+-   `avg` / `sum` — one nullable `Float` field per numeric column
+-   `min` / `max` — one field per orderable column (numbers, strings, enums, dates, bigints),
+    typed exactly like that column is in the table's own type
+
+Columns that have no meaningful ordering — booleans, arrays, JSON, buffers, and geometry —
+are left out of these types, and the `avg` / `sum` / `min` / `max` fields themselves are
+omitted when no column qualifies.
+
+The optional `where` argument takes the same filter input as the table's list query, and is
+applied to every aggregate in the selection. All requested aggregates are computed in a
+single `SELECT`, and on an empty result set `count` is `0` while the other values are `null`.
+
+Grouping (`groupBy`) is not supported yet.
+
 ## Relations & N+1 handling
 
 Generated schemas resolve nested relations without N+1 query explosions:

--- a/README.md
+++ b/README.md
@@ -211,6 +211,21 @@ All parents in a selection are aggregated with a single
 users is one extra query, not one per user. Differently-aliased selections with different
 `where` arguments are batched separately.
 
+## Pagination ordering
+
+SQL gives no ordering guarantee for a query that has no `ORDER BY`, so paging through an
+unordered result can return the same row twice or skip one entirely. To keep pages stable,
+a query that returns only part of a table is ordered by its primary key when the request
+supplies no `orderBy`:
+
+-   list queries with `limit` and/or `offset`
+-   `<tableName>Single` queries, which are an implicit `limit 1`
+-   to-many relation fields with `limit` and/or `offset` (as a tiebreak appended to any
+    `orderBy` you do supply, so per-parent slices are deterministic)
+
+An explicit `orderBy` always takes precedence, composite primary keys are ordered by every
+key column, and an unpaginated list query is left unordered so no sort is paid for.
+
 ## Relations & N+1 handling
 
 Generated schemas resolve nested relations without N+1 query explosions:

--- a/README.md
+++ b/README.md
@@ -221,6 +221,34 @@ All parents in a selection are aggregated with a single
 users is one extra query, not one per user. Differently-aliased selections with different
 `where` arguments are batched separately.
 
+## Distinct
+
+List queries take a `distinct` argument — a list of columns from the `<Type>DistinctColumn`
+enum. Rows sharing the same combination of those columns collapse to one:
+
+```graphql
+{
+    # the first post of each author
+    posts(distinct: [authorId], orderBy: { createdAt: { direction: asc, priority: 1 } }) {
+        id
+        authorId
+        createdAt
+    }
+}
+```
+
+-   Which row survives each group is decided by `orderBy` — the first one wins. With no
+    `orderBy`, that's the lowest primary key
+-   `where` is applied **before** rows are collapsed; `limit` and `offset` are applied
+    **after**, so `limit: 10` returns ten distinct rows
+-   Several columns are treated as one combined key, not as independent ones
+-   `distinct` is available on list queries only — a single query returns one row either way
+
+It runs as an extra `row_number() over (partition by …)` query that picks the surviving
+rows' primary keys, after which the main query is narrowed to them — so it needs the same
+window-function support as per-parent paginated relations (**PostgreSQL**, **MySQL 8.0+**,
+or **SQLite 3.25+**), and a table with no primary key cannot use it.
+
 ## Pagination ordering
 
 SQL gives no ordering guarantee for a query that has no `ORDER BY`, so paging through an

--- a/README.md
+++ b/README.md
@@ -85,6 +85,55 @@ Automatically create GraphQL schema or customizable schema config fields from Dr
     })
     ```
 
+## Relation filters
+
+A table's `where` input also exposes its relations, so you can filter rows by what they're
+related to instead of pulling everything and filtering client-side.
+
+A **to-one** relation takes the target table's filter input directly:
+
+```graphql
+{
+    posts(where: { author: { name: { eq: "FifthUser" } } }) {
+        id
+    }
+}
+```
+
+A **to-many** relation takes a `some` / `none` / `every` wrapper
+(`<Target>ListRelationFilter`):
+
+```graphql
+{
+    # users who wrote at least one post containing "drizzle"
+    users(where: { posts: { some: { content: { like: "%drizzle%" } } } }) {
+        id
+    }
+
+    # users with no posts at all
+    users(where: { posts: { none: {} } }) {
+        id
+    }
+
+    # users all of whose posts are published (users with no posts match vacuously)
+    users(where: { posts: { every: { isPublished: { eq: true } } } }) {
+        id
+    }
+}
+```
+
+-   Relation filters compile to correlated `EXISTS` subqueries — the related rows are never
+    fetched, and no join duplicates the parent rows
+-   They nest arbitrarily (`users(where: { posts: { some: { author: { … } } } })`) and combine
+    freely with column filters (implicit `AND`) and with `OR`
+-   They're accepted anywhere a filter is — list and single queries, aggregate queries,
+    `update`/`delete` mutations, and the `where` argument on a relation field
+-   `some: {}` means "at least one related row exists"; `none: {}` means "none exist"
+-   Several modes may be given at once and are `AND`ed together
+-   A relation whose name collides with a column name is skipped — the column keeps the field
+-   Many-to-many relations declared with `.through()` are not filterable yet and are left out
+    of the filter input
+
 ## Aggregate queries
 
 Every table also gets an aggregate query field — `<tableName>Aggregate` (e.g. `usersAggregate`),

--- a/README.md
+++ b/README.md
@@ -85,6 +85,45 @@ Automatically create GraphQL schema or customizable schema config fields from Dr
     })
     ```
 
+## Scalars
+
+Columns whose values don't fit a built-in GraphQL scalar get a named custom scalar, so the
+generated SDL says what a field actually holds instead of falling back to `String`:
+
+| Drizzle column                             | GraphQL type | Transported as                       |
+| ------------------------------------------ | ------------ | ------------------------------------ |
+| `json` / `jsonb` (and `mode: 'json'`)       | `JSON`       | the parsed value                     |
+| `bigint` (and `mode: 'bigint'`)             | `BigInt`     | a decimal string                     |
+| `uuid`                                      | `UUID`       | a validated UUID string              |
+| `timestamp` / `datetime`                    | `DateTime`   | an ISO-8601 string                   |
+| `date`                                      | `Date`       | a `YYYY-MM-DD` string                |
+
+```graphql
+mutation {
+    createDocumentSingle(values: { id: "11111111-1111-4111-8111-111111111111", payload: { tags: ["a"], views: 3 }, counter: "9007199254740993" }) {
+        payload
+        counter
+    }
+}
+```
+
+-   **`JSON`** carries the value itself — objects, arrays, numbers, strings, `true`/`false`.
+    Reads return the parsed value, not a stringified one, and writes take a literal or a
+    variable rather than a string of JSON
+-   **`BigInt`** is always a decimal string in both directions, so values past
+    `Number.MAX_SAFE_INTEGER` survive the round-trip. Integer literals are accepted on input;
+    floats and non-numeric strings are rejected
+-   **`UUID`** validates the format on the way in, including inside `where` filters
+
+The scalars are exported if you need them in a hand-written schema:
+
+```Typescript
+import { GraphQLBigIntString, GraphQLDate, GraphQLDateTime, GraphQLJSON, GraphQLUUID } from 'drizzle-graphql'
+```
+
+`GraphQLBigIntString` is the `BigInt` scalar — named for what it does rather than what it is
+called in SDL, to avoid clashing with the language's own `BigInt`.
+
 ## Relation filters
 
 A table's `where` input also exposes its relations, so you can filter rows by what they're

--- a/README.md
+++ b/README.md
@@ -101,12 +101,15 @@ const { schema } = buildSchema(db, {
         insert: false,            // create<Table> / create<Table>Single mutations
         update: false,            // update<Table> mutations
         delete: false,            // delete<Table> mutations
+        upsert: true,             // upsert<Table> / upsert<Table>Single mutations (off by default)
     },
 })
 ```
 
 -   Any flag left out keeps its default of `true`, so `{ features: { delete: false } }`
     changes nothing else
+-   `upsert` is the exception: it defaults to `false`, so the upsert mutations and their
+    conflict input only exist if you ask for them
 -   Turning off `insert` or `update` also drops the input type that only that mutation
     used (`Create<Type>Input` / `Update<Type>Input`)
 -   Turning off all three mutation features omits the `Mutation` type entirely, the same as
@@ -330,6 +333,69 @@ supplies no `orderBy`:
 
 An explicit `orderBy` always takes precedence, composite primary keys are ordered by every
 key column, and an unpaginated list query is left unordered so no sort is paid for.
+
+## Upsert
+
+`features.upsert` adds a pair of mutations per table that insert rows, or update the ones
+that already exist:
+
+```graphql
+mutation {
+    upsertUsersSingle(values: { id: 1, name: "Dan", email: "dan@example.com" }) {
+        id
+        name
+    }
+}
+```
+
+With no `onConflict`, a conflict on the **primary key** overwrites every column the request
+supplied. `onConflict` changes that:
+
+```graphql
+mutation {
+    upsertUsers(
+        values: [
+            { email: "dan@example.com", name: "Dan", visits: 1 }
+            { email: "sam@example.com", name: "Sam", visits: 1 }
+        ]
+        onConflict: {
+            target: [email] # must be a unique constraint; defaults to the primary key
+            action: UPDATE # or NOTHING, to keep the existing row
+            update: [name] # columns to overwrite; defaults to every supplied column
+            where: { isConfirmed: { eq: true } } # only overwrite rows that match
+        }
+    ) {
+        id
+        name
+    }
+}
+```
+
+-   A batch upsert updates each row with **its own** values (`excluded.<column>`), not with
+    the last row's
+-   Columns the request did not supply are never overwritten — a partial upsert does not null
+    out the rest of the row. Listing an unsupplied column in `update` is an error rather than
+    a silent no-op
+-   `target` must match one of the table's unique constraints exactly; anything else is
+    rejected with the list of valid targets, instead of the database's opaque "no unique or
+    exclusion constraint matching" error
+-   `action: NOTHING` inserts nothing and returns nothing for the conflicting row. An `UPDATE`
+    with no columns left to write degrades to the same thing
+-   `values` is the same `Create<Type>Input` the insert mutations take, so turning `insert`
+    off does not remove it
+
+Dialect differences:
+
+-   **PostgreSQL** and **SQLite** — the full surface above. A table with no primary key and no
+    unique constraint has nothing to conflict on, so it gets no upsert mutations at all
+-   **MySQL** — `ON DUPLICATE KEY UPDATE` fires on whichever unique key was violated and takes
+    no predicate, so `<Type>OnConflict` there has only `action` and `update`. `action: NOTHING`
+    becomes `INSERT IGNORE`, and the mutations return `MutationReturn` like every other MySQL
+    mutation
+
+The build-wide `conflictDoNothing` option is deprecated in favour of this: it applies to every
+`create*` mutation with no way for a request to opt out. `onConflict: { action: NOTHING }` is
+the per-request replacement.
 
 ## Error handling
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,52 @@
+# TODO
+
+Ideas parked from the competitive gap analysis against Prisma, Hasura, PostGraphile and
+Supabase's `pg_graphql`. Roughly ordered within each group; nothing here is committed to.
+
+## Planned
+
+- **Upsert + nested writes** — designed in
+  [docs/plans/upsert-and-nested-writes.md](docs/plans/upsert-and-nested-writes.md). Not started.
+
+## Medium priority
+
+- **Multi-mutation transactions** — a request that fires several mutations runs each on its
+  own connection, so a failure halfway leaves the earlier ones committed. Needs the mutation
+  resolvers to take an executor parameter instead of closing over `db`, plus a
+  request-scoped transaction. Shared prerequisite with nested writes.
+- **`groupBy` / `having` on aggregates** — the aggregate queries compute one row over the
+  whole filtered set. Grouping is the obvious next step and the most-asked-for aggregate
+  feature after the ones already built.
+- **Query depth and complexity limits** — currently unbounded; a cyclic relation graph lets
+  a client ask for arbitrarily deep nesting. `graphql-depth-limit` and
+  `graphql-query-complexity` cover this from outside, but per-field complexity hints
+  (a relation with `limit: 1000` costs more than a scalar) can only come from the generator.
+- **Full-text search** — Postgres `tsvector` / `websearch_to_tsquery`, MySQL `MATCH … AGAINST`,
+  SQLite FTS5. Would slot in as an operator on the filter input for qualifying columns.
+
+## Lower priority
+
+- **Nulls ordering** — `orderBy` cannot say `NULLS FIRST` / `NULLS LAST`. The default differs
+  between Postgres (nulls last on ASC) and MySQL/SQLite (nulls first), so ordering a nullable
+  column is not portable today.
+- **Views and computed fields** — Drizzle views are not picked up, and there is no way to add
+  a derived field backed by SQL. Reachable now by composing a custom schema.
+- **Relay connections** — `Node` interface, global IDs, `PageInfo`, cursor pagination. A large
+  surface, and the current `limit`/`offset` covers most uses; worth doing only if a client
+  framework demands it.
+- **Subscriptions / live queries** — needs a change-feed (`LISTEN`/`NOTIFY`, binlog, polling)
+  that this library does not have and cannot fake cheaply.
+- **Descriptions and deprecations from the database** — carry column and table comments into
+  GraphQL descriptions, and mark deprecated columns with `@deprecated`. Also `affected_rows`
+  on mutation payloads, which Hasura exposes and MySQL's returnless mutations would benefit
+  from.
+- **Many-to-many relation filters** — relations declared with `.through()` are currently left
+  out of the filter input entirely. Same gap exists for relation aggregates.
+
+## Deliberately not doing
+
+- **Column and table exposure control** — allow/deny lists for what appears in the schema.
+  Better handled by `graphql-shield` or an equivalent layer, which already has the
+  per-request context this library does not.
+- **Per-request authorization hooks** — same reasoning: auth middleware sits above the schema
+  and has the request context it needs.

--- a/TODO.md
+++ b/TODO.md
@@ -6,14 +6,16 @@ Supabase's `pg_graphql`. Roughly ordered within each group; nothing here is comm
 ## Planned
 
 - **Upsert + nested writes** — designed in
-  [docs/plans/upsert-and-nested-writes.md](docs/plans/upsert-and-nested-writes.md). Not started.
+  [docs/plans/upsert-and-nested-writes.md](docs/plans/upsert-and-nested-writes.md). The shared
+  groundwork (steps 1, 2 and 4) has landed; upsert and nested writes themselves have not.
 
 ## Medium priority
 
-- **Multi-mutation transactions** — a request that fires several mutations runs each on its
-  own connection, so a failure halfway leaves the earlier ones committed. Needs the mutation
-  resolvers to take an executor parameter instead of closing over `db`, plus a
-  request-scoped transaction. Shared prerequisite with nested writes.
+- **Multi-mutation transactions** — a caller can now run a whole request on one transaction
+  by putting it on the GraphQL context under `drizzleExecutorKey`; every resolver reads it at
+  resolve time. What is left is doing it automatically: wrapping a request that fires several
+  mutations in a transaction the library opens itself, without the caller wiring up the
+  context.
 - **`groupBy` / `having` on aggregates** — the aggregate queries compute one row over the
   whole filtered set. Grouping is the obvious next step and the most-asked-for aggregate
   feature after the ones already built.

--- a/TODO.md
+++ b/TODO.md
@@ -5,9 +5,10 @@ Supabase's `pg_graphql`. Roughly ordered within each group; nothing here is comm
 
 ## Planned
 
-- **Upsert + nested writes** — designed in
-  [docs/plans/upsert-and-nested-writes.md](docs/plans/upsert-and-nested-writes.md). The shared
-  groundwork (steps 1, 2 and 4) has landed; upsert and nested writes themselves have not.
+- **Nested writes** — designed in
+  [docs/plans/upsert-and-nested-writes.md](docs/plans/upsert-and-nested-writes.md). Upsert
+  (step 3) and the shared groundwork (steps 1, 2 and 4) have landed; nested `create` /
+  `connect` on the insert inputs has not.
 
 ## Medium priority
 

--- a/docs/plans/upsert-and-nested-writes.md
+++ b/docs/plans/upsert-and-nested-writes.md
@@ -1,0 +1,183 @@
+# Plan: upsert and nested writes
+
+Status: **not started** — this is a design document, no code has been written.
+
+Two features that Prisma, Hasura and pg_graphql all expose and this library does not:
+
+1. **Upsert** — insert a row, or update it if a conflicting one already exists.
+2. **Nested writes** — create or connect related rows in the same mutation as their parent.
+
+They are planned together because nested writes need upsert's conflict handling to be
+useful, and both need the same transaction wrapper.
+
+## Where we are today
+
+- `create<Table>` / `create<Table>Single` insert and return the rows. PostgreSQL and SQLite
+  use `.returning()`; MySQL returns only `{ isSuccess }`.
+- `config.conflictDoNothing` is a **build-wide** boolean that adds `onConflictDoNothing()` to
+  PostgreSQL inserts. SQLite hardcodes `onConflictDoNothing()` on every insert, which is a
+  separate bug worth fixing under this work — it silently swallows conflicts with no way to
+  opt out.
+- Insert inputs (`Create<Table>Input`) contain columns only. Relations are output-only.
+- Nothing is wrapped in a transaction. A multi-row insert is one statement, so it is atomic
+  by accident, not by design.
+
+## Part 1 — upsert
+
+### Surface
+
+A new mutation per table, named with a configurable prefix (default `upsert`), mirroring the
+existing array/single pair:
+
+```graphql
+upsertUsers(values: [UpsertUsersInput!]!, onConflict: UsersOnConflict): [User!]!
+upsertUsersSingle(values: UpsertUsersInput!, onConflict: UsersOnConflict): User
+```
+
+`UpsertUsersInput` is the insert input — every column, required where the column is
+`notNull` without a default.
+
+`UsersOnConflict` controls what happens when a row already exists:
+
+```graphql
+input UsersOnConflict {
+  target: [UsersConflictTarget!]   # defaults to the primary key
+  action: ConflictAction!          # UPDATE (default) | NOTHING
+  update: [UsersColumn!]           # which columns to overwrite; defaults to every supplied column
+  where: UsersFilters              # optional guard on the update branch
+}
+```
+
+`UsersConflictTarget` is an enum of the columns covered by a unique constraint or unique
+index, plus the primary key. Drizzle exposes these through the table's extra config
+(`uniqueIndex()` / `unique()`), so the enum can be derived rather than guessed — a target
+that is not actually unique produces a runtime database error, so it must not be offerable.
+
+`UsersColumn` is an enum of updatable columns. `distinct` already generates a very similar
+`<Type>DistinctColumn` enum, so `generateDistinctEnum` should be generalized into a shared
+`generateColumnEnum(table, typeName, suffix, predicate)` rather than duplicated.
+
+### Dialect mapping
+
+| Dialect    | Mechanism                                                                              |
+| ---------- | -------------------------------------------------------------------------------------- |
+| PostgreSQL | `.onConflictDoUpdate({ target, set, setWhere })` / `.onConflictDoNothing({ target })`   |
+| SQLite     | same API as PostgreSQL                                                                  |
+| MySQL      | `.onDuplicateKeyUpdate({ set })` — **no conflict target, no `where`**                   |
+
+MySQL's `ON DUPLICATE KEY UPDATE` fires on any unique key, so `target` and `where` cannot be
+honoured. Two options, in order of preference:
+
+1. Omit `target` and `where` from `UsersOnConflict` when the dialect is MySQL, so the schema
+   itself says what is supported. This matches how MySQL already gets a different mutation
+   return type.
+2. Accept and ignore them. Rejected — silently ignoring a `where` on an upsert is a data
+   correctness hazard.
+
+MySQL also cannot return the affected rows, so `upsertUsers` there returns
+`MutationReturn` like its other mutations.
+
+### `set` construction
+
+`onConflictDoUpdate` needs an explicit `set`. Building it from the supplied values means
+`sql`-excluded references so that a batch upsert updates each row with its own values:
+
+```ts
+set = Object.fromEntries(updateColumns.map((c) => [c, sql`excluded.${sql.identifier(c)}`]))
+```
+
+MySQL uses `values(col)` rather than `excluded.col`; drizzle's `onDuplicateKeyUpdate` takes
+the same shape, so this is a per-dialect helper.
+
+Columns the caller did not supply must be left out of `set`, otherwise an upsert of a
+partial row nulls out everything it omitted.
+
+### Interaction with `conflictDoNothing`
+
+Once `onConflict` exists as a per-request argument, the build-wide `config.conflictDoNothing`
+is redundant and confusing (a request cannot opt out of it). Deprecate it: keep it working
+as the default for `create*` mutations, document the replacement, and remove it in a later
+major. SQLite's unconditional `onConflictDoNothing()` should start honouring the same flag,
+which is a breaking change and needs to ship in the same release.
+
+## Part 2 — nested writes
+
+### Surface
+
+Relation fields appear on the insert input, each taking a per-relation input:
+
+```graphql
+input CreateUserInput {
+  name: String!
+  email: String
+  posts: UserPostsNestedInput      # to-many
+  customer: UserCustomerNestedInput # to-one
+}
+
+input UserPostsNestedInput {
+  create: [CreatePostNestedInput!]  # rows to insert, parent FK filled in automatically
+  connect: [PostWhereUnique!]       # existing rows to point at the new parent
+}
+```
+
+`CreatePostNestedInput` is `CreatePostInput` **minus the foreign key columns that this
+relation supplies** — otherwise the caller can set `authorId` to something other than the
+parent being created. That subtraction is per (table, relation) pair, so it needs its own
+cache keyed on the relation, alongside the existing `filterTypeCache` / `orderTypeCache`.
+
+`PostWhereUnique` is a filter restricted to unique columns — the same derivation the upsert
+conflict target needs. Sharing it is the main reason to build upsert first.
+
+Scope for a first pass, deliberately narrow:
+
+- `create` and `connect` only. No `connectOrCreate`, no nested `update`/`delete`/`upsert`,
+  no `disconnect`. Prisma's full nested-write surface is very large and most of it is
+  reachable today with two round-trips.
+- One level of nesting to start (`create` inputs contain relation fields; those nested
+  create inputs do not). Deeper nesting is a cache/recursion problem identical to the one
+  `relationsDepthLimit` already solves, so it can be lifted later without an API change.
+- To-one relations: `create` and `connect`, both single-valued.
+
+### Execution order
+
+For a to-many relation where the child holds the FK (the common case):
+
+1. Insert the parent, returning its primary key.
+2. Insert the children with the FK set to that key.
+3. `UPDATE child SET fk = <parent pk> WHERE <unique filter>` for each `connect`.
+
+For a to-one relation where the **parent** holds the FK, that inverts: the related row must
+be inserted first, and its key folded into the parent's values. So the resolver has to
+partition relations by which side owns the FK before it does anything. `extractRelationJoinColumns`
+in `common.ts` already computes this and can be reused.
+
+Many-to-many (`.through()`) relations are out of scope, the same as they are for relation
+filters.
+
+### Transactions
+
+Every nested write is at least two statements and must be atomic. `db.transaction(async (tx) => …)`
+exists on all three dialects, but every resolver currently closes over `db` directly. The
+resolvers would need to take the executor as a parameter instead, which is the same
+refactor [TODO #7 (multi-mutation transactions)](../../TODO.md) needs — worth doing once, for
+both.
+
+Note that a transaction changes the eager relation re-fetch too: the re-fetch after an insert
+has to run on `tx`, not `db`, or it will not see the uncommitted rows.
+
+MySQL cannot `.returning()`, so step 1 needs `insertId` from the result header plus a
+follow-up select — and that only works for a single auto-increment key, not a composite or
+client-supplied one. MySQL nested writes may have to be restricted to tables with a single
+auto-increment primary key, or left unsupported in the first pass.
+
+## Suggested order
+
+1. Extract `generateColumnEnum` and a `WhereUnique` derivation from the table's unique
+   constraints. Both features need them; neither is user-visible on its own.
+2. Thread an executor parameter through the mutation resolvers (shared with TODO #7).
+3. Upsert, PostgreSQL and SQLite first, then MySQL with the reduced input.
+4. Fix SQLite's unconditional `onConflictDoNothing()` and deprecate `config.conflictDoNothing`.
+5. Nested `create` for to-many relations, then to-one, then `connect`.
+
+Steps 1–4 are each independently shippable. Step 5 is the only one that needs all of the
+preceding work.

--- a/docs/plans/upsert-and-nested-writes.md
+++ b/docs/plans/upsert-and-nested-writes.md
@@ -1,6 +1,6 @@
 # Plan: upsert and nested writes
 
-Status: **partially built** — the shared groundwork is in place, the two features are not.
+Status: **upsert shipped, nested writes not started.**
 
 - Step 1 (shared column enum + unique-key derivation) — **done**: `generateColumnEnum` and
   `getUniqueColumnSets` in `src/util/builders/common.ts`; `generateDistinctEnum` is now a
@@ -8,11 +8,16 @@ Status: **partially built** — the shared groundwork is in place, the two featu
 - Step 2 (executor parameter) — **done**: every generated resolver resolves its executor from
   the GraphQL context at resolve time via `resolveExecutor` / `drizzleExecutorKey`, so a
   caller can run a whole request on one transaction.
-- Step 4 (SQLite conflict handling) — **half done**: SQLite honours `config.conflictDoNothing`
-  instead of appending `onConflictDoNothing()` unconditionally. `config.conflictDoNothing`
-  is not deprecated yet, because the `onConflict` argument that replaces it does not exist.
-- Steps 3 and 5 (upsert, nested writes) — **not started**. Everything below still describes
-  the intended design for those.
+- Step 3 (upsert) — **done** on all three dialects, behind `features.upsert` (opt-in, unlike
+  every other feature flag). It deviates from the design below in three places:
+  - `values` reuses `Create<Table>Input` rather than an identical `Upsert<Table>Input`.
+  - The updatable-column enum is `<Type>UpdateColumn`, not `<Type>Column`.
+  - On PostgreSQL and SQLite a table with no primary key and no unique constraint gets **no**
+    upsert mutations, rather than ones whose every call is a database error.
+- Step 4 (SQLite conflict handling + deprecation) — **done**: SQLite honours
+  `config.conflictDoNothing` instead of appending `onConflictDoNothing()` unconditionally,
+  and `config.conflictDoNothing` is now deprecated in favour of `onConflict`.
+- Step 5 (nested writes) — **not started**. Part 2 below still describes the intended design.
 
 Two features that Prisma, Hasura and pg_graphql all expose and this library does not:
 
@@ -106,10 +111,10 @@ partial row nulls out everything it omitted.
 
 ### Interaction with `conflictDoNothing`
 
-Once `onConflict` exists as a per-request argument, the build-wide `config.conflictDoNothing`
-is redundant and confusing (a request cannot opt out of it). Deprecate it: keep it working
-as the default for `create*` mutations, document the replacement, and remove it in a later
-major. SQLite already honours the flag rather than applying `onConflictDoNothing()`
+Now that `onConflict` exists as a per-request argument, the build-wide
+`config.conflictDoNothing` is redundant and confusing (a request cannot opt out of it). It is
+deprecated: it still works and still defaults the `create*` mutations, the replacement is
+documented, and it goes in a later major. SQLite already honours the flag rather than applying `onConflictDoNothing()`
 unconditionally — that part shipped ahead of the rest as a breaking change.
 
 ## Part 2 — nested writes
@@ -190,10 +195,13 @@ auto-increment primary key, or left unsupported in the first pass.
    *input type* built from those sets is still to do.
 2. ~~Thread an executor parameter through the mutation resolvers.~~ Done, and it covers the
    query, relation and aggregate resolvers too.
-3. Upsert, PostgreSQL and SQLite first, then MySQL with the reduced input.
-4. ~~Fix SQLite's unconditional `onConflictDoNothing()`~~ (done) and deprecate
-   `config.conflictDoNothing` — the deprecation waits on step 3, which supplies the
-   replacement.
+3. ~~Upsert, PostgreSQL and SQLite first, then MySQL with the reduced input.~~ Done, behind
+   `features.upsert`. The `WhereUnique` *input type* is still to do — upsert needed only the
+   column sets, not an input built from them.
+4. ~~Fix SQLite's unconditional `onConflictDoNothing()` and deprecate
+   `config.conflictDoNothing`.~~ Done — `conflictDoNothing` still works and still defaults
+   the `create*` mutations, but is documented as replaced by
+   `onConflict: { action: NOTHING }` and will go in a later major.
 5. Nested `create` for to-many relations, then to-one, then `connect`.
 
 Steps 1–4 are each independently shippable. Step 5 is the only one that needs all of the

--- a/docs/plans/upsert-and-nested-writes.md
+++ b/docs/plans/upsert-and-nested-writes.md
@@ -1,6 +1,18 @@
 # Plan: upsert and nested writes
 
-Status: **not started** — this is a design document, no code has been written.
+Status: **partially built** — the shared groundwork is in place, the two features are not.
+
+- Step 1 (shared column enum + unique-key derivation) — **done**: `generateColumnEnum` and
+  `getUniqueColumnSets` in `src/util/builders/common.ts`; `generateDistinctEnum` is now a
+  thin wrapper over the former.
+- Step 2 (executor parameter) — **done**: every generated resolver resolves its executor from
+  the GraphQL context at resolve time via `resolveExecutor` / `drizzleExecutorKey`, so a
+  caller can run a whole request on one transaction.
+- Step 4 (SQLite conflict handling) — **half done**: SQLite honours `config.conflictDoNothing`
+  instead of appending `onConflictDoNothing()` unconditionally. `config.conflictDoNothing`
+  is not deprecated yet, because the `onConflict` argument that replaces it does not exist.
+- Steps 3 and 5 (upsert, nested writes) — **not started**. Everything below still describes
+  the intended design for those.
 
 Two features that Prisma, Hasura and pg_graphql all expose and this library does not:
 
@@ -15,12 +27,12 @@ useful, and both need the same transaction wrapper.
 - `create<Table>` / `create<Table>Single` insert and return the rows. PostgreSQL and SQLite
   use `.returning()`; MySQL returns only `{ isSuccess }`.
 - `config.conflictDoNothing` is a **build-wide** boolean that adds `onConflictDoNothing()` to
-  PostgreSQL inserts. SQLite hardcodes `onConflictDoNothing()` on every insert, which is a
-  separate bug worth fixing under this work — it silently swallows conflicts with no way to
-  opt out.
+  PostgreSQL and SQLite inserts. (SQLite used to hardcode it on every insert, silently
+  swallowing conflicts with no way to opt out; that is fixed.)
 - Insert inputs (`Create<Table>Input`) contain columns only. Relations are output-only.
-- Nothing is wrapped in a transaction. A multi-row insert is one statement, so it is atomic
-  by accident, not by design.
+- Nothing is wrapped in a transaction by the library. A multi-row insert is one statement, so
+  it is atomic by accident, not by design — but a caller can now supply a transaction on the
+  GraphQL context (`drizzleExecutorKey`) and every resolver will run on it.
 
 ## Part 1 — upsert
 
@@ -97,8 +109,8 @@ partial row nulls out everything it omitted.
 Once `onConflict` exists as a per-request argument, the build-wide `config.conflictDoNothing`
 is redundant and confusing (a request cannot opt out of it). Deprecate it: keep it working
 as the default for `create*` mutations, document the replacement, and remove it in a later
-major. SQLite's unconditional `onConflictDoNothing()` should start honouring the same flag,
-which is a breaking change and needs to ship in the same release.
+major. SQLite already honours the flag rather than applying `onConflictDoNothing()`
+unconditionally — that part shipped ahead of the rest as a breaking change.
 
 ## Part 2 — nested writes
 
@@ -157,10 +169,11 @@ filters.
 ### Transactions
 
 Every nested write is at least two statements and must be atomic. `db.transaction(async (tx) => …)`
-exists on all three dialects, but every resolver currently closes over `db` directly. The
-resolvers would need to take the executor as a parameter instead, which is the same
-refactor [TODO #7 (multi-mutation transactions)](../../TODO.md) needs — worth doing once, for
-both.
+exists on all three dialects. Resolvers no longer close over `db`: they resolve their
+executor from the GraphQL context at resolve time (`resolveExecutor`), which is the same
+refactor [multi-mutation transactions](../../TODO.md) needed. Nested writes still have to
+open the transaction themselves and pass it down, rather than relying on the caller having
+put one on the context.
 
 Note that a transaction changes the eager relation re-fetch too: the re-fetch after an insert
 has to run on `tx`, not `db`, or it will not see the uncommitted rows.
@@ -172,11 +185,15 @@ auto-increment primary key, or left unsupported in the first pass.
 
 ## Suggested order
 
-1. Extract `generateColumnEnum` and a `WhereUnique` derivation from the table's unique
-   constraints. Both features need them; neither is user-visible on its own.
-2. Thread an executor parameter through the mutation resolvers (shared with TODO #7).
+1. ~~Extract `generateColumnEnum` and a `WhereUnique` derivation from the table's unique
+   constraints.~~ Done — `generateColumnEnum` and `getUniqueColumnSets`. The `WhereUnique`
+   *input type* built from those sets is still to do.
+2. ~~Thread an executor parameter through the mutation resolvers.~~ Done, and it covers the
+   query, relation and aggregate resolvers too.
 3. Upsert, PostgreSQL and SQLite first, then MySQL with the reduced input.
-4. Fix SQLite's unconditional `onConflictDoNothing()` and deprecate `config.conflictDoNothing`.
+4. ~~Fix SQLite's unconditional `onConflictDoNothing()`~~ (done) and deprecate
+   `config.conflictDoNothing` — the deprecation waits on step 3, which supplies the
+   replacement.
 5. Nested `create` for to-many relations, then to-one, then `connect`.
 
 Steps 1–4 are each independently shippable. Step 5 is the only one that needs all of the

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,13 @@ export {
   extractRelationJoinColumns,
 } from './util/builders/common.ts';
 export type { TableNamedRelations } from './util/builders/types.ts';
+export {
+  GraphQLBigIntString,
+  GraphQLDate,
+  GraphQLDateTime,
+  GraphQLJSON,
+  GraphQLUUID,
+} from './util/scalars/index.ts';
 
 type ObjMap<T> = Record<string, T>;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,10 @@ export type {
   SelectResolver,
   SelectSingleResolver,
   UpdateResolver,
+  UpsertArgs,
+  UpsertArrResolver,
+  UpsertConflictArgs,
+  UpsertResolver,
 } from './types.ts';
 export type { RelationResolverFactory } from './util/builders/common.ts';
 export {
@@ -83,6 +87,7 @@ export const buildSchema = <TDbClient extends AnyDrizzleDB<any>>(
     insert: config?.prefixes?.insert ?? 'create',
     delete: config?.prefixes?.delete ?? 'delete',
     update: config?.prefixes?.update ?? 'update',
+    upsert: config?.prefixes?.upsert ?? 'upsert',
   };
 
   const suffixes = {
@@ -93,7 +98,8 @@ export const buildSchema = <TDbClient extends AnyDrizzleDB<any>>(
   const typeNameMapper = config?.typeNameMapper;
 
   // Every feature is on unless the caller says otherwise, so a build without a `features`
-  // block generates what it always did.
+  // block generates what it always did — except upsert, which is new surface and so has to
+  // be asked for.
   const features = {
     aggregates: config?.features?.aggregates ?? true,
     relationAggregates: config?.features?.relationAggregates ?? true,
@@ -101,6 +107,7 @@ export const buildSchema = <TDbClient extends AnyDrizzleDB<any>>(
     insert: config?.features?.insert ?? true,
     update: config?.features?.update ?? true,
     delete: config?.features?.delete ?? true,
+    upsert: config?.features?.upsert ?? false,
   };
 
   // Normalize eagerLoadRelations (boolean | predicate | undefined) into a predicate.

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
   type GraphQLSchemaConfig,
 } from 'graphql';
 import type { AnyDrizzleDB, BuildSchemaConfig, GeneratedData } from './types.ts';
+import { applyErrorMapper, defaultErrorMapper } from './util/builders/common.ts';
 import { generateMySQL, generatePG, generateSQLite } from './util/builders/index.ts';
 
 export type {
@@ -37,6 +38,7 @@ export type {
 export type { RelationResolverFactory } from './util/builders/common.ts';
 export {
   createRelationResolverFactory,
+  defaultErrorMapper,
   extractFilters,
   extractOrderBy,
   extractRelationJoinColumns,
@@ -152,6 +154,14 @@ export const buildSchema = <TDbClient extends AnyDrizzleDB<any>>(
   } else {
     throw new Error('Drizzle-GraphQL Error: Unknown database instance type');
   }
+
+  // Wrap resolvers before the schema is assembled, so the generated schema and the returned
+  // entities share the same handling.
+  const onError = config?.onError;
+  applyErrorMapper(
+    generatorOutput as any,
+    onError ? (error) => onError(error) ?? defaultErrorMapper(error) : defaultErrorMapper,
+  );
 
   const { queries, mutations, inputs, types } = generatorOutput;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import type { AnyDrizzleDB, BuildSchemaConfig, GeneratedData } from './types.ts'
 import { generateMySQL, generatePG, generateSQLite } from './util/builders/index.ts';
 
 export type {
+  AggregateResolver,
   AnyDrizzleDB,
   BuildSchemaConfig,
   DeleteResolver,

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
 import type { AnyDrizzleDB, BuildSchemaConfig, GeneratedData } from './types.ts';
 import { applyErrorMapper, defaultErrorMapper } from './util/builders/common.ts';
 import { generateMySQL, generatePG, generateSQLite } from './util/builders/index.ts';
+import type { SchemaGeneratorOptions } from './util/builders/types.ts';
 
 export type {
   AggregateResolver,
@@ -31,6 +32,7 @@ export type {
   MutationReturnlessResult,
   MutationsCore,
   QueriesCore,
+  SchemaFeatures,
   SelectResolver,
   SelectSingleResolver,
   UpdateResolver,
@@ -39,6 +41,7 @@ export type { RelationResolverFactory } from './util/builders/common.ts';
 export {
   createRelationResolverFactory,
   defaultErrorMapper,
+  drizzleExecutorKey,
   extractFilters,
   extractOrderBy,
   extractRelationJoinColumns,
@@ -89,6 +92,17 @@ export const buildSchema = <TDbClient extends AnyDrizzleDB<any>>(
 
   const typeNameMapper = config?.typeNameMapper;
 
+  // Every feature is on unless the caller says otherwise, so a build without a `features`
+  // block generates what it always did.
+  const features = {
+    aggregates: config?.features?.aggregates ?? true,
+    relationAggregates: config?.features?.relationAggregates ?? true,
+    distinct: config?.features?.distinct ?? true,
+    insert: config?.features?.insert ?? true,
+    update: config?.features?.update ?? true,
+    delete: config?.features?.delete ?? true,
+  };
+
   // Normalize eagerLoadRelations (boolean | predicate | undefined) into a predicate.
   const eagerOpt = config?.eagerLoadRelations;
   const shouldEagerLoad: (tableName: string, relationName: string) => boolean =
@@ -116,41 +130,23 @@ export const buildSchema = <TDbClient extends AnyDrizzleDB<any>>(
     }
   }
 
+  const generatorOptions: SchemaGeneratorOptions = {
+    relationsDepthLimit: config?.relationsDepthLimit,
+    prefixes,
+    suffixes,
+    conflictDoNothing: config?.conflictDoNothing ?? false,
+    typeNameMapper,
+    shouldEagerLoad,
+    features,
+  };
+
   let generatorOutput;
   if (is(db, MySqlDatabase)) {
-    generatorOutput = generateMySQL(
-      db,
-      schema,
-      relations,
-      config?.relationsDepthLimit,
-      prefixes,
-      suffixes,
-      typeNameMapper,
-      shouldEagerLoad,
-    );
+    generatorOutput = generateMySQL(db, schema, relations, generatorOptions);
   } else if (is(db, PgAsyncDatabase)) {
-    generatorOutput = generatePG(
-      db,
-      schema,
-      relations,
-      config?.relationsDepthLimit,
-      prefixes,
-      suffixes,
-      config?.conflictDoNothing ?? false,
-      typeNameMapper,
-      shouldEagerLoad,
-    );
+    generatorOutput = generatePG(db, schema, relations, generatorOptions);
   } else if (is(db, BaseSQLiteDatabase)) {
-    generatorOutput = generateSQLite(
-      db,
-      schema,
-      relations,
-      config?.relationsDepthLimit,
-      prefixes,
-      suffixes,
-      typeNameMapper,
-      shouldEagerLoad,
-    );
+    generatorOutput = generateSQLite(db, schema, relations, generatorOptions);
   } else {
     throw new Error('Drizzle-GraphQL Error: Unknown database instance type');
   }
@@ -173,7 +169,9 @@ export const buildSchema = <TDbClient extends AnyDrizzleDB<any>>(
     }),
   };
 
-  if (config?.mutations !== false) {
+  // An empty Mutation type is invalid GraphQL, so turning off every mutation feature
+  // omits the type the same way `mutations: false` does.
+  if (config?.mutations !== false && Object.keys(mutations).length) {
     const mutation = new GraphQLObjectType({
       name: 'Mutation',
       fields: mutations as ObjMap<GraphQLFieldConfig<any, any, any>>,

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ import type { RelationalQueryBuilder as PgQuery } from 'drizzle-orm/pg-core/quer
 import type { BaseSQLiteDatabase } from 'drizzle-orm/sqlite-core';
 import type { RelationalQueryBuilder as SQLiteQuery } from 'drizzle-orm/sqlite-core/query-builders/query';
 import type {
+  GraphQLEnumType,
   GraphQLInputObjectType,
   GraphQLList,
   GraphQLNonNull,
@@ -232,6 +233,9 @@ export type QueriesCore<
             type: TInputs[`${Capitalize<TName>}Filters`] extends GraphQLInputObjectType
               ? TInputs[`${Capitalize<TName>}Filters`]
               : never;
+          };
+          distinct: {
+            type: GraphQLList<GraphQLNonNull<GraphQLEnumType>>;
           };
         };
         resolve: SelectResolver<

--- a/src/types.ts
+++ b/src/types.ts
@@ -538,4 +538,28 @@ export type BuildSchemaConfig = {
    * @default true
    */
   eagerLoadRelations?: boolean | ((tableName: string, relationName: string) => boolean);
+  /**
+   * Called for every error thrown by a generated resolver, before it reaches the client.
+   *
+   * Return an error to surface that one instead. Return nothing to fall through to the
+   * default handling, which makes this a pure logging hook:
+   *
+   * ```ts
+   * buildSchema(db, { onError: (error) => { logger.error(error) } })
+   * ```
+   *
+   * The default passes through errors drizzle-graphql raises itself (bad filter, missing
+   * values, invalid date, …) and replaces everything else — driver and database errors —
+   * with a generic `Internal server error`, keeping the original on `originalError` so it
+   * is still available to server-side logging. Database messages routinely name tables,
+   * columns, constraints and the values that violated them, which is not something a
+   * public API should hand back.
+   *
+   * To surface raw database errors instead (useful in development):
+   *
+   * ```ts
+   * buildSchema(db, { onError: (error) => error as Error })
+   * ```
+   */
+  onError?: (error: unknown) => unknown;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -188,6 +188,18 @@ export type UpdateResolver<TTable extends Table, IsReturnless extends boolean> =
   info: GraphQLResolveInfo,
 ) => Promise<IsReturnless extends false ? GetRemappedTableDataType<TTable> | undefined : MutationReturnlessResult>;
 
+/**
+ * Resolver for a table's generated aggregate query (`<plural>Aggregate`).
+ * Returns only the requested aggregations: `count` plus per-column `avg` / `sum`
+ * (numeric columns, as Float) and `min` / `max` (orderable columns, as the column's type).
+ */
+export type AggregateResolver<TTable extends Table> = (
+  source: any,
+  args: { where?: Filters<TTable> },
+  context: any,
+  info: GraphQLResolveInfo,
+) => Promise<Record<string, any>>;
+
 export type DeleteResolver<TTable extends Table, IsReturnless extends boolean> = (
   source: any,
   args: DeleteArgs<TTable>,
@@ -253,6 +265,26 @@ export type QueriesCore<
           TSchemaTables,
           ExtractTableRelations<TSchemaTables[TName], TSchemaRelations> extends infer R ? R[keyof R] : never
         >;
+      }
+    : never;
+} & {
+  [TName in keyof TSchemaTables as TName extends string
+    ? `${Uncapitalize<TName>}Aggregate`
+    : never]: TName extends string
+    ? {
+        type: GraphQLNonNull<
+          TOutputs[`${Capitalize<TName>}Aggregate`] extends GraphQLObjectType
+            ? TOutputs[`${Capitalize<TName>}Aggregate`]
+            : GraphQLObjectType
+        >;
+        args: {
+          where: {
+            type: TInputs[`${Capitalize<TName>}Filters`] extends GraphQLInputObjectType
+              ? TInputs[`${Capitalize<TName>}Filters`]
+              : never;
+          };
+        };
+        resolve: AggregateResolver<TSchemaTables[TName]>;
       }
     : never;
 };
@@ -350,13 +382,15 @@ export type GeneratedInputs<TSchema extends Record<string, Table>> = {
 
 export type GeneratedOutputs<TSchema extends Record<string, Table>, IsReturnless extends boolean> = {
   [TName in keyof TSchema as TName extends string ? `${Capitalize<TName>}SelectItem` : never]: GraphQLObjectType;
+} & {
+  [TName in keyof TSchema as TName extends string ? `${Capitalize<TName>}Aggregate` : never]: GraphQLObjectType;
 } & (IsReturnless extends true
-  ? {
-      MutationReturn: GraphQLObjectType;
-    }
-  : {
-      [TName in keyof TSchema as TName extends string ? `${Capitalize<TName>}Item` : never]: GraphQLObjectType;
-    });
+    ? {
+        MutationReturn: GraphQLObjectType;
+      }
+    : {
+        [TName in keyof TSchema as TName extends string ? `${Capitalize<TName>}Item` : never]: GraphQLObjectType;
+      });
 
 export type GeneratedEntities<
   TDatabase extends AnyDrizzleDB<TSchema>,

--- a/src/types.ts
+++ b/src/types.ts
@@ -435,6 +435,25 @@ export type GeneratedData<TDatabase extends AnyDrizzleDB<any>> = {
   entities: GeneratedEntities<TDatabase>;
 };
 
+/**
+ * Per-feature switches for what `buildSchema` generates. Every flag defaults to `true`.
+ * See {@link BuildSchemaConfig.features}.
+ */
+export type SchemaFeatures = {
+  /** `<plural>Aggregate` root queries and the aggregate output types. @default true */
+  aggregates?: boolean;
+  /** `<relation>Aggregate` fields on object types, for to-many relations. @default true */
+  relationAggregates?: boolean;
+  /** The `distinct` argument on list queries. @default true */
+  distinct?: boolean;
+  /** `create<Table>` / `create<Table>Single` mutations. @default true */
+  insert?: boolean;
+  /** `update<Table>` mutations. @default true */
+  update?: boolean;
+  /** `delete<Table>` mutations. @default true */
+  delete?: boolean;
+};
+
 export type BuildSchemaConfig = {
   /**
    * Determines whether generated mutations will be passed to returned schema.
@@ -492,8 +511,34 @@ export type BuildSchemaConfig = {
   /**
    * When true, insert mutations will use onConflictDoNothing() to silently
    * ignore duplicate key violations. Defaults to false (conflicts throw errors).
+   *
+   * PostgreSQL and SQLite only — MySQL's insert builder has no equivalent, so the flag is
+   * ignored there and conflicts keep throwing.
    */
   conflictDoNothing?: boolean;
+  /**
+   * Turns individual generated features off.
+   *
+   * Every flag defaults to `true`: a build with no `features` block generates exactly what
+   * it generated before this option existed. Turning one off removes both the schema
+   * surface it adds and the work behind it.
+   *
+   * ```ts
+   * buildSchema(db, {
+   *   features: {
+   *     aggregates: false,         // no `<plural>Aggregate` root queries
+   *     relationAggregates: false, // no `<relation>Aggregate` fields on object types
+   *     distinct: false,           // no `distinct` argument on list queries
+   *     delete: false,             // no delete mutations
+   *   },
+   * });
+   * ```
+   *
+   * Turning off every mutation feature omits the `Mutation` type entirely, exactly as
+   * `mutations: false` does. Query-side features can all be off — the list and single
+   * queries are always generated, so `Query` is never empty.
+   */
+  features?: SchemaFeatures;
   /**
    * Optional mapper from table key to singular/plural name pair.
    * When provided for a table, overrides the default (table key) naming for GraphQL type names,

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,6 +99,24 @@ export type UpdateArgs<TTable extends Table> = Partial<{
   where?: Filters<TTable>;
 }>;
 
+/**
+ * The `onConflict` argument of the generated upsert mutations.
+ *
+ * `target` and `where` exist on PostgreSQL and SQLite only: MySQL's
+ * `ON DUPLICATE KEY UPDATE` fires on whichever unique key was violated and takes no
+ * predicate, so neither field is generated there.
+ */
+export type UpsertConflictArgs<TTable extends Table> = {
+  action?: 'UPDATE' | 'NOTHING';
+  target?: string[];
+  update?: string[];
+  where?: Filters<TTable>;
+};
+
+export type UpsertArgs<TTable extends Table, isSingle extends boolean> = InsertArgs<TTable, isSingle> & {
+  onConflict?: UpsertConflictArgs<TTable>;
+};
+
 export type DeleteArgs<TTable extends Table> = {
   where?: Filters<TTable>;
 };
@@ -188,6 +206,22 @@ export type UpdateResolver<TTable extends Table, IsReturnless extends boolean> =
   context: any,
   info: GraphQLResolveInfo,
 ) => Promise<IsReturnless extends false ? GetRemappedTableDataType<TTable> | undefined : MutationReturnlessResult>;
+
+/** Resolver for `upsert<Table>Single`. */
+export type UpsertResolver<TTable extends Table, IsReturnless extends boolean> = (
+  source: any,
+  args: Partial<UpsertArgs<TTable, true>>,
+  context: any,
+  info: GraphQLResolveInfo,
+) => Promise<IsReturnless extends false ? GetRemappedTableDataType<TTable> | undefined : MutationReturnlessResult>;
+
+/** Resolver for `upsert<Table>`. */
+export type UpsertArrResolver<TTable extends Table, IsReturnless extends boolean> = (
+  source: any,
+  args: Partial<UpsertArgs<TTable, false>>,
+  context: any,
+  info: GraphQLResolveInfo,
+) => Promise<IsReturnless extends false ? Array<GetRemappedTableDataType<TTable>> : MutationReturnlessResult>;
 
 /**
  * Resolver for a table's generated aggregate query (`<plural>Aggregate`).
@@ -334,6 +368,48 @@ export type MutationsCore<
       }
     : never;
 } & {
+  // Optional, because upsert is the one feature that is off unless asked for — and on
+  // PostgreSQL and SQLite a table with nothing unique to conflict on never gets one.
+  [TName in keyof TSchemaTables as TName extends string ? `upsert${Capitalize<TName>}` : never]?: TName extends string
+    ? {
+        type: IsReturnless extends true
+          ? TOutputs['MutationReturn'] extends GraphQLObjectType
+            ? TOutputs['MutationReturn']
+            : never
+          : GraphQLNonNull<GraphQLList<GraphQLNonNull<TOutputs[`${Capitalize<TName>}Item`]>>>;
+        args: {
+          values: {
+            type: GraphQLNonNull<GraphQLList<GraphQLNonNull<TInputs[`${Capitalize<TName>}InsertInput`]>>>;
+          };
+          onConflict: {
+            type: GraphQLInputObjectType;
+          };
+        };
+        resolve: UpsertArrResolver<TSchemaTables[TName], IsReturnless>;
+      }
+    : never;
+} & {
+  [TName in keyof TSchemaTables as TName extends string
+    ? `upsert${Capitalize<TName>}Single`
+    : never]?: TName extends string
+    ? {
+        type: IsReturnless extends true
+          ? TOutputs['MutationReturn'] extends GraphQLObjectType
+            ? TOutputs['MutationReturn']
+            : never
+          : TOutputs[`${Capitalize<TName>}Item`];
+        args: {
+          values: {
+            type: GraphQLNonNull<TInputs[`${Capitalize<TName>}InsertInput`]>;
+          };
+          onConflict: {
+            type: GraphQLInputObjectType;
+          };
+        };
+        resolve: UpsertResolver<TSchemaTables[TName], IsReturnless>;
+      }
+    : never;
+} & {
   [TName in keyof TSchemaTables as TName extends string ? `update${Capitalize<TName>}` : never]: TName extends string
     ? {
         type: IsReturnless extends true
@@ -452,6 +528,14 @@ export type SchemaFeatures = {
   update?: boolean;
   /** `delete<Table>` mutations. @default true */
   delete?: boolean;
+  /**
+   * `upsert<Table>` / `upsert<Table>Single` mutations — insert, or update the row that
+   * already holds the same unique key. Off unless asked for, so an existing schema does
+   * not grow new mutations on upgrade.
+   *
+   * @default false
+   */
+  upsert?: boolean;
 };
 
 export type BuildSchemaConfig = {
@@ -486,7 +570,7 @@ export type BuildSchemaConfig = {
   /**
    * Customizes query name prefixes for generated GraphQL operations.
    *
-   * @default { insert: 'create', delete: 'delete', update: 'update' }
+   * @default { insert: 'create', delete: 'delete', update: 'update', upsert: 'upsert' }
    */
   prefixes?: {
     /** Prefix for insert mutations (e.g., 'users' -> 'createUsers') */
@@ -495,6 +579,8 @@ export type BuildSchemaConfig = {
     delete?: string;
     /** Prefix for update mutations (e.g., 'users' -> 'updateUsers') */
     update?: string;
+    /** Prefix for upsert mutations (e.g., 'users' -> 'upsertUsers') */
+    upsert?: string;
   };
 
   /**
@@ -514,14 +600,19 @@ export type BuildSchemaConfig = {
    *
    * PostgreSQL and SQLite only — MySQL's insert builder has no equivalent, so the flag is
    * ignored there and conflicts keep throwing.
+   *
+   * @deprecated Build-wide and unconditional: a request cannot opt out of it, and a
+   * swallowed insert returns `null` with no indication why. Turn on `features.upsert` and
+   * pass `onConflict: { action: NOTHING }` per request instead. This flag keeps working
+   * until the next major.
    */
   conflictDoNothing?: boolean;
   /**
    * Turns individual generated features off.
    *
-   * Every flag defaults to `true`: a build with no `features` block generates exactly what
-   * it generated before this option existed. Turning one off removes both the schema
-   * surface it adds and the work behind it.
+   * Every flag defaults to `true` except `upsert`, which is opt-in: a build with no
+   * `features` block generates exactly what it generated before this option existed.
+   * Turning one off removes both the schema surface it adds and the work behind it.
    *
    * ```ts
    * buildSchema(db, {
@@ -530,6 +621,7 @@ export type BuildSchemaConfig = {
    *     relationAggregates: false, // no `<relation>Aggregate` fields on object types
    *     distinct: false,           // no `distinct` argument on list queries
    *     delete: false,             // no delete mutations
+   *     upsert: true,              // opt in to `upsert<Table>` mutations
    *   },
    * });
    * ```

--- a/src/util/builders/aggregates.ts
+++ b/src/util/builders/aggregates.ts
@@ -34,6 +34,7 @@ import {
   type RelationAggregateFactory,
   type RelationFilterBase,
   relationFilterCtx,
+  resolveExecutor,
   resolveTypeName,
   type TypeCacheCtx,
   type TypeNameMapper,
@@ -351,14 +352,14 @@ export const generateAggregate = (
 
   return {
     name: fieldName,
-    resolver: async (_source, args: { where?: Filters<Table> }, _context, info) => {
+    resolver: async (_source, args: { where?: Filters<Table> }, context, info) => {
       try {
         const request = parseAggregateRequest(info, target);
         if (!Object.keys(request.selection).length) {
           return {};
         }
 
-        let query = db.select(request.selection).from(table);
+        let query = resolveExecutor(db, context).select(request.selection).from(table);
         if (args.where) {
           query = query.where(extractFilters(table, tableName, args.where, relationFilterCtx(filterCtx, tableName)));
         }
@@ -434,6 +435,8 @@ export const createRelationAggregateFactory = (
         const loaderKey = `${tableName}::${relationName}::aggregate::${argsKey}`;
 
         const loader = getOrCreateLoader(context, loaderKey, async (parentIds: readonly any[]) => {
+          // Loaders are cached per context, so the whole batch shares this request's executor.
+          const executor = resolveExecutor(db, context);
           const uniqueIds = [...new Set(parentIds)];
           const whereCondition = and(
             inArray(foreignCol, uniqueIds),
@@ -442,7 +445,7 @@ export const createRelationAggregateFactory = (
               : undefined,
           );
 
-          const rows: any[] = await db
+          const rows: any[] = await executor
             .select({ [GROUP_KEY]: foreignCol, ...request.selection })
             .from(targetTable)
             .where(whereCondition)

--- a/src/util/builders/aggregates.ts
+++ b/src/util/builders/aggregates.ts
@@ -4,6 +4,7 @@ import {
   avg,
   type Column,
   count,
+  countDistinct,
   extractExtendedColumnType,
   getColumns,
   inArray,
@@ -41,10 +42,20 @@ import {
 import type { CreatedResolver, Filters } from './types.ts';
 
 /** Operations that aggregate over a set of column values. `count` is handled separately (whole rows). */
-const AGGREGATE_OPS = ['avg', 'sum', 'min', 'max'] as const;
+const AGGREGATE_OPS = ['avg', 'sum', 'min', 'max', 'countNonNull', 'countDistinct'] as const;
 type AggregateOp = (typeof AGGREGATE_OPS)[number];
 
-const OP_FNS: Record<AggregateOp, (col: Column) => any> = { avg, sum, min, max };
+/** Ops whose result is a row count: never null, and returned as `Int!` rather than the column's type. */
+const COUNT_OPS = new Set<AggregateOp>(['countNonNull', 'countDistinct']);
+
+const OP_FNS: Record<AggregateOp, (col: Column) => any> = {
+  avg,
+  sum,
+  min,
+  max,
+  countNonNull: count,
+  countDistinct,
+};
 
 /** Separator for flat select aliases (`avg__price`) — reassembled into nested output by the resolver. */
 const SEP = '__';
@@ -54,6 +65,8 @@ interface AggregateColumnSets {
   numeric: Record<string, Column>;
   /** Columns min/max apply to: anything with a total ordering the DB supports (numbers, strings, dates, enums). */
   orderable: Record<string, { column: Column; converted: ConvertedColumn }>;
+  /** Every column — `count(col)` is valid whatever the type. */
+  all: Record<string, Column>;
 }
 
 /**
@@ -65,8 +78,10 @@ interface AggregateColumnSets {
 const classifyAggregateColumns = (table: Table, tableName: string): AggregateColumnSets => {
   const numeric: AggregateColumnSets['numeric'] = {};
   const orderable: AggregateColumnSets['orderable'] = {};
+  const all: AggregateColumnSets['all'] = {};
 
   for (const [columnName, column] of Object.entries(getColumns(table))) {
+    all[columnName] = column;
     const converted = drizzleColumnToGraphQLType(column, columnName, tableName, true, false, false);
     const gqlType = converted.type;
 
@@ -93,7 +108,7 @@ const classifyAggregateColumns = (table: Table, tableName: string): AggregateCol
     }
   }
 
-  return { numeric, orderable };
+  return { numeric, orderable, all };
 };
 
 /**
@@ -102,7 +117,9 @@ const classifyAggregateColumns = (table: Table, tableName: string): AggregateCol
  * - `avg` / `sum` — per numeric column, always nullable Float (SQL returns NULL on empty sets,
  *   and avg/sum of integers overflow Int / produce decimals)
  * - `min` / `max` — per orderable column, the column's own (nullable) scalar type
- * The avg/sum (min/max) wrappers are omitted when no column qualifies.
+ * - `countNonNull` — per column, `Int!`: how many matching rows have a non-null value there
+ * - `countDistinct` — per orderable column, `Int!`: how many distinct non-null values there are
+ * Each wrapper is omitted when no column qualifies for it.
  */
 export const generateAggregateTypes = (
   table: Table,
@@ -115,7 +132,7 @@ export const generateAggregateTypes = (
     return cached;
   }
 
-  const { numeric, orderable } = classifyAggregateColumns(table, tableName);
+  const { numeric, orderable, all } = classifyAggregateColumns(table, tableName);
 
   const fields: Record<string, { type: any }> = {
     count: { type: new GraphQLNonNull(GraphQLInt) },
@@ -146,6 +163,24 @@ export const generateAggregateTypes = (
         }),
       };
     }
+  }
+
+  // `count(col)` works on any column type; `count(distinct col)` needs an equality operator,
+  // which is the same requirement min/max have, so it reuses the orderable set.
+  const countSets: Record<string, Record<string, unknown>> = { countNonNull: all, countDistinct: orderable };
+  for (const [op, columns] of Object.entries(countSets)) {
+    const columnNames = Object.keys(columns);
+    if (!columnNames.length) {
+      continue;
+    }
+    fields[op] = {
+      type: new GraphQLObjectType({
+        name: `${typeName}${capitalize(op)}Aggregate`,
+        fields: Object.fromEntries(
+          columnNames.map((columnName) => [columnName, { type: new GraphQLNonNull(GraphQLInt) }]),
+        ),
+      }),
+    };
   }
 
   const aggregateType = new GraphQLObjectType({
@@ -213,7 +248,7 @@ const parseAggregateRequest = (info: any, target: AggregateTarget): AggregateReq
 
   const request: AggregateRequest = {
     count: false,
-    ops: { avg: [], sum: [], min: [], max: [] },
+    ops: { avg: [], sum: [], min: [], max: [], countNonNull: [], countDistinct: [] },
     selection: {},
   };
 
@@ -266,7 +301,10 @@ const assembleAggregateRow = (row: Record<string, any>, request: AggregateReques
     const opResult: Record<string, any> = {};
     for (const columnName of request.ops[op]) {
       const value = row[`${op}${SEP}${columnName}`];
-      if (value == null) {
+      if (COUNT_OPS.has(op)) {
+        // A count is never null: an empty set counts to 0, and a missing group means no rows.
+        opResult[columnName] = value == null ? 0 : Number(value);
+      } else if (value == null) {
         opResult[columnName] = null;
       } else if (op === 'avg' || op === 'sum') {
         // Drivers return numeric/decimal aggregates as strings — coerce to Float.

--- a/src/util/builders/aggregates.ts
+++ b/src/util/builders/aggregates.ts
@@ -1,5 +1,17 @@
 // @ts-nocheck — vendored file, drizzle-orm 1.0 type compat not guaranteed
-import { avg, type Column, count, extractExtendedColumnType, getColumns, max, min, sum, type Table } from 'drizzle-orm';
+import {
+  and,
+  avg,
+  type Column,
+  count,
+  extractExtendedColumnType,
+  getColumns,
+  inArray,
+  max,
+  min,
+  sum,
+  type Table,
+} from 'drizzle-orm';
 import {
   GraphQLFloat,
   type GraphQLInputObjectType,
@@ -10,11 +22,22 @@ import {
 } from 'graphql';
 import type { ResolveTree } from 'graphql-parse-resolve-info';
 import { parseResolveInfo } from 'graphql-parse-resolve-info';
+import { getOrCreateLoader } from '../batch-loader/index.ts';
 import { capitalize } from '../case-ops/index.ts';
 import { remapToGraphQLCore } from '../data-mappers/index.ts';
 import { drizzleColumnToGraphQLType } from '../type-converter/index.ts';
 import type { ConvertedColumn } from '../type-converter/types.ts';
-import { extractFilters, type RelationFilterBase, relationFilterCtx, toGraphQLError } from './common.ts';
+import {
+  extractFilters,
+  extractRelationJoinColumns,
+  type RelationAggregateFactory,
+  type RelationFilterBase,
+  relationFilterCtx,
+  resolveTypeName,
+  type TypeCacheCtx,
+  type TypeNameMapper,
+  toGraphQLError,
+} from './common.ts';
 import type { CreatedResolver, Filters } from './types.ts';
 
 /** Operations that aggregate over a set of column values. `count` is handled separately (whole rows). */
@@ -81,7 +104,17 @@ const classifyAggregateColumns = (table: Table, tableName: string): AggregateCol
  * - `min` / `max` — per orderable column, the column's own (nullable) scalar type
  * The avg/sum (min/max) wrappers are omitted when no column qualifies.
  */
-export const generateAggregateTypes = (table: Table, tableName: string, typeName: string): GraphQLObjectType => {
+export const generateAggregateTypes = (
+  table: Table,
+  tableName: string,
+  typeName: string,
+  cacheCtx?: TypeCacheCtx,
+): GraphQLObjectType => {
+  const cached = cacheCtx?.aggregateTypeCache.get(tableName);
+  if (cached) {
+    return cached;
+  }
+
   const { numeric, orderable } = classifyAggregateColumns(table, tableName);
 
   const fields: Record<string, { type: any }> = {
@@ -115,10 +148,14 @@ export const generateAggregateTypes = (table: Table, tableName: string, typeName
     }
   }
 
-  return new GraphQLObjectType({
+  const aggregateType = new GraphQLObjectType({
     name: `${typeName}Aggregate`,
     fields,
   });
+
+  cacheCtx?.aggregateTypeCache.set(tableName, aggregateType);
+
+  return aggregateType;
 };
 
 /** Parses a driver-level date/time string (`2024-04-02 06:44:41.785`, `2024-04-02`) as UTC. */
@@ -132,6 +169,123 @@ const parseDriverDateTime = (raw: string): Date => {
   }
   const parsed = new Date(v);
   return Number.isNaN(parsed.getTime()) ? new Date(raw) : parsed;
+};
+
+/** What the client asked for, plus the drizzle select map that computes it. */
+interface AggregateRequest {
+  count: boolean;
+  ops: Record<AggregateOp, string[]>;
+  selection: Record<string, any>;
+}
+
+/** Everything about a table that aggregating over it needs, resolved once at build time. */
+interface AggregateTarget {
+  tableName: string;
+  typeName: string;
+  columns: Record<string, Column>;
+  /** Columns whose GraphQL output is DateTime — their min/max may need string→Date coercion. */
+  dateTimeColumns: Set<string>;
+}
+
+const aggregateTarget = (table: Table, tableName: string, typeName: string): AggregateTarget => {
+  const { orderable } = classifyAggregateColumns(table, tableName);
+
+  return {
+    tableName,
+    typeName,
+    columns: getColumns(table),
+    dateTimeColumns: new Set(
+      Object.entries(orderable)
+        .filter(([, { converted }]) => converted.description === 'DateTime')
+        .map(([columnName]) => columnName),
+    ),
+  };
+};
+
+/**
+ * Reads the requested count/avg/sum/min/max selections off the resolve tree and turns them
+ * into one drizzle select expression per (op, column) pair. An empty `selection` means the
+ * client asked for nothing runnable (`__typename` only, or empty sub-selections).
+ */
+const parseAggregateRequest = (info: any, target: AggregateTarget): AggregateRequest => {
+  const parsedInfo = parseResolveInfo(info, { deep: true }) as ResolveTree;
+  const selectionTree = parsedInfo.fieldsByTypeName[`${target.typeName}Aggregate`] ?? {};
+
+  const request: AggregateRequest = {
+    count: false,
+    ops: { avg: [], sum: [], min: [], max: [] },
+    selection: {},
+  };
+
+  // Keys are aliases; `field.name` is the real field. Duplicate selections of the same
+  // field under different aliases collapse into one SQL expression — graphql-js resolves
+  // every alias from the same result property.
+  for (const field of Object.values(selectionTree) as ResolveTree[]) {
+    if (field.name === 'count') {
+      request.count = true;
+      request.selection.count = count();
+      continue;
+    }
+
+    if (!AGGREGATE_OPS.includes(field.name as AggregateOp)) {
+      continue;
+    }
+    const op = field.name as AggregateOp;
+    const subTree = field.fieldsByTypeName[`${target.typeName}${capitalize(op)}Aggregate`];
+    if (!subTree) {
+      continue;
+    }
+
+    for (const subField of Object.values(subTree) as ResolveTree[]) {
+      const columnName = subField.name;
+      const column = target.columns[columnName];
+      if (!column || request.ops[op].includes(columnName)) {
+        continue;
+      }
+      request.ops[op].push(columnName);
+      request.selection[`${op}${SEP}${columnName}`] = OP_FNS[op](column);
+    }
+  }
+
+  return request;
+};
+
+/** Reassembles a flat aggregate row (`avg__price`) into the nested GraphQL shape. */
+const assembleAggregateRow = (row: Record<string, any>, request: AggregateRequest, target: AggregateTarget) => {
+  const result: Record<string, any> = {};
+
+  if (request.count) {
+    // drizzle's count() maps to number already; guard for drivers returning strings.
+    result.count = row.count == null ? 0 : Number(row.count);
+  }
+
+  for (const op of AGGREGATE_OPS) {
+    if (!request.ops[op].length) {
+      continue;
+    }
+    const opResult: Record<string, any> = {};
+    for (const columnName of request.ops[op]) {
+      const value = row[`${op}${SEP}${columnName}`];
+      if (value == null) {
+        opResult[columnName] = null;
+      } else if (op === 'avg' || op === 'sum') {
+        // Drivers return numeric/decimal aggregates as strings — coerce to Float.
+        opResult[columnName] = Number(value);
+      } else {
+        // min/max keep the column's own type — drizzle already ran the column's decoder over
+        // the value (`min`/`max` are `mapWith(column)`), so all that's left is coercing a
+        // leftover raw date string (PG decodes timestamps in driver-level codecs, which raw
+        // select expressions bypass) and remapping for GraphQL output.
+        const column = target.columns[columnName];
+        const decoded =
+          typeof value === 'string' && target.dateTimeColumns.has(columnName) ? parseDriverDateTime(value) : value;
+        opResult[columnName] = remapToGraphQLCore(columnName, decoded, target.tableName, column);
+      }
+    }
+    result[op] = opResult;
+  }
+
+  return result;
 };
 
 /**
@@ -151,15 +305,7 @@ export const generateAggregate = (
   filterArgs: GraphQLInputObjectType,
   filterCtx?: RelationFilterBase,
 ): CreatedResolver => {
-  const aggregateTypeName = `${typeName}Aggregate`;
-  const columns = getColumns(table);
-  // Columns whose GraphQL output is DateTime — their min/max may need string→Date coercion.
-  const { orderable } = classifyAggregateColumns(table, tableName);
-  const dateTimeColumns = new Set(
-    Object.entries(orderable)
-      .filter(([, { converted }]) => converted.description === 'DateTime')
-      .map(([columnName]) => columnName),
-  );
+  const target = aggregateTarget(table, tableName, typeName);
 
   const queryArgs = {
     where: { type: filterArgs },
@@ -169,94 +315,114 @@ export const generateAggregate = (
     name: fieldName,
     resolver: async (_source, args: { where?: Filters<Table> }, _context, info) => {
       try {
-        const parsedInfo = parseResolveInfo(info, { deep: true }) as ResolveTree;
-        const selectionTree = parsedInfo.fieldsByTypeName[aggregateTypeName] ?? {};
-
-        const selection: Record<string, any> = {};
-        // Which ops (and which columns per op) the client asked for — drives result assembly.
-        const requested: { count: boolean; ops: Record<AggregateOp, string[]> } = {
-          count: false,
-          ops: { avg: [], sum: [], min: [], max: [] },
-        };
-
-        // Keys are aliases; `field.name` is the real field. Duplicate selections of the same
-        // field under different aliases collapse into one SQL expression — graphql-js resolves
-        // every alias from the same result property.
-        for (const field of Object.values(selectionTree) as ResolveTree[]) {
-          if (field.name === 'count') {
-            requested.count = true;
-            selection.count = count();
-            continue;
-          }
-
-          if (!AGGREGATE_OPS.includes(field.name as AggregateOp)) {
-            continue;
-          }
-          const op = field.name as AggregateOp;
-          const subTree = field.fieldsByTypeName[`${typeName}${capitalize(op)}Aggregate`];
-          if (!subTree) {
-            continue;
-          }
-
-          for (const subField of Object.values(subTree) as ResolveTree[]) {
-            const columnName = subField.name;
-            const column = columns[columnName];
-            if (!column || requested.ops[op].includes(columnName)) {
-              continue;
-            }
-            requested.ops[op].push(columnName);
-            selection[`${op}${SEP}${columnName}`] = OP_FNS[op](column);
-          }
-        }
-
-        // Only __typename (or empty sub-selections) requested — nothing to run.
-        if (!Object.keys(selection).length) {
+        const request = parseAggregateRequest(info, target);
+        if (!Object.keys(request.selection).length) {
           return {};
         }
 
-        let query = db.select(selection).from(table);
+        let query = db.select(request.selection).from(table);
         if (args.where) {
           query = query.where(extractFilters(table, tableName, args.where, relationFilterCtx(filterCtx, tableName)));
         }
         const rows = await query;
-        const row = rows[0] ?? {};
 
-        const result: Record<string, any> = {};
-        if (requested.count) {
-          // drizzle's count() maps to number already; guard for drivers returning strings.
-          result.count = row.count == null ? 0 : Number(row.count);
-        }
-        for (const op of AGGREGATE_OPS) {
-          if (!requested.ops[op].length) {
-            continue;
-          }
-          const opResult: Record<string, any> = {};
-          for (const columnName of requested.ops[op]) {
-            const value = row[`${op}${SEP}${columnName}`];
-            if (value == null) {
-              opResult[columnName] = null;
-            } else if (op === 'avg' || op === 'sum') {
-              // Drivers return numeric/decimal aggregates as strings — coerce to Float.
-              opResult[columnName] = Number(value);
-            } else {
-              // min/max keep the column's own type — drizzle already ran the column's decoder over
-              // the value (`min`/`max` are `mapWith(column)`), so all that's left is coercing a
-              // leftover raw date string (PG decodes timestamps in driver-level codecs, which raw
-              // select expressions bypass) and remapping for GraphQL output.
-              const column = columns[columnName];
-              const decoded =
-                typeof value === 'string' && dateTimeColumns.has(columnName) ? parseDriverDateTime(value) : value;
-              opResult[columnName] = remapToGraphQLCore(columnName, decoded, tableName, column);
-            }
-          }
-          result[op] = opResult;
-        }
-
-        return result;
+        return assembleAggregateRow(rows[0] ?? {}, request, target);
       } catch (e) {
         throw toGraphQLError(e);
       }
     },
     args: queryArgs,
+  };
+};
+
+/** Alias the grouping key is selected under. Prefixed so it can't collide with `${op}__${column}`. */
+const GROUP_KEY = '__dgql_group_key';
+
+/**
+ * Builds the `${relationName}Aggregate` field that hangs off a parent type for each to-many
+ * relation — `user { postsAggregate { count } }`.
+ *
+ * Resolution is batched the same way relation fields are: every parent row in the current tick
+ * that asked for the same relation with the same arguments is served by one
+ * `SELECT fk, <aggregates> ... WHERE fk IN (...) GROUP BY fk`, so a list of N parents costs one
+ * extra query rather than N. Parents with no matching related rows get `count: 0` and `null`
+ * for every other aggregate.
+ */
+export const createRelationAggregateFactory = (
+  db: any,
+  tables: Record<string, Table>,
+  cacheCtx: TypeCacheCtx,
+  typeNameMapper?: TypeNameMapper,
+  filterCtx?: RelationFilterBase,
+): RelationAggregateFactory => {
+  return ({ tableName, relationName, relEntry }) => {
+    const parentTable = tables[tableName];
+    const targetTableName = relEntry.targetTableName;
+    const targetTable = tables[targetTableName];
+
+    if (!parentTable || !targetTable) {
+      return undefined;
+    }
+
+    const joinCols = extractRelationJoinColumns(relEntry, parentTable, targetTable);
+    if (!joinCols) {
+      return undefined;
+    }
+    const { localColPropName, foreignCol } = joinCols;
+
+    const targetTypeName = resolveTypeName(targetTableName, typeNameMapper);
+    const type = generateAggregateTypes(targetTable, targetTableName, targetTypeName, cacheCtx);
+    const target = aggregateTarget(targetTable, targetTableName, targetTypeName);
+
+    const resolve = async (parent: any, args: { where?: Filters<Table> }, context: any, info: any) => {
+      try {
+        const request = parseAggregateRequest(info, target);
+        if (!Object.keys(request.selection).length) {
+          return {};
+        }
+
+        const localValue = parent[localColPropName];
+        // No key to correlate on — the relation is empty by definition.
+        if (localValue == null) {
+          return assembleAggregateRow({}, request, target);
+        }
+
+        const whereArg = args?.where;
+        // Siblings only share a batch when they'd run the same query: same filters, same aggregates.
+        const argsKey = JSON.stringify({
+          where: whereArg ?? null,
+          selection: Object.keys(request.selection).sort(),
+        });
+        const loaderKey = `${tableName}::${relationName}::aggregate::${argsKey}`;
+
+        const loader = getOrCreateLoader(context, loaderKey, async (parentIds: readonly any[]) => {
+          const uniqueIds = [...new Set(parentIds)];
+          const whereCondition = and(
+            inArray(foreignCol, uniqueIds),
+            whereArg
+              ? extractFilters(targetTable, targetTableName, whereArg, relationFilterCtx(filterCtx, targetTableName))
+              : undefined,
+          );
+
+          const rows: any[] = await db
+            .select({ [GROUP_KEY]: foreignCol, ...request.selection })
+            .from(targetTable)
+            .where(whereCondition)
+            .groupBy(foreignCol);
+
+          const byKey = new Map(rows.map((row) => [row[GROUP_KEY], row]));
+
+          // A parent with no matching rows produces no group — hand back an empty row so it
+          // assembles to count 0 / null aggregates rather than dropping the field.
+          return parentIds.map((id) => byKey.get(id) ?? {});
+        });
+
+        return assembleAggregateRow(await loader.load(localValue), request, target);
+      } catch (e) {
+        throw toGraphQLError(e);
+      }
+    };
+
+    return { type, resolve };
   };
 };

--- a/src/util/builders/aggregates.ts
+++ b/src/util/builders/aggregates.ts
@@ -1,0 +1,261 @@
+// @ts-nocheck — vendored file, drizzle-orm 1.0 type compat not guaranteed
+import { avg, type Column, count, extractExtendedColumnType, getColumns, max, min, sum, type Table } from 'drizzle-orm';
+import {
+  GraphQLFloat,
+  type GraphQLInputObjectType,
+  GraphQLInt,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+} from 'graphql';
+import type { ResolveTree } from 'graphql-parse-resolve-info';
+import { parseResolveInfo } from 'graphql-parse-resolve-info';
+import { capitalize } from '../case-ops/index.ts';
+import { remapToGraphQLCore } from '../data-mappers/index.ts';
+import { drizzleColumnToGraphQLType } from '../type-converter/index.ts';
+import type { ConvertedColumn } from '../type-converter/types.ts';
+import { extractFilters, toGraphQLError } from './common.ts';
+import type { CreatedResolver, Filters } from './types.ts';
+
+/** Operations that aggregate over a set of column values. `count` is handled separately (whole rows). */
+const AGGREGATE_OPS = ['avg', 'sum', 'min', 'max'] as const;
+type AggregateOp = (typeof AGGREGATE_OPS)[number];
+
+const OP_FNS: Record<AggregateOp, (col: Column) => any> = { avg, sum, min, max };
+
+/** Separator for flat select aliases (`avg__price`) — reassembled into nested output by the resolver. */
+const SEP = '__';
+
+interface AggregateColumnSets {
+  /** Columns avg/sum apply to: plain Int/Float scalars. */
+  numeric: Record<string, Column>;
+  /** Columns min/max apply to: anything with a total ordering the DB supports (numbers, strings, dates, enums). */
+  orderable: Record<string, { column: Column; converted: ConvertedColumn }>;
+}
+
+/**
+ * Classifies a table's columns for aggregation. avg/sum only make sense on numeric scalars;
+ * min/max work on any orderable scalar (numbers, strings, bigints, dates, enums). Booleans,
+ * arrays (including array-typed number columns), JSON, buffers, and object-shaped columns
+ * (e.g. geometry) are excluded entirely.
+ */
+const classifyAggregateColumns = (table: Table, tableName: string): AggregateColumnSets => {
+  const numeric: AggregateColumnSets['numeric'] = {};
+  const orderable: AggregateColumnSets['orderable'] = {};
+
+  for (const [columnName, column] of Object.entries(getColumns(table))) {
+    const converted = drizzleColumnToGraphQLType(column, columnName, tableName, true, false, false);
+    const gqlType = converted.type;
+
+    // Anything that isn't a plain scalar in the generated schema (arrays, geometry objects)
+    // has no meaningful min/max. This also catches array-typed number columns, which keep
+    // their scalar drizzle dataType but convert to a GraphQL list.
+    if (gqlType instanceof GraphQLList || gqlType instanceof GraphQLObjectType) {
+      continue;
+    }
+
+    // Classify on the drizzle data type rather than the GraphQL one: date columns convert to
+    // different GraphQL scalars per dialect, but are orderable everywhere.
+    const { type: dataType, constraint } = extractExtendedColumnType(column);
+    if (dataType === 'boolean' || dataType === 'array' || dataType === 'custom') {
+      continue;
+    }
+    if (dataType === 'object' && constraint !== 'date') {
+      continue;
+    }
+
+    orderable[columnName] = { column, converted };
+    if (dataType === 'number') {
+      numeric[columnName] = column;
+    }
+  }
+
+  return { numeric, orderable };
+};
+
+/**
+ * Builds the `${typeName}Aggregate` output type for a table:
+ * - `count: Int!` — number of matching rows
+ * - `avg` / `sum` — per numeric column, always nullable Float (SQL returns NULL on empty sets,
+ *   and avg/sum of integers overflow Int / produce decimals)
+ * - `min` / `max` — per orderable column, the column's own (nullable) scalar type
+ * The avg/sum (min/max) wrappers are omitted when no column qualifies.
+ */
+export const generateAggregateTypes = (table: Table, tableName: string, typeName: string): GraphQLObjectType => {
+  const { numeric, orderable } = classifyAggregateColumns(table, tableName);
+
+  const fields: Record<string, { type: any }> = {
+    count: { type: new GraphQLNonNull(GraphQLInt) },
+  };
+
+  if (Object.keys(numeric).length) {
+    for (const op of ['avg', 'sum'] as const) {
+      fields[op] = {
+        type: new GraphQLObjectType({
+          name: `${typeName}${capitalize(op)}Aggregate`,
+          fields: Object.fromEntries(Object.keys(numeric).map((columnName) => [columnName, { type: GraphQLFloat }])),
+        }),
+      };
+    }
+  }
+
+  if (Object.keys(orderable).length) {
+    for (const op of ['min', 'max'] as const) {
+      fields[op] = {
+        type: new GraphQLObjectType({
+          name: `${typeName}${capitalize(op)}Aggregate`,
+          fields: Object.fromEntries(
+            Object.entries(orderable).map(([columnName, { converted }]) => [
+              columnName,
+              { type: converted.type, description: converted.description },
+            ]),
+          ),
+        }),
+      };
+    }
+  }
+
+  return new GraphQLObjectType({
+    name: `${typeName}Aggregate`,
+    fields,
+  });
+};
+
+/** Parses a driver-level date/time string (`2024-04-02 06:44:41.785`, `2024-04-02`) as UTC. */
+const parseDriverDateTime = (raw: string): Date => {
+  let v = raw.includes(' ') ? raw.replace(' ', 'T') : raw;
+  if (!v.includes('T')) {
+    v = `${v}T00:00:00`;
+  }
+  if (!/(?:[Zz]|[+-]\d{2}(?::?\d{2})?)$/.test(v)) {
+    v = `${v}Z`;
+  }
+  const parsed = new Date(v);
+  return Number.isNaN(parsed.getTime()) ? new Date(raw) : parsed;
+};
+
+/**
+ * Creates the resolver for a table's aggregate query field. Reads the requested
+ * count/avg/sum/min/max selections from the resolve tree, runs them all as a single
+ * `SELECT` with one aggregate expression per requested (op, column) pair, and
+ * reassembles the flat row into the nested GraphQL shape.
+ *
+ * Shared by all three dialects — it only relies on `db.select().from().where()`.
+ */
+export const generateAggregate = (
+  db: any,
+  tableName: string,
+  table: Table,
+  typeName: string,
+  fieldName: string,
+  filterArgs: GraphQLInputObjectType,
+): CreatedResolver => {
+  const aggregateTypeName = `${typeName}Aggregate`;
+  const columns = getColumns(table);
+  // Columns whose GraphQL output is DateTime — their min/max may need string→Date coercion.
+  const { orderable } = classifyAggregateColumns(table, tableName);
+  const dateTimeColumns = new Set(
+    Object.entries(orderable)
+      .filter(([, { converted }]) => converted.description === 'DateTime')
+      .map(([columnName]) => columnName),
+  );
+
+  const queryArgs = {
+    where: { type: filterArgs },
+  };
+
+  return {
+    name: fieldName,
+    resolver: async (_source, args: { where?: Filters<Table> }, _context, info) => {
+      try {
+        const parsedInfo = parseResolveInfo(info, { deep: true }) as ResolveTree;
+        const selectionTree = parsedInfo.fieldsByTypeName[aggregateTypeName] ?? {};
+
+        const selection: Record<string, any> = {};
+        // Which ops (and which columns per op) the client asked for — drives result assembly.
+        const requested: { count: boolean; ops: Record<AggregateOp, string[]> } = {
+          count: false,
+          ops: { avg: [], sum: [], min: [], max: [] },
+        };
+
+        // Keys are aliases; `field.name` is the real field. Duplicate selections of the same
+        // field under different aliases collapse into one SQL expression — graphql-js resolves
+        // every alias from the same result property.
+        for (const field of Object.values(selectionTree) as ResolveTree[]) {
+          if (field.name === 'count') {
+            requested.count = true;
+            selection.count = count();
+            continue;
+          }
+
+          if (!AGGREGATE_OPS.includes(field.name as AggregateOp)) {
+            continue;
+          }
+          const op = field.name as AggregateOp;
+          const subTree = field.fieldsByTypeName[`${typeName}${capitalize(op)}Aggregate`];
+          if (!subTree) {
+            continue;
+          }
+
+          for (const subField of Object.values(subTree) as ResolveTree[]) {
+            const columnName = subField.name;
+            const column = columns[columnName];
+            if (!column || requested.ops[op].includes(columnName)) {
+              continue;
+            }
+            requested.ops[op].push(columnName);
+            selection[`${op}${SEP}${columnName}`] = OP_FNS[op](column);
+          }
+        }
+
+        // Only __typename (or empty sub-selections) requested — nothing to run.
+        if (!Object.keys(selection).length) {
+          return {};
+        }
+
+        let query = db.select(selection).from(table);
+        if (args.where) {
+          query = query.where(extractFilters(table, tableName, args.where));
+        }
+        const rows = await query;
+        const row = rows[0] ?? {};
+
+        const result: Record<string, any> = {};
+        if (requested.count) {
+          // drizzle's count() maps to number already; guard for drivers returning strings.
+          result.count = row.count == null ? 0 : Number(row.count);
+        }
+        for (const op of AGGREGATE_OPS) {
+          if (!requested.ops[op].length) {
+            continue;
+          }
+          const opResult: Record<string, any> = {};
+          for (const columnName of requested.ops[op]) {
+            const value = row[`${op}${SEP}${columnName}`];
+            if (value == null) {
+              opResult[columnName] = null;
+            } else if (op === 'avg' || op === 'sum') {
+              // Drivers return numeric/decimal aggregates as strings — coerce to Float.
+              opResult[columnName] = Number(value);
+            } else {
+              // min/max keep the column's own type — drizzle already ran the column's decoder over
+              // the value (`min`/`max` are `mapWith(column)`), so all that's left is coercing a
+              // leftover raw date string (PG decodes timestamps in driver-level codecs, which raw
+              // select expressions bypass) and remapping for GraphQL output.
+              const column = columns[columnName];
+              const decoded =
+                typeof value === 'string' && dateTimeColumns.has(columnName) ? parseDriverDateTime(value) : value;
+              opResult[columnName] = remapToGraphQLCore(columnName, decoded, tableName, column);
+            }
+          }
+          result[op] = opResult;
+        }
+
+        return result;
+      } catch (e) {
+        throw toGraphQLError(e);
+      }
+    },
+    args: queryArgs,
+  };
+};

--- a/src/util/builders/aggregates.ts
+++ b/src/util/builders/aggregates.ts
@@ -14,7 +14,7 @@ import { capitalize } from '../case-ops/index.ts';
 import { remapToGraphQLCore } from '../data-mappers/index.ts';
 import { drizzleColumnToGraphQLType } from '../type-converter/index.ts';
 import type { ConvertedColumn } from '../type-converter/types.ts';
-import { extractFilters, toGraphQLError } from './common.ts';
+import { extractFilters, type RelationFilterBase, relationFilterCtx, toGraphQLError } from './common.ts';
 import type { CreatedResolver, Filters } from './types.ts';
 
 /** Operations that aggregate over a set of column values. `count` is handled separately (whole rows). */
@@ -149,6 +149,7 @@ export const generateAggregate = (
   typeName: string,
   fieldName: string,
   filterArgs: GraphQLInputObjectType,
+  filterCtx?: RelationFilterBase,
 ): CreatedResolver => {
   const aggregateTypeName = `${typeName}Aggregate`;
   const columns = getColumns(table);
@@ -215,7 +216,7 @@ export const generateAggregate = (
 
         let query = db.select(selection).from(table);
         if (args.where) {
-          query = query.where(extractFilters(table, tableName, args.where));
+          query = query.where(extractFilters(table, tableName, args.where, relationFilterCtx(filterCtx, tableName)));
         }
         const rows = await query;
         const row = rows[0] ?? {};

--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -1293,25 +1293,24 @@ export const generateTableTypes = <WithReturning extends boolean>(
   };
 };
 
+/**
+ * Column name / direction pairs from an `orderBy` argument, highest priority first. Split out
+ * of `extractOrderBy` so the same ordering can be rebuilt against a subquery's fields, where
+ * there is no `Table` to read columns from.
+ */
+export const orderByEntries = (orderArgs: Record<string, any>): [string, 'asc' | 'desc'][] =>
+  Object.entries(orderArgs)
+    .sort((a, b) => (b[1]?.priority ?? 0) - (a[1]?.priority ?? 0))
+    .filter(([, config]) => config)
+    .map(([column, config]) => [column, config.direction]);
+
 export const extractOrderBy = <TTable extends Table, TArgs extends OrderByArgs<any> = OrderByArgs<TTable>>(
   table: TTable,
   orderArgs: TArgs,
-): SQL[] => {
-  const res = [] as SQL[];
-
-  for (const [column, config] of Object.entries(orderArgs).sort(
-    (a, b) => (b[1]?.priority ?? 0) - (a[1]?.priority ?? 0),
-  )) {
-    if (!config) {
-      continue;
-    }
-    const { direction } = config;
-
-    res.push(direction === 'asc' ? asc(getColumns(table)[column]!) : desc(getColumns(table)[column]!));
-  }
-
-  return res;
-};
+): SQL[] =>
+  orderByEntries(orderArgs).map(([column, direction]) =>
+    direction === 'asc' ? asc(getColumns(table)[column]!) : desc(getColumns(table)[column]!),
+  );
 
 export const extractFiltersColumn = <TColumn extends Column>(
   column: TColumn,
@@ -1809,6 +1808,128 @@ export const primaryKeyOrderExprs = (table: Table, pkNames: readonly string[]): 
     .map((col) => asc(col!));
 };
 
+/** Alias of the row-number helper column in the `distinct` pass. Namespaced against real columns. */
+const DISTINCT_RN = '__drizzle_graphql_distinct_rn';
+
+const distinctEnumCache = new WeakMap<object, GraphQLEnumType>();
+
+/**
+ * `${typeName}DistinctColumn` — the enum of columns a list query may be made distinct on.
+ * Cached per table object, like the order/filter inputs, so repeated builds reuse one instance.
+ */
+export const generateDistinctEnum = (table: Table, typeName: string): GraphQLEnumType | undefined => {
+  const cached = distinctEnumCache.get(table);
+  if (cached) {
+    return cached;
+  }
+
+  const columnNames = Object.keys(getColumns(table));
+  if (!columnNames.length) {
+    return undefined;
+  }
+
+  const enumType = new GraphQLEnumType({
+    name: `${typeName}DistinctColumn`,
+    description: `Columns of ${typeName} that a query can be made distinct on`,
+    values: Object.fromEntries(columnNames.map((columnName) => [columnName, { value: columnName }])),
+  });
+
+  distinctEnumCache.set(table, enumType);
+  return enumType;
+};
+
+/**
+ * Keeps the first row of each distinct combination of the requested columns, following the
+ * query's own ordering, then applies `limit`/`offset` to what survives — and returns the
+ * surviving rows' primary key values in that order.
+ *
+ * The relational query builder has no `distinct` support, so this runs as its own
+ * `row_number() over (partition by … order by …)` pass and the main query is narrowed to the
+ * keys it returns. `orderExprs` is the full ordering (the request's `orderBy` plus the primary
+ * key tiebreak); the caller applies the same ordering to the main query, so the two agree.
+ */
+export const selectDistinctKeys = async (params: {
+  db: any;
+  table: Table;
+  tableName: string;
+  distinct: string[];
+  pkNames: readonly string[];
+  where: SQL | undefined;
+  orderBy: Record<string, any> | undefined;
+  limit?: number;
+  offset?: number;
+}): Promise<Record<string, any>[]> => {
+  const { db, table, tableName, distinct, pkNames, where, orderBy, limit, offset } = params;
+  const cols = getColumns(table);
+
+  if (!pkNames.length) {
+    throw new GraphQLError(`Table ${tableName} has no primary key, so 'distinct' cannot be applied to it.`);
+  }
+
+  const partitionCols = distinct.map((name) => cols[name]).filter(Boolean);
+  if (!partitionCols.length) {
+    throw new GraphQLError(`No known columns were given to 'distinct' on ${tableName}.`);
+  }
+
+  const orderEntries = orderBy ? orderByEntries(orderBy) : [];
+  // Both orderings must agree, so build each from the same entries — once against the table
+  // (inside the window) and once against the subquery's fields (for the outer row order).
+  const windowOrder = [
+    ...orderEntries.map(([column, direction]) => (direction === 'asc' ? asc(cols[column]!) : desc(cols[column]!))),
+    ...primaryKeyOrderExprs(table, pkNames),
+  ];
+
+  const rowNumber = sql`row_number() over (partition by ${sql.join(partitionCols, sql`, `)} order by ${sql.join(
+    windowOrder,
+    sql`, `,
+  )})`.as(DISTINCT_RN);
+
+  const sub = db
+    .select({ ...cols, [DISTINCT_RN]: rowNumber })
+    .from(table)
+    .where(where)
+    .as('__dgql_distinct');
+
+  const outerOrder = [
+    ...orderEntries.map(([column, direction]) => (direction === 'asc' ? asc(sub[column]) : desc(sub[column]))),
+    ...pkNames.filter((name) => sub[name]).map((name) => asc(sub[name])),
+  ];
+
+  let query = db
+    .select(Object.fromEntries(pkNames.map((name) => [name, sub[name]])))
+    .from(sub)
+    .where(eq(sub[DISTINCT_RN], 1))
+    .orderBy(...outerOrder);
+
+  if (offset) {
+    query = query.offset(offset);
+  }
+  if (limit != null) {
+    query = query.limit(limit);
+  }
+
+  return await query;
+};
+
+/**
+ * Condition matching exactly the rows identified by `keys` — an `IN (…)` for a single-column
+ * primary key, an `OR` of per-row equality for a composite one. `table` may be the aliased
+ * RQB proxy.
+ */
+export const primaryKeyRestriction = (table: Table, pkNames: readonly string[], keys: Record<string, any>[]): SQL => {
+  const cols = getColumns(table);
+
+  if (pkNames.length === 1) {
+    const name = pkNames[0]!;
+    return inArray(
+      cols[name]!,
+      keys.map((key) => key[name]),
+    );
+  }
+
+  return or(...keys.map((key) => and(...pkNames.map((name) => eq(cols[name]!, key[name])))))!;
+};
+
 /**
  * Computes the RETURNING columns and relation selection for a mutation resolver: extracts
  * the selected scalar columns, determines whether any relations were selected, and only
@@ -1892,11 +2013,13 @@ export const computeResolverFieldNames = (
 export const selectArrayArgs = (
   orderArgs: GraphQLInputObjectType,
   filterArgs: GraphQLInputObjectType,
+  distinctEnum?: GraphQLEnumType,
 ): Record<string, { type: any }> => ({
   offset: { type: GraphQLInt },
   limit: { type: GraphQLInt },
   orderBy: { type: orderArgs },
   where: { type: filterArgs },
+  ...(distinctEnum ? { distinct: { type: new GraphQLList(new GraphQLNonNull(distinctEnum)) } } : {}),
 });
 
 /** GraphQL argument map for a single-row select field (no `limit`). */
@@ -1932,6 +2055,8 @@ export const runRelationalSelect = async (opts: {
   single: boolean;
   filterCtx?: RelationFilterBase;
   pkNames?: readonly string[];
+  db?: any;
+  distinct?: string[];
 }): Promise<any> => {
   const {
     queryBase,
@@ -1949,31 +2074,62 @@ export const runRelationalSelect = async (opts: {
     filterCtx,
     pkNames,
   } = opts;
+  const distinct = opts.distinct?.length ? opts.distinct : undefined;
   // Taking a slice of an unordered result lets the database return any rows it likes, so
   // `limit`/`offset` pages can overlap or skip rows between requests, and a single query
   // can return a different row each time. Default to the primary key whenever the query is
   // narrowed to a subset, mirroring the relation-level default in extractRelationsParamsInner.
   const needsDefaultOrder = single || offset != null || opts.limit != null;
+
+  // `distinct` runs as its own pass — the relational query builder cannot express it — and
+  // the main query is then narrowed to the primary keys it picked, with the same ordering
+  // and without re-applying limit/offset.
+  let distinctKeys: Record<string, any>[] | undefined;
+  if (distinct) {
+    distinctKeys = await selectDistinctKeys({
+      db: opts.db,
+      table,
+      tableName,
+      distinct,
+      pkNames: pkNames ?? [],
+      where: where ? extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName)) : undefined,
+      orderBy,
+      limit: single ? 1 : opts.limit,
+      offset,
+    });
+
+    if (!distinctKeys.length) {
+      return single ? undefined : [];
+    }
+  }
+
   const params: any = {
     columns: extractSelectedColumnsFromTree(parsedInfo.fieldsByTypeName[typeName]!, table, {
       tableName,
       relationMap,
       tables,
     }),
-    offset,
+    offset: distinctKeys ? undefined : offset,
     // drizzle-orm v1 RQB calls orderBy/where with the aliased table proxy — use it
     // directly so column refs match the CTE alias.
-    orderBy: orderBy
-      ? (aliasedTable: Table) => extractOrderBy(aliasedTable, orderBy)
-      : needsDefaultOrder && pkNames?.length
-        ? (aliasedTable: Table) => primaryKeyOrderExprs(aliasedTable, pkNames)
+    orderBy: distinctKeys
+      ? (aliasedTable: Table) => [
+          ...(orderBy ? extractOrderBy(aliasedTable, orderBy) : []),
+          ...primaryKeyOrderExprs(aliasedTable, pkNames!),
+        ]
+      : orderBy
+        ? (aliasedTable: Table) => extractOrderBy(aliasedTable, orderBy)
+        : needsDefaultOrder && pkNames?.length
+          ? (aliasedTable: Table) => primaryKeyOrderExprs(aliasedTable, pkNames)
+          : undefined,
+    where: distinctKeys
+      ? { RAW: (aliasedTable: Table) => primaryKeyRestriction(aliasedTable, pkNames!, distinctKeys!) }
+      : where
+        ? {
+            RAW: (aliasedTable: Table) =>
+              extractFilters(aliasedTable, tableName, where, relationFilterCtx(filterCtx, tableName)),
+          }
         : undefined,
-    where: where
-      ? {
-          RAW: (aliasedTable: Table) =>
-            extractFilters(aliasedTable, tableName, where, relationFilterCtx(filterCtx, tableName)),
-        }
-      : undefined,
     with: relationMap[tableName]
       ? extractRelationsParams(relationMap, tables, tableName, parsedInfo, typeName, typeNameMapper, filterCtx)
       : undefined,
@@ -1984,7 +2140,7 @@ export const runRelationalSelect = async (opts: {
     return result ? remapToGraphQLSingleOutput(result, tableName, table, relationMap) : undefined;
   }
 
-  params.limit = opts.limit;
+  params.limit = distinctKeys ? undefined : opts.limit;
   const result = await queryBase.findMany(params);
   return remapToGraphQLArrayOutput(result, tableName, table, relationMap);
 };

--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -87,7 +87,7 @@ const rqbCrashTypes = ['SQLiteBigInt', 'SQLiteBlobJson', 'SQLiteBlobBuffer'];
 export type TypeNameMapper = (tableName: string) => { singular: string; plural: string } | undefined;
 
 /** Produce the GraphQL object type name for a table, using the mapper if provided. */
-const resolveTypeName = (name: string, typeNameMapper?: TypeNameMapper): string => {
+export const resolveTypeName = (name: string, typeNameMapper?: TypeNameMapper): string => {
   const mapped = typeNameMapper?.(name);
   return mapped ? capitalize(mapped.singular) : capitalize(name);
 };
@@ -229,6 +229,17 @@ export type RelationResolverFactory = (params: {
   relEntry: TableNamedRelations;
   isOne: boolean;
 }) => GraphQLFieldResolver<any, any> | undefined;
+
+/**
+ * Builds the `${relationName}Aggregate` field for a to-many relation. Implemented in
+ * `aggregates.ts` and injected here so the aggregate code can depend on this module
+ * without the two importing each other.
+ */
+export type RelationAggregateFactory = (params: {
+  tableName: string;
+  relationName: string;
+  relEntry: TableNamedRelations;
+}) => { type: GraphQLObjectType; resolve: GraphQLFieldResolver<any, any> } | undefined;
 
 /**
  * Fetches a to-many relation with per-parent limit/offset for ALL parents in a
@@ -434,11 +445,70 @@ export interface TypeCacheCtx {
    * used by to-many relation filters), keyed by target table name.
    */
   listRelationFilterCache: Map<string, GraphQLInputObjectType>;
+  /**
+   * Per-call cache for `${Table}Aggregate` output types, keyed by table name. Shared between the
+   * root `<table>Aggregate` query and the `<relation>Aggregate` field on every table that points
+   * at it, so the schema never holds two types with the same name.
+   */
+  aggregateTypeCache: Map<string, GraphQLObjectType>;
 }
+
+/**
+ * Everything needed to work out which extra columns a selection implies. Passed to the column
+ * extractors so a requested `<relation>Aggregate` field can pull in the join column it resolves
+ * from, which the client has no reason to have selected itself.
+ */
+export interface SelectionCtx {
+  tableName: string;
+  relationMap: Record<string, Record<string, TableNamedRelations>>;
+  tables: Record<string, Table>;
+}
+
+const AGGREGATE_FIELD_SUFFIX = 'Aggregate';
+
+/**
+ * Property names of the join columns that the `<relation>Aggregate` fields in this selection
+ * correlate on. Without them the parent row reaches the aggregate resolver with no key and
+ * every count would come back 0.
+ */
+const relationAggregateJoinColumns = (
+  tree: Record<string, ResolveTree>,
+  table: Table,
+  selectionCtx: SelectionCtx | undefined,
+): string[] => {
+  const relations = selectionCtx?.relationMap[selectionCtx.tableName];
+  if (!relations || !selectionCtx) {
+    return [];
+  }
+
+  const tableColumns = getColumns(table);
+  const needed: string[] = [];
+
+  for (const fieldData of Object.values(tree)) {
+    // A column that happens to end in "Aggregate" is a column, not a relation aggregate.
+    if (tableColumns[fieldData.name] || !fieldData.name.endsWith(AGGREGATE_FIELD_SUFFIX)) {
+      continue;
+    }
+
+    const relEntry = relations[fieldData.name.slice(0, -AGGREGATE_FIELD_SUFFIX.length)];
+    const targetTable = relEntry ? selectionCtx.tables[relEntry.targetTableName] : undefined;
+    if (!relEntry || !targetTable) {
+      continue;
+    }
+
+    const joinCols = extractRelationJoinColumns(relEntry, table, targetTable);
+    if (joinCols) {
+      needed.push(joinCols.localColPropName);
+    }
+  }
+
+  return needed;
+};
 
 export const extractSelectedColumnsFromTree = (
   tree: Record<string, ResolveTree>,
   table: Table,
+  selectionCtx?: SelectionCtx,
 ): Record<string, true> => {
   const tableColumns = getColumns(table);
 
@@ -451,6 +521,10 @@ export const extractSelectedColumnsFromTree = (
     }
 
     selectedColumns.push([fieldData.name, true]);
+  }
+
+  for (const columnName of relationAggregateJoinColumns(tree, table, selectionCtx)) {
+    selectedColumns.push([columnName, true]);
   }
 
   if (!selectedColumns.length) {
@@ -471,6 +545,7 @@ export const extractSelectedColumnsFromTree = (
 export const extractSelectedColumnsFromTreeSQLFormat = <TColType extends Column = Column>(
   tree: Record<string, ResolveTree>,
   table: Table,
+  selectionCtx?: SelectionCtx,
 ): Record<string, TColType> => {
   const tableColumns = getColumns(table);
 
@@ -483,6 +558,10 @@ export const extractSelectedColumnsFromTreeSQLFormat = <TColType extends Column 
     }
 
     selectedColumns.push([fieldData.name, tableColumns[fieldData.name]!]);
+  }
+
+  for (const columnName of relationAggregateJoinColumns(tree, table, selectionCtx)) {
+    selectedColumns.push([columnName, tableColumns[columnName]!]);
   }
 
   if (!selectedColumns.length) {
@@ -887,6 +966,7 @@ const generateSelectFields = <TWithOrder extends boolean>(
   usedTables: Set<string> = new Set(),
   resolverFactory?: RelationResolverFactory,
   currentDepth: number = 0,
+  relationAggregateFactory?: RelationAggregateFactory,
 ): SelectData<TWithOrder> => {
   const table = tables[tableName]!;
   const order = withOrder ? generateTableOrderTypeCached(table, tableName, typeNameMapper, cacheCtx) : undefined;
@@ -985,6 +1065,7 @@ const generateSelectFields = <TWithOrder extends boolean>(
         nextUsedTables,
         resolverFactory,
         currentDepth + 1,
+        relationAggregateFactory,
       );
 
       // Use the target table's own GraphQL type directly instead of creating an intermediate relation type.
@@ -1043,6 +1124,30 @@ const generateSelectFields = <TWithOrder extends boolean>(
           resolve,
         },
       ]);
+
+      // Aggregate over the related rows without fetching them: `user { postsAggregate { count } }`.
+      // Skipped when the name would shadow a column or another relation.
+      const aggregateFieldName = `${relationName}Aggregate`;
+      if (!tableFields[aggregateFieldName] && !relationsForTable?.[aggregateFieldName]) {
+        const relationAggregate = relationAggregateFactory?.({
+          tableName,
+          relationName,
+          relEntry: relEntry as TableNamedRelations,
+        });
+
+        if (relationAggregate) {
+          rawRelationFields.push([
+            aggregateFieldName,
+            {
+              type: new GraphQLNonNull(relationAggregate.type),
+              args: {
+                where: { type: relSelectData.filters },
+              },
+              resolve: relationAggregate.resolve,
+            } as unknown as ConvertedRelationColumnWithArgs,
+          ]);
+        }
+      }
     }
 
     const builtRelationFields = Object.fromEntries(rawRelationFields);
@@ -1088,6 +1193,7 @@ export const generateTableTypes = <WithReturning extends boolean>(
   insertPrefix: string = 'create',
   updatePrefix: string = 'update',
   resolverFactory?: RelationResolverFactory,
+  relationAggregateFactory?: RelationAggregateFactory,
 ): GeneratedTableTypes<WithReturning> => {
   const { tableFields, relationFields, filters, order } = generateSelectFields(
     tables,
@@ -1102,6 +1208,7 @@ export const generateTableTypes = <WithReturning extends boolean>(
     new Set(),
     resolverFactory,
     0,
+    relationAggregateFactory,
   );
 
   const table = tables[tableName]!;
@@ -1521,7 +1628,11 @@ const extractRelationsParamsInner = (
       continue;
     }
 
-    const columns = extractSelectedColumnsFromTree(relFieldSelection, tables[targetTableName]!);
+    const columns = extractSelectedColumnsFromTree(relFieldSelection, tables[targetTableName]!, {
+      tableName: targetTableName,
+      relationMap,
+      tables,
+    });
 
     const thisRecord: Partial<ProcessedTableSelectArgs> = {};
     thisRecord.columns = columns;
@@ -1723,7 +1834,11 @@ export const prepareMutationRelationColumns = (params: {
     ? extractRelationsParams(relationMap, tables, tableName, parsedInfo, typeName, typeNameMapper)
     : undefined;
   const hasRelations = !!(withParams && Object.keys(withParams).length);
-  const baseColumns = extractSelectedColumnsFromTreeSQLFormat(parsedInfo.fieldsByTypeName[typeName]!, table);
+  const baseColumns = extractSelectedColumnsFromTreeSQLFormat(parsedInfo.fieldsByTypeName[typeName]!, table, {
+    tableName,
+    relationMap,
+    tables,
+  });
   const columns = hasRelations ? withPrimaryKeyColumns(baseColumns, table, pkNames) : baseColumns;
   return { columns, hasRelations, withParams };
 };
@@ -1833,7 +1948,11 @@ export const runRelationalSelect = async (opts: {
     filterCtx,
   } = opts;
   const params: any = {
-    columns: extractSelectedColumnsFromTree(parsedInfo.fieldsByTypeName[typeName]!, table),
+    columns: extractSelectedColumnsFromTree(parsedInfo.fieldsByTypeName[typeName]!, table, {
+      tableName,
+      relationMap,
+      tables,
+    }),
     offset,
     // drizzle-orm v1 RQB calls orderBy/where with the aliased table proxy — use it
     // directly so column refs match the CTE alias.

--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -1984,6 +1984,192 @@ export const generateColumnEnum = (
 export const generateDistinctEnum = (table: Table, typeName: string): GraphQLEnumType | undefined =>
   generateColumnEnum(table, `${typeName}DistinctColumn`, `Columns of ${typeName} that a query can be made distinct on`);
 
+// ── upsert / conflict handling ────────────────────────────────────────────────
+
+/** Shared by every table's `${typeName}OnConflict` input, so it is created once. */
+export const conflictActionEnum = new GraphQLEnumType({
+  name: 'ConflictAction',
+  description: 'What an upsert does when a row with the same unique key already exists',
+  values: {
+    UPDATE: { value: 'UPDATE', description: 'Overwrite the conflicting row with the supplied values' },
+    NOTHING: { value: 'NOTHING', description: 'Keep the existing row and insert nothing' },
+  },
+});
+
+/**
+ * The `${typeName}OnConflict` input that types an upsert's `onConflict` argument.
+ *
+ * `target` and `where` only exist when the dialect can express them: MySQL's
+ * `ON DUPLICATE KEY UPDATE` fires on any unique key and takes no predicate, so offering
+ * either there would mean silently ignoring it.
+ *
+ * Returns `undefined` when the table has nothing to conflict on (`withTarget` dialects
+ * only) — the caller then generates no upsert mutations for that table at all, rather than
+ * an operation whose every call is a database error.
+ */
+export const generateOnConflictInput = (params: {
+  table: Table;
+  typeName: string;
+  uniqueSets: string[][];
+  tableFilters: GraphQLInputObjectType;
+  withTarget: boolean;
+}): GraphQLInputObjectType | undefined => {
+  const { table, typeName, uniqueSets, tableFilters, withTarget } = params;
+
+  const updateEnum = generateColumnEnum(
+    table,
+    `${typeName}UpdateColumn`,
+    `Columns of ${typeName} that an upsert can overwrite`,
+  );
+  if (!updateEnum) {
+    return undefined;
+  }
+
+  const fields: Record<string, any> = {
+    action: {
+      type: conflictActionEnum,
+      defaultValue: 'UPDATE',
+      description: 'Whether a conflicting row is overwritten or left alone. Defaults to UPDATE.',
+    },
+    update: {
+      type: new GraphQLList(new GraphQLNonNull(updateEnum)),
+      description:
+        'Columns to overwrite on conflict. Defaults to every column the request supplied, minus the conflict target. Columns the request did not supply cannot be listed here — there would be no value to write.',
+    },
+  };
+
+  if (withTarget) {
+    const uniqueColumns = new Set(uniqueSets.flat());
+    const targetEnum = generateColumnEnum(
+      table,
+      `${typeName}ConflictTarget`,
+      `Columns of ${typeName} that carry a unique constraint, and so can be conflicted on`,
+      (_column, columnName) => uniqueColumns.has(columnName),
+    );
+    if (!targetEnum) {
+      return undefined;
+    }
+
+    fields['target'] = {
+      type: new GraphQLList(new GraphQLNonNull(targetEnum)),
+      description:
+        'The unique column set a conflict is detected on. Must match one of the table’s unique constraints exactly. Defaults to the primary key.',
+    };
+    fields['where'] = {
+      type: tableFilters,
+      description: 'Only overwrite conflicting rows that match this filter. Others are left alone.',
+    };
+  }
+
+  return new GraphQLInputObjectType({
+    name: `${typeName}OnConflict`,
+    description: `Conflict handling for an upsert of ${typeName}`,
+    fields,
+  });
+};
+
+/** The `onConflict` argument as it arrives from GraphQL. */
+export type OnConflictArg = {
+  action?: 'UPDATE' | 'NOTHING';
+  target?: string[];
+  update?: string[];
+  where?: any;
+};
+
+/** What a dialect needs to turn an insert into an upsert. */
+export type ConflictPlan = {
+  action: 'UPDATE' | 'NOTHING';
+  /** Columns to conflict on, or `undefined` on dialects that take no conflict target. */
+  target: Column[] | undefined;
+  /** `column -> value to write`, in Drizzle's `set` shape. Empty when the action is NOTHING. */
+  set: Record<string, SQL>;
+  setWhere: SQL | undefined;
+};
+
+/**
+ * Turns the request's `onConflict` argument and the rows it is inserting into the clause a
+ * dialect should attach.
+ *
+ * `excludedRef` names the row that failed to insert in the dialect's own terms
+ * (`excluded.col` on PostgreSQL and SQLite, `values(col)` on MySQL), which is what makes a
+ * batch upsert update each row with its own values instead of the last row's.
+ *
+ * An UPDATE with nothing left to write degrades to NOTHING: `DO UPDATE SET` with an empty
+ * body is not valid SQL, and doing nothing is what the request asked for anyway.
+ */
+export const resolveConflictPlan = (params: {
+  table: Table;
+  values: Record<string, any>[];
+  onConflict: OnConflictArg | undefined;
+  pkNames: readonly string[];
+  uniqueSets: string[][];
+  excludedRef: (columnName: string) => SQL;
+  withTarget: boolean;
+  buildWhere?: (where: any) => SQL | undefined;
+}): ConflictPlan => {
+  const { table, values, onConflict, pkNames, uniqueSets, excludedRef, withTarget, buildWhere } = params;
+  const columns = getColumns(table) as Record<string, Column>;
+
+  let target: Column[] | undefined;
+  if (withTarget) {
+    const targetNames = onConflict?.target?.length ? onConflict.target : [...pkNames];
+    if (!targetNames.length) {
+      throw new GraphQLError(
+        'Unable to upsert: no conflict target was given and this table has no primary key. Pass onConflict.target.',
+      );
+    }
+    // A target that is not itself a unique constraint is a database error, and a confusing
+    // one ("there is no unique or exclusion constraint matching the ON CONFLICT
+    // specification"), so reject it here where we can say which sets are valid.
+    const requested = [...targetNames].sort().join(',');
+    if (!uniqueSets.some((set) => [...set].sort().join(',') === requested)) {
+      throw new GraphQLError(
+        `Unable to upsert: [${targetNames.join(', ')}] is not a unique constraint on this table. Valid conflict targets: ${uniqueSets
+          .map((set) => `[${set.join(', ')}]`)
+          .join(', ')}.`,
+      );
+    }
+    target = targetNames.map((name) => columns[name]!);
+  }
+
+  if ((onConflict?.action ?? 'UPDATE') === 'NOTHING') {
+    return { action: 'NOTHING', target, set: {}, setWhere: undefined };
+  }
+
+  // Only columns the request actually supplied have a value to copy over; anything else
+  // would write the column's default (usually null) onto the row that already exists.
+  const supplied = new Set(values.flatMap((row) => Object.keys(row)));
+  const targetNames = new Set(withTarget ? (onConflict?.target?.length ? onConflict.target : pkNames) : []);
+
+  let updateNames: string[];
+  if (onConflict?.update?.length) {
+    const unsupplied = onConflict.update.filter((name) => !supplied.has(name));
+    if (unsupplied.length) {
+      throw new GraphQLError(
+        `Unable to upsert: onConflict.update lists ${unsupplied.join(', ')}, which the values do not supply.`,
+      );
+    }
+    updateNames = onConflict.update;
+  } else {
+    updateNames = [...supplied].filter((name) => !targetNames.has(name));
+  }
+
+  if (!updateNames.length) {
+    return { action: 'NOTHING', target, set: {}, setWhere: undefined };
+  }
+
+  const set = Object.fromEntries(updateNames.map((name) => [name, excludedRef(columns[name]!.name)]));
+  const setWhere = onConflict?.where && buildWhere ? buildWhere(onConflict.where) : undefined;
+
+  return { action: 'UPDATE', target, set, setWhere };
+};
+
+/** `excluded.<column>` — PostgreSQL and SQLite name the rejected row this way. */
+export const excludedColumnRef = (columnName: string): SQL => sql`excluded.${sql.identifier(columnName)}`;
+
+/** `values(<column>)` — MySQL's equivalent inside ON DUPLICATE KEY UPDATE. */
+export const mysqlValuesColumnRef = (columnName: string): SQL => sql`values(${sql.identifier(columnName)})`;
+
 /**
  * Keeps the first row of each distinct combination of the requested columns, following the
  * query's own ordering, then applies `limit`/`offset` to what survives — and returns the
@@ -2204,7 +2390,7 @@ export const applyErrorMapper = (
 export const computeResolverFieldNames = (
   tableName: string,
   typeNameMapper: TypeNameMapper | undefined,
-  prefixes: { insert: string; update: string; delete: string },
+  prefixes: { insert: string; update: string; delete: string; upsert?: string },
   suffixes: { list: string; single: string },
 ): {
   typeName: string;
@@ -2213,6 +2399,8 @@ export const computeResolverFieldNames = (
   aggregateFieldName: string;
   createArrayFieldName: string;
   createSingleFieldName: string;
+  upsertArrayFieldName: string;
+  upsertSingleFieldName: string;
   updateFieldName: string;
   deleteFieldName: string;
 } => {
@@ -2225,6 +2413,11 @@ export const computeResolverFieldNames = (
   const createSingleFieldName = mapped
     ? `${prefixes.insert}${capitalize(mapped.singular)}`
     : `${prefixes.insert}${capitalize(tableName)}${suffixes.single}`;
+  const upsertPrefix = prefixes.upsert ?? 'upsert';
+  const upsertArrayFieldName = `${upsertPrefix}${mapped ? capitalize(mapped.plural) : capitalize(tableName)}`;
+  const upsertSingleFieldName = mapped
+    ? `${upsertPrefix}${capitalize(mapped.singular)}`
+    : `${upsertPrefix}${capitalize(tableName)}${suffixes.single}`;
   const updateFieldName = `${prefixes.update}${mapped ? capitalize(mapped.singular) : capitalize(tableName)}`;
   const deleteFieldName = `${prefixes.delete}${mapped ? capitalize(mapped.singular) : capitalize(tableName)}`;
   return {
@@ -2234,6 +2427,8 @@ export const computeResolverFieldNames = (
     aggregateFieldName,
     createArrayFieldName,
     createSingleFieldName,
+    upsertArrayFieldName,
+    upsertSingleFieldName,
     updateFieldName,
     deleteFieldName,
   };

--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -1431,6 +1431,7 @@ export const computeResolverFieldNames = (
   typeName: string;
   listFieldName: string;
   singleFieldName: string;
+  aggregateFieldName: string;
   createArrayFieldName: string;
   createSingleFieldName: string;
   updateFieldName: string;
@@ -1440,6 +1441,7 @@ export const computeResolverFieldNames = (
   const typeName = mapped ? capitalize(mapped.singular) : capitalize(tableName);
   const listFieldName = (mapped?.plural ?? uncapitalize(tableName)) + suffixes.list;
   const singleFieldName = mapped?.singular ?? uncapitalize(tableName) + suffixes.single;
+  const aggregateFieldName = `${mapped?.plural ?? uncapitalize(tableName)}Aggregate`;
   const createArrayFieldName = `${prefixes.insert}${mapped ? capitalize(mapped.plural) : capitalize(tableName)}`;
   const createSingleFieldName = mapped
     ? `${prefixes.insert}${capitalize(mapped.singular)}`
@@ -1450,6 +1452,7 @@ export const computeResolverFieldNames = (
     typeName,
     listFieldName,
     singleFieldName,
+    aggregateFieldName,
     createArrayFieldName,
     createSingleFieldName,
     updateFieldName,

--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -15,11 +15,13 @@
 // @ts-nocheck — vendored file, drizzle-orm 1.0 type compat not guaranteed
 import type { Column, Relation, Table } from 'drizzle-orm';
 import {
+  aliasedTable,
   and,
   asc,
   desc,
   eq,
   getColumns,
+  getTableAsAliasSQL,
   gt,
   gte,
   ilike,
@@ -31,11 +33,13 @@ import {
   lt,
   lte,
   ne,
+  not,
   notIlike,
   notInArray,
   notLike,
   One,
   or,
+  relationsFilterToSQL,
   type SQL,
   sql,
 } from 'drizzle-orm';
@@ -297,7 +301,7 @@ const batchedPaginatedRelationQuery = async (
  *      into a single IN-clause query, eliminating N+1 database round-trips.
  */
 export const createRelationResolverFactory =
-  (db: any, tables: Record<string, Table>): RelationResolverFactory =>
+  (db: any, tables: Record<string, Table>, filterCtx?: RelationFilterBase): RelationResolverFactory =>
   ({ tableName, relationName, relEntry, isOne }) => {
     const parentTable = tables[tableName];
     const targetTableName = relEntry.targetTableName;
@@ -345,7 +349,9 @@ export const createRelationResolverFactory =
         const uniqueIds = [...new Set(parentIds)];
         const whereCondition = and(
           inArray(foreignCol, uniqueIds),
-          whereArg ? extractFilters(targetTable, targetTableName, whereArg) : undefined,
+          whereArg
+            ? extractFilters(targetTable, targetTableName, whereArg, relationFilterCtx(filterCtx, targetTableName))
+            : undefined,
         );
 
         let rows: any[];
@@ -423,6 +429,11 @@ export interface TypeCacheCtx {
   orderTypeCache: WeakMap<object, GraphQLInputObjectType>;
   /** Per-call cache for filter GraphQL input types, keyed by table reference. */
   filterTypeCache: WeakMap<object, GraphQLInputObjectType>;
+  /**
+   * Per-call cache for `${Target}ListRelationFilter` input types (the some/every/none wrapper
+   * used by to-many relation filters), keyed by target table name.
+   */
+  listRelationFilterCache: Map<string, GraphQLInputObjectType>;
 }
 
 export const extractSelectedColumnsFromTree = (
@@ -701,32 +712,150 @@ const generateTableOrderTypeCached = (
   return order;
 };
 
+/**
+ * Relations that can be expressed as a correlated `EXISTS` subquery. Many-to-many relations
+ * declared with `.through()` need a junction join that the filter builder doesn't emit yet,
+ * so they're left out of the filter input entirely — a missing field is a clean GraphQL
+ * validation error, whereas a silently ignored filter would return too many rows.
+ */
+const isFilterableRelation = (relation: Relation<string>): boolean => !(relation as any).through;
+
+/**
+ * `${Target}ListRelationFilter` — the Prisma-style some/every/none wrapper for a to-many
+ * relation. Shared by every table that points at the same target, and built through a thunk
+ * so mutually-referencing tables (Users.posts ⇄ Posts.author) don't recurse forever.
+ */
+const generateListRelationFilterCached = (
+  targetTable: Table,
+  targetTableName: string,
+  cacheCtx: TypeCacheCtx,
+  typeNameMapper: TypeNameMapper | undefined,
+  relationMap: Record<string, Record<string, TableNamedRelations>> | undefined,
+  tables: Record<string, Table> | undefined,
+): GraphQLInputObjectType => {
+  const cached = cacheCtx.listRelationFilterCache.get(targetTableName);
+  if (cached) {
+    return cached;
+  }
+
+  const listFilter = new GraphQLInputObjectType({
+    name: `${resolveTypeName(targetTableName, typeNameMapper)}ListRelationFilter`,
+    fields: () => {
+      const targetFilters = generateTableFilterTypeCached(
+        targetTable,
+        targetTableName,
+        cacheCtx,
+        typeNameMapper,
+        relationMap,
+        tables,
+      );
+
+      return {
+        some: { type: targetFilters, description: 'At least one related row matches' },
+        none: { type: targetFilters, description: 'No related row matches' },
+        every: { type: targetFilters, description: 'Every related row matches' },
+      };
+    },
+  });
+
+  cacheCtx.listRelationFilterCache.set(targetTableName, listFilter);
+
+  return listFilter;
+};
+
+/**
+ * Filter fields for a table's relations: a to-one relation takes the target's own filter input
+ * directly, a to-many relation takes the some/every/none wrapper. A relation whose name collides
+ * with a column name is skipped — the column keeps the field.
+ */
+const generateRelationFilterFields = (
+  tableName: string,
+  cacheCtx: TypeCacheCtx,
+  typeNameMapper: TypeNameMapper | undefined,
+  columnFields: Record<string, ConvertedInputColumn>,
+  relationMap?: Record<string, Record<string, TableNamedRelations>>,
+  tables?: Record<string, Table>,
+): Record<string, { type: GraphQLInputObjectType; description?: string }> => {
+  const relations = relationMap?.[tableName];
+  if (!relations || !tables) {
+    return {};
+  }
+
+  const fields: Record<string, { type: GraphQLInputObjectType; description?: string }> = {};
+
+  for (const [relationName, relEntry] of Object.entries(relations)) {
+    if (relationName in columnFields) {
+      continue;
+    }
+
+    const targetTable = tables[relEntry.targetTableName];
+    const relation = (relEntry as any).relation ?? relEntry;
+    if (!targetTable || !isFilterableRelation(relation)) {
+      continue;
+    }
+
+    fields[relationName] = is(relation, One)
+      ? {
+          type: generateTableFilterTypeCached(
+            targetTable,
+            relEntry.targetTableName,
+            cacheCtx,
+            typeNameMapper,
+            relationMap,
+            tables,
+          ),
+          description: `Matches rows whose ${relationName} matches these filters`,
+        }
+      : {
+          type: generateListRelationFilterCached(
+            targetTable,
+            relEntry.targetTableName,
+            cacheCtx,
+            typeNameMapper,
+            relationMap,
+            tables,
+          ),
+        };
+  }
+
+  return fields;
+};
+
 const generateTableFilterTypeCached = (
   table: Table,
   tableName: string,
   cacheCtx: TypeCacheCtx,
   typeNameMapper?: TypeNameMapper,
+  relationMap?: Record<string, Record<string, TableNamedRelations>>,
+  tables?: Record<string, Table>,
 ) => {
   if (cacheCtx.filterTypeCache.has(table)) {
     return cacheCtx.filterTypeCache.get(table)!;
   }
 
-  const filterColumns = generateTableFilterValuesCached(table, tableName, cacheCtx);
+  // Fields are thunked so that relation filters, which reference other tables' filter inputs
+  // (and eventually this one again), are only resolved after this type is in the cache.
+  const buildFields = () => {
+    const filterColumns = generateTableFilterValuesCached(table, tableName, cacheCtx);
+    return {
+      ...filterColumns,
+      ...generateRelationFilterFields(tableName, cacheCtx, typeNameMapper, filterColumns, relationMap, tables),
+    };
+  };
+
+  const orFilters = new GraphQLInputObjectType({
+    name: `${resolveTypeName(tableName, typeNameMapper)}FiltersOr`,
+    fields: buildFields,
+  });
+
   const filters = new GraphQLInputObjectType({
     name: `${resolveTypeName(tableName, typeNameMapper)}Filters`,
-    fields: {
-      ...filterColumns,
+    fields: () => ({
+      ...buildFields(),
       OR: {
-        type: new GraphQLList(
-          new GraphQLNonNull(
-            new GraphQLInputObjectType({
-              name: `${resolveTypeName(tableName, typeNameMapper)}FiltersOr`,
-              fields: filterColumns,
-            }),
-          ),
-        ),
+        type: new GraphQLList(new GraphQLNonNull(orFilters)),
       },
-    },
+    }),
   });
 
   cacheCtx.filterTypeCache.set(table, filters);
@@ -761,7 +890,7 @@ const generateSelectFields = <TWithOrder extends boolean>(
 ): SelectData<TWithOrder> => {
   const table = tables[tableName]!;
   const order = withOrder ? generateTableOrderTypeCached(table, tableName, typeNameMapper, cacheCtx) : undefined;
-  const filters = generateTableFilterTypeCached(table, tableName, cacheCtx, typeNameMapper);
+  const filters = generateTableFilterTypeCached(table, tableName, cacheCtx, typeNameMapper, relationMap, tables);
   const tableFields = generateTableSelectTypeFieldsCached(table, tableName);
 
   const relationsForTable = relationMap[tableName];
@@ -1136,10 +1265,169 @@ export const extractFiltersColumn = <TColumn extends Column>(
   return variants.length ? (variants.length > 1 ? and(...variants) : variants[0]) : undefined;
 };
 
+/**
+ * Everything `extractFilters` needs to turn a relation key in a `where` argument into a
+ * correlated subquery. Omitted by callers that don't generate relation filters, in which case
+ * relation keys can't appear in the input to begin with.
+ */
+export interface RelationFilterContext {
+  /** Every table in the schema, keyed by its schema key. */
+  tables: Record<string, Table>;
+  /** Relations keyed by table schema key, then relation name. */
+  relationMap: Record<string, Record<string, TableNamedRelations>>;
+  /**
+   * Schema key of the table being filtered. Not always the same as the `tableName` label
+   * used in error messages (relation `where` callbacks pass the relation name there).
+   */
+  tableKey: string;
+  /** Shared counter making every subquery alias unique within one extraction. */
+  aliases?: { n: number };
+}
+
+/**
+ * The build-scoped half of {@link RelationFilterContext}. Created once per generated schema and
+ * handed to every resolver, which adds the table it is filtering.
+ */
+export type RelationFilterBase = Pick<RelationFilterContext, 'tables' | 'relationMap'>;
+
+/** Narrows the build-scoped relation filter context to the table a resolver is filtering. */
+export const relationFilterCtx = (
+  base: RelationFilterBase | undefined,
+  tableKey: string,
+): RelationFilterContext | undefined => (base ? { ...base, tableKey } : undefined);
+
+/** The three ways a to-many relation can be required to match, plus the to-one shorthand. */
+type RelationMatchMode = 'some' | 'none' | 'every';
+
+/**
+ * Correlates the parent row with the aliased target table using the relation's own join
+ * columns. Columns are matched by SQL name rather than object identity so this also works when
+ * the parent is an aliased proxy (as it is inside a relational `with:` where callback).
+ */
+const buildRelationJoinCondition = (
+  parentTable: Table,
+  relation: Relation<string>,
+  aliasedTarget: Table,
+  relationName: string,
+): SQL | undefined => {
+  const sourceColumns = (relation as any).sourceColumns as Column[] | undefined;
+  const targetColumns = (relation as any).targetColumns as Column[] | undefined;
+
+  if (!sourceColumns?.length || sourceColumns.length !== targetColumns?.length) {
+    throw new GraphQLError(`WHERE ${relationName}: Relation cannot be used as a filter`);
+  }
+
+  const parentColumns = Object.values(getColumns(parentTable));
+  const targetColumnsByName = Object.values(getColumns(aliasedTarget));
+
+  const conditions: SQL[] = [];
+  for (let i = 0; i < sourceColumns.length; i++) {
+    const localColumn = parentColumns.find((c) => c.name === sourceColumns[i]!.name);
+    const foreignColumn = targetColumnsByName.find((c) => c.name === targetColumns[i]!.name);
+
+    if (!localColumn || !foreignColumn) {
+      throw new GraphQLError(`WHERE ${relationName}: Relation cannot be used as a filter`);
+    }
+
+    conditions.push(eq(localColumn, foreignColumn));
+  }
+
+  return conditions.length > 1 ? and(...conditions) : conditions[0];
+};
+
+/**
+ * Builds one `[NOT] EXISTS (SELECT 1 FROM target alias WHERE …)` for a relation filter.
+ *
+ * `some` / the to-one shorthand match when a related row satisfies the inner filters, `none`
+ * when none does, and `every` is expressed as "no related row fails the inner filters".
+ * Because `every` negates the inner condition, a related row whose compared column is NULL
+ * counts as matching (SQL three-valued logic) — the same caveat Prisma carries.
+ */
+const buildRelationExists = (
+  parentTable: Table,
+  relationName: string,
+  relEntry: TableNamedRelations,
+  innerFilters: Filters<Table> | undefined,
+  mode: RelationMatchMode,
+  ctx: RelationFilterContext,
+): SQL | undefined => {
+  const { targetTableName } = relEntry;
+  const targetTable = ctx.tables[targetTableName];
+  const relation = ((relEntry as any).relation ?? relEntry) as Relation<string>;
+
+  if (!targetTable || !isFilterableRelation(relation)) {
+    throw new GraphQLError(`WHERE ${relationName}: Relation cannot be used as a filter`);
+  }
+
+  ctx.aliases ??= { n: 0 };
+  const aliases = ctx.aliases;
+  const aliasedTarget = aliasedTable(targetTable, `dgql_rel_${aliases.n++}`);
+
+  const joinCondition = buildRelationJoinCondition(parentTable, relation, aliasedTarget, relationName);
+  // A relation declared with its own `where` only ever exposes the rows it selects, so the
+  // subquery has to honour it too — otherwise a filter could match a row the relation hides.
+  const relationWhere = (relation as any).where
+    ? relationsFilterToSQL((relation as any).isReversed ? parentTable : aliasedTarget, (relation as any).where)
+    : undefined;
+
+  const inner = innerFilters
+    ? extractFilters(aliasedTarget, targetTableName, innerFilters, { ...ctx, tableKey: targetTableName, aliases })
+    : undefined;
+
+  if (mode === 'every') {
+    // "every related row matches" with no inner condition is vacuously true.
+    if (!inner) {
+      return undefined;
+    }
+
+    return sql`not exists (select 1 from ${getTableAsAliasSQL(aliasedTarget)} where ${and(joinCondition, relationWhere, not(inner))})`;
+  }
+
+  const condition = and(joinCondition, relationWhere, inner);
+
+  return mode === 'none'
+    ? sql`not exists (select 1 from ${getTableAsAliasSQL(aliasedTarget)} where ${condition})`
+    : sql`exists (select 1 from ${getTableAsAliasSQL(aliasedTarget)} where ${condition})`;
+};
+
+/**
+ * Handles one relation key in a `where` argument. To-one relations take the target's filters
+ * inline; to-many relations take any combination of `some` / `none` / `every`, ANDed together.
+ */
+const extractRelationFilter = (
+  parentTable: Table,
+  relationName: string,
+  relEntry: TableNamedRelations,
+  value: Record<string, any>,
+  ctx: RelationFilterContext,
+): SQL | undefined => {
+  const relation = ((relEntry as any).relation ?? relEntry) as Relation<string>;
+
+  if (is(relation, One)) {
+    return buildRelationExists(parentTable, relationName, relEntry, value, 'some', ctx);
+  }
+
+  const variants: SQL[] = [];
+  for (const mode of ['some', 'none', 'every'] as const) {
+    const inner = value[mode];
+    if (inner === undefined || inner === null) {
+      continue;
+    }
+
+    const extracted = buildRelationExists(parentTable, relationName, relEntry, inner, mode, ctx);
+    if (extracted) {
+      variants.push(extracted);
+    }
+  }
+
+  return variants.length ? (variants.length > 1 ? and(...variants) : variants[0]) : undefined;
+};
+
 export const extractFilters = <TTable extends Table>(
   table: TTable,
   tableName: string,
   filters: Filters<TTable>,
+  relationCtx?: RelationFilterContext,
 ): SQL | undefined => {
   if (!filters.OR?.length) {
     delete filters.OR;
@@ -1158,7 +1446,7 @@ export const extractFilters = <TTable extends Table>(
     const variants = [] as SQL[];
 
     for (const variant of filters.OR) {
-      const extracted = extractFilters(table, tableName, variant);
+      const extracted = extractFilters(table, tableName, variant, relationCtx);
       if (extracted) {
         variants.push(extracted);
       }
@@ -1167,14 +1455,25 @@ export const extractFilters = <TTable extends Table>(
     return variants.length ? (variants.length > 1 ? or(...variants) : variants[0]) : undefined;
   }
 
+  const columns = getColumns(table);
+  const relations = relationCtx?.relationMap[relationCtx.tableKey];
+
   const variants = [] as SQL[];
-  for (const [columnName, operators] of entries) {
-    if (operators === null) {
+  for (const [fieldName, operators] of entries) {
+    if (operators === null || operators === undefined) {
       continue;
     }
 
-    const column = getColumns(table)[columnName]!;
-    variants.push(extractFiltersColumn(column, columnName, operators)!);
+    const column = columns[fieldName];
+    const extracted = column
+      ? extractFiltersColumn(column, fieldName, operators)
+      : relations?.[fieldName] && relationCtx
+        ? extractRelationFilter(table, fieldName, relations[fieldName]!, operators as any, relationCtx)
+        : undefined;
+
+    if (extracted) {
+      variants.push(extracted);
+    }
   }
 
   return variants.length ? (variants.length > 1 ? and(...variants) : variants[0]) : undefined;
@@ -1188,6 +1487,7 @@ const extractRelationsParamsInner = (
   originField: ResolveTree,
   typeNameMapper?: TypeNameMapper,
   _isInitial: boolean = false,
+  filterCtx?: RelationFilterBase,
 ) => {
   const relationsForTable = relationMap[tableName];
   if (!relationsForTable) {
@@ -1238,7 +1538,10 @@ const extractRelationsParamsInner = (
     // original unaliased table name.
     const relWhere = relationArgs?.where;
     thisRecord.where = relWhere
-      ? { RAW: (aliasedTable: Table) => extractFilters(aliasedTable, relName, relWhere) }
+      ? {
+          RAW: (aliasedTable: Table) =>
+            extractFilters(aliasedTable, relName, relWhere, relationFilterCtx(filterCtx, targetTableName)),
+        }
       : undefined;
     // When a relation is paginated (limit/offset) but unordered, default to the target's
     // primary key so the per-parent slice is deterministic. Drizzle's RQB calls orderBy
@@ -1255,7 +1558,16 @@ const extractRelationsParamsInner = (
     thisRecord.limit = limit;
 
     const relWith = relationField
-      ? extractRelationsParamsInner(relationMap, tables, targetTableName, relTypeName, relationField, typeNameMapper)
+      ? extractRelationsParamsInner(
+          relationMap,
+          tables,
+          targetTableName,
+          relTypeName,
+          relationField,
+          typeNameMapper,
+          false,
+          filterCtx,
+        )
       : undefined;
     thisRecord.with = relWith;
 
@@ -1272,12 +1584,13 @@ export const extractRelationsParams = (
   info: ResolveTree | undefined,
   typeName: string,
   typeNameMapper?: TypeNameMapper,
+  filterCtx?: RelationFilterBase,
 ): Record<string, Partial<ProcessedTableSelectArgs>> | undefined => {
   if (!info) {
     return undefined;
   }
 
-  return extractRelationsParamsInner(relationMap, tables, tableName, typeName, info, typeNameMapper, true);
+  return extractRelationsParamsInner(relationMap, tables, tableName, typeName, info, typeNameMapper, true, filterCtx);
 };
 
 /**
@@ -1502,6 +1815,7 @@ export const runRelationalSelect = async (opts: {
   orderBy?: any;
   where?: any;
   single: boolean;
+  filterCtx?: RelationFilterBase;
 }): Promise<any> => {
   const {
     queryBase,
@@ -1516,6 +1830,7 @@ export const runRelationalSelect = async (opts: {
     orderBy,
     where,
     single,
+    filterCtx,
   } = opts;
   const params: any = {
     columns: extractSelectedColumnsFromTree(parsedInfo.fieldsByTypeName[typeName]!, table),
@@ -1523,9 +1838,14 @@ export const runRelationalSelect = async (opts: {
     // drizzle-orm v1 RQB calls orderBy/where with the aliased table proxy — use it
     // directly so column refs match the CTE alias.
     orderBy: orderBy ? (aliasedTable: Table) => extractOrderBy(aliasedTable, orderBy) : undefined,
-    where: where ? { RAW: (aliasedTable: Table) => extractFilters(aliasedTable, tableName, where) } : undefined,
+    where: where
+      ? {
+          RAW: (aliasedTable: Table) =>
+            extractFilters(aliasedTable, tableName, where, relationFilterCtx(filterCtx, tableName)),
+        }
+      : undefined,
     with: relationMap[tableName]
-      ? extractRelationsParams(relationMap, tables, tableName, parsedInfo, typeName, typeNameMapper)
+      ? extractRelationsParams(relationMap, tables, tableName, parsedInfo, typeName, typeNameMapper, filterCtx)
       : undefined,
   };
 

--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -1931,6 +1931,7 @@ export const runRelationalSelect = async (opts: {
   where?: any;
   single: boolean;
   filterCtx?: RelationFilterBase;
+  pkNames?: readonly string[];
 }): Promise<any> => {
   const {
     queryBase,
@@ -1946,7 +1947,13 @@ export const runRelationalSelect = async (opts: {
     where,
     single,
     filterCtx,
+    pkNames,
   } = opts;
+  // Taking a slice of an unordered result lets the database return any rows it likes, so
+  // `limit`/`offset` pages can overlap or skip rows between requests, and a single query
+  // can return a different row each time. Default to the primary key whenever the query is
+  // narrowed to a subset, mirroring the relation-level default in extractRelationsParamsInner.
+  const needsDefaultOrder = single || offset != null || opts.limit != null;
   const params: any = {
     columns: extractSelectedColumnsFromTree(parsedInfo.fieldsByTypeName[typeName]!, table, {
       tableName,
@@ -1956,7 +1963,11 @@ export const runRelationalSelect = async (opts: {
     offset,
     // drizzle-orm v1 RQB calls orderBy/where with the aliased table proxy — use it
     // directly so column refs match the CTE alias.
-    orderBy: orderBy ? (aliasedTable: Table) => extractOrderBy(aliasedTable, orderBy) : undefined,
+    orderBy: orderBy
+      ? (aliasedTable: Table) => extractOrderBy(aliasedTable, orderBy)
+      : needsDefaultOrder && pkNames?.length
+        ? (aliasedTable: Table) => primaryKeyOrderExprs(aliasedTable, pkNames)
+        : undefined,
     where: where
       ? {
           RAW: (aliasedTable: Table) =>

--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -1965,7 +1965,91 @@ export const prepareMutationRelationColumns = (params: {
 };
 
 /** Wraps a thrown Error as a (message-only) GraphQLError; passes non-Errors through unchanged. */
-export const toGraphQLError = (e: unknown): unknown => (e instanceof Error ? new GraphQLError(e.message) : e);
+/**
+ * Normalizes whatever a driver threw into a `GraphQLError`. Errors drizzle-graphql raised
+ * itself pass straight through; anything else keeps the thrown value on `originalError`,
+ * which is how {@link defaultErrorMapper} later tells the two apart.
+ */
+export const toGraphQLError = (e: unknown): unknown => {
+  if (e instanceof GraphQLError) {
+    return e;
+  }
+  return e instanceof Error ? new GraphQLError(e.message, { originalError: e }) : e;
+};
+
+/**
+ * Default for `config.onError`: keeps drizzle-graphql's own errors, which are written for
+ * the client, and replaces driver/database errors with a generic message. Their text names
+ * tables, columns, constraints and offending values, none of which belongs in a response.
+ * The original is preserved on `originalError` for server-side logging.
+ */
+export const defaultErrorMapper = (error: unknown): unknown => {
+  if (error instanceof GraphQLError && !error.originalError) {
+    return error;
+  }
+
+  return new GraphQLError('Internal server error', {
+    originalError:
+      error instanceof GraphQLError ? (error.originalError ?? error) : error instanceof Error ? error : null,
+    extensions: { code: 'INTERNAL_SERVER_ERROR' },
+  });
+};
+
+/**
+ * Wraps every resolver reachable from a generated entity set so that its errors pass through
+ * `mapError` first. Done here rather than at each `throw` site so that the hook also covers
+ * relation field resolvers and anything that throws outside a builder's own try/catch.
+ */
+export const applyErrorMapper = (
+  entities: {
+    queries: Record<string, { resolve?: (...args: any[]) => any }>;
+    mutations: Record<string, { resolve?: (...args: any[]) => any }>;
+    types: Record<string, { getFields?: () => Record<string, { resolve?: (...args: any[]) => any }> }>;
+    fieldResolvers?: Record<string, Record<string, (...args: any[]) => any>>;
+  },
+  mapError: (error: unknown) => unknown,
+): void => {
+  const wrap =
+    (resolve: (...args: any[]) => any) =>
+    (...args: any[]) => {
+      try {
+        const result = resolve(...args);
+        if (result && typeof result.then === 'function') {
+          return result.then(undefined, (e: unknown) => {
+            throw mapError(e);
+          });
+        }
+        return result;
+      } catch (e) {
+        throw mapError(e);
+      }
+    };
+
+  for (const field of [...Object.values(entities.queries), ...Object.values(entities.mutations)]) {
+    if (field?.resolve) {
+      field.resolve = wrap(field.resolve);
+    }
+  }
+
+  // Relation and aggregate fields live on the object types, not in the query/mutation maps.
+  for (const type of Object.values(entities.types)) {
+    if (typeof type?.getFields !== 'function') {
+      continue;
+    }
+    for (const field of Object.values(type.getFields())) {
+      if (field?.resolve) {
+        field.resolve = wrap(field.resolve);
+      }
+    }
+  }
+
+  // Standalone relation resolvers, handed out for use in hand-written schemas.
+  for (const tableResolvers of Object.values(entities.fieldResolvers ?? {})) {
+    for (const [relationName, resolve] of Object.entries(tableResolvers)) {
+      tableResolvers[relationName] = wrap(resolve);
+    }
+  }
+};
 
 /**
  * Derives the generated query/mutation field names for a table from the naming config

--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -242,6 +242,59 @@ export type RelationAggregateFactory = (params: {
 }) => { type: GraphQLObjectType; resolve: GraphQLFieldResolver<any, any> } | undefined;
 
 /**
+ * Key on the GraphQL context object under which a caller can place a Drizzle transaction
+ * (or any other executor: a pooled connection, a logging proxy). Every generated resolver
+ * reads it at resolve time and runs its statements there instead of on the database the
+ * schema was built from, which is what lets several mutations in one request share a
+ * transaction and lets a query see that transaction's uncommitted rows:
+ *
+ * ```ts
+ * await db.transaction(async (tx) => {
+ *   await graphql({ schema, source, contextValue: { [drizzleExecutorKey]: tx } });
+ * });
+ * ```
+ *
+ * Registered with `Symbol.for` so the ESM and CJS builds of this package agree on it when
+ * both end up loaded in one process.
+ */
+export const drizzleExecutorKey: unique symbol = Symbol.for('drizzle-graphql:executor') as any;
+
+/**
+ * The executor a resolver should run on: the request's transaction when the context
+ * carries one, otherwise the database the schema was built from.
+ */
+export const resolveExecutor = <T>(db: T, context: any): T => {
+  if (context && typeof context === 'object') {
+    const executor = context[drizzleExecutorKey];
+    if (executor) {
+      return executor as T;
+    }
+  }
+  return db;
+};
+
+/**
+ * This request's executor together with the relational query builder to select through.
+ *
+ * `buildTimeQueryBase` decides whether the table supports the relational query builder at
+ * all — a table with no relations has none, and the caller falls back to a plain select.
+ * The executor only decides which connection the query runs on, so a transaction that is
+ * missing `query` (or a table absent from its schema) keeps the build-time builder.
+ */
+export const resolveQueryExecutor = (
+  db: any,
+  context: any,
+  tableName: string,
+  buildTimeQueryBase: any,
+): { executor: any; queryBase: any } => {
+  const executor = resolveExecutor(db, context);
+  return {
+    executor,
+    queryBase: buildTimeQueryBase ? (executor?.query?.[tableName] ?? buildTimeQueryBase) : buildTimeQueryBase,
+  };
+};
+
+/**
  * Fetches a to-many relation with per-parent limit/offset for ALL parents in a
  * single query, using a window function (ROW_NUMBER() OVER (PARTITION BY fk ...)).
  *
@@ -357,6 +410,9 @@ export const createRelationResolverFactory =
       const loaderKey = `${tableName}::${relationName}::${argsKey}`;
 
       const loader = getOrCreateLoader(context, loaderKey, async (parentIds: readonly any[]) => {
+        // Loaders are cached per context, so every call batched here shares this request's
+        // executor — the transaction on the context, when there is one.
+        const executor = resolveExecutor(db, context);
         const uniqueIds = [...new Set(parentIds)];
         const whereCondition = and(
           inArray(foreignCol, uniqueIds),
@@ -369,7 +425,7 @@ export const createRelationResolverFactory =
         if (limit != null || offset != null) {
           // Per-parent pagination across the whole batch in one query.
           rows = await batchedPaginatedRelationQuery(
-            db,
+            executor,
             targetTable,
             foreignCol,
             whereCondition,
@@ -381,7 +437,7 @@ export const createRelationResolverFactory =
         } else {
           // Use plain db.select() so column refs are never aliased — avoids drizzle-orm v1
           // RQB aliasing requirements that would require referencing via aliasedTable proxy.
-          let q = db.select().from(targetTable).where(whereCondition) as any;
+          let q = executor.select().from(targetTable).where(whereCondition) as any;
           if (orderByArg) {
             q = q.orderBy(...extractOrderBy(targetTable, orderByArg));
           }
@@ -1808,35 +1864,125 @@ export const primaryKeyOrderExprs = (table: Table, pkNames: readonly string[]): 
     .map((col) => asc(col!));
 };
 
+/**
+ * Every set of columns that uniquely identifies a row of `table`: the primary key first,
+ * then each unique constraint and unique index, then each column declared `.unique()`
+ * inline. Sets are property names (what GraphQL inputs use), not database column names.
+ *
+ * `getTableConfig` is the dialect's own — the three dialects expose the same
+ * `{ primaryKeys, uniqueConstraints, indexes }` shape but from different modules, so the
+ * caller passes theirs in, as `getPrimaryKeyPropNamesFromConfig` does.
+ *
+ * Index entries whose columns are SQL expressions rather than plain columns are skipped:
+ * an expression index is a valid conflict target in the database but cannot be named by a
+ * column enum. Deduplicated, order-insensitive — a column that is both the primary key and
+ * a unique constraint yields one set.
+ */
+export const getUniqueColumnSets = (
+  table: Table,
+  getTableConfig: (table: Table) => {
+    primaryKeys: { columns: { name: string }[] }[];
+    uniqueConstraints?: { columns: { name: string }[] }[];
+    indexes?: { config: { unique?: boolean; columns: any[] } }[];
+  },
+): string[][] => {
+  const cols = getColumns(table);
+  const propNameByColumnName = new Map(Object.entries(cols).map(([propName, col]) => [(col as any).name, propName]));
+  // A set is usable only if every one of its columns maps back to a property on the table.
+  const toPropNames = (columnNames: (string | undefined)[]): string[] | undefined => {
+    const propNames: string[] = [];
+    for (const columnName of columnNames) {
+      const propName = columnName === undefined ? undefined : propNameByColumnName.get(columnName);
+      if (!propName) {
+        return undefined;
+      }
+      propNames.push(propName);
+    }
+    return propNames.length ? propNames : undefined;
+  };
+
+  const config = getTableConfig(table);
+  const candidates: (string[] | undefined)[] = [
+    // Inline `.primaryKey()` columns, then table-level `primaryKey({ columns })`.
+    Object.entries(cols)
+      .filter(([, col]) => (col as any).primary)
+      .map(([propName]) => propName),
+    ...config.primaryKeys.map((pk) => toPropNames(pk.columns.map((c) => c.name))),
+    ...(config.uniqueConstraints ?? []).map((uc) => toPropNames(uc.columns.map((c) => c.name))),
+    ...(config.indexes ?? [])
+      .filter((index) => index.config.unique)
+      .map((index) => toPropNames(index.config.columns.map((c) => (c as any)?.name))),
+    ...Object.entries(cols)
+      .filter(([, col]) => (col as any).isUnique)
+      .map(([propName]) => [propName]),
+  ];
+
+  const seen = new Set<string>();
+  const sets: string[][] = [];
+  for (const set of candidates) {
+    if (!set?.length) {
+      continue;
+    }
+    const key = [...set].sort().join(',');
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    sets.push(set);
+  }
+  return sets;
+};
+
 /** Alias of the row-number helper column in the `distinct` pass. Namespaced against real columns. */
 const DISTINCT_RN = '__drizzle_graphql_distinct_rn';
 
-const distinctEnumCache = new WeakMap<object, GraphQLEnumType>();
+const columnEnumCache = new WeakMap<object, Map<string, GraphQLEnumType>>();
 
 /**
- * `${typeName}DistinctColumn` — the enum of columns a list query may be made distinct on.
- * Cached per table object, like the order/filter inputs, so repeated builds reuse one instance.
+ * An enum of a table's column property names, under `enumName`. Cached per (table, enum
+ * name), like the order/filter inputs, so repeated builds reuse one instance and two enums
+ * over the same table never collide.
+ *
+ * Returns `undefined` when no column qualifies — the caller then omits the argument or
+ * input field the enum would have typed, rather than emitting an empty enum, which is
+ * invalid GraphQL.
  */
-export const generateDistinctEnum = (table: Table, typeName: string): GraphQLEnumType | undefined => {
-  const cached = distinctEnumCache.get(table);
+export const generateColumnEnum = (
+  table: Table,
+  enumName: string,
+  description: string,
+  predicate: (column: Column, columnName: string) => boolean = () => true,
+): GraphQLEnumType | undefined => {
+  let tableCache = columnEnumCache.get(table);
+  const cached = tableCache?.get(enumName);
   if (cached) {
     return cached;
   }
 
-  const columnNames = Object.keys(getColumns(table));
+  const columnNames = Object.entries(getColumns(table))
+    .filter(([columnName, column]) => predicate(column as Column, columnName))
+    .map(([columnName]) => columnName);
   if (!columnNames.length) {
     return undefined;
   }
 
   const enumType = new GraphQLEnumType({
-    name: `${typeName}DistinctColumn`,
-    description: `Columns of ${typeName} that a query can be made distinct on`,
+    name: enumName,
+    description,
     values: Object.fromEntries(columnNames.map((columnName) => [columnName, { value: columnName }])),
   });
 
-  distinctEnumCache.set(table, enumType);
+  if (!tableCache) {
+    tableCache = new Map();
+    columnEnumCache.set(table, tableCache);
+  }
+  tableCache.set(enumName, enumType);
   return enumType;
 };
+
+/** `${typeName}DistinctColumn` — the enum of columns a list query may be made distinct on. */
+export const generateDistinctEnum = (table: Table, typeName: string): GraphQLEnumType | undefined =>
+  generateColumnEnum(table, `${typeName}DistinctColumn`, `Columns of ${typeName} that a query can be made distinct on`);
 
 /**
  * Keeps the first row of each distinct combination of the requested columns, following the

--- a/src/util/builders/mysql.ts
+++ b/src/util/builders/mysql.ts
@@ -22,13 +22,17 @@ import {
   createRelationResolverFactory,
   extractFilters,
   generateDistinctEnum,
+  generateOnConflictInput,
   generateTableTypes,
   getPrimaryKeyPropNamesFromConfig,
+  mysqlValuesColumnRef,
+  type OnConflictArg,
   pruneNonEagerRelations,
   type RelationAggregateFactory,
   type RelationFilterBase,
   type RelationResolverFactory,
   relationFilterCtx,
+  resolveConflictPlan,
   resolveExecutor,
   resolveQueryExecutor,
   runRelationalSelect,
@@ -226,6 +230,71 @@ const generateInsertSingle = (
   };
 };
 
+const generateUpsert = (
+  db: MySqlDatabase<any, any, any, any>,
+  table: MySqlTable,
+  baseType: GraphQLInputObjectType,
+  onConflictType: GraphQLInputObjectType,
+  fieldName: string,
+  single: boolean,
+): CreatedResolver => {
+  const queryArgs: GraphQLFieldConfigArgumentMap = {
+    values: {
+      type: single ? new GraphQLNonNull(baseType) : new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(baseType))),
+    },
+    onConflict: {
+      type: onConflictType,
+      description: 'How a conflicting row is resolved. Defaults to overwriting it.',
+    },
+  };
+
+  const pkNames = mysqlPrimaryKeyPropNames(table);
+
+  return {
+    name: fieldName,
+    resolver: async (
+      _source,
+      args: { values: Record<string, any> | Record<string, any>[]; onConflict?: OnConflictArg },
+      context,
+      _info,
+    ) => {
+      try {
+        const input = single
+          ? [remapFromGraphQLSingleInput(args.values as Record<string, any>, table)]
+          : remapFromGraphQLArrayInput(args.values as Record<string, any>[], table);
+        if (!input.length) {
+          throw new GraphQLError('No values were provided!');
+        }
+
+        // MySQL's ON DUPLICATE KEY UPDATE fires on whichever unique key was violated, so
+        // there is no target to resolve and no predicate to attach.
+        const plan = resolveConflictPlan({
+          table,
+          values: input,
+          onConflict: args.onConflict,
+          pkNames,
+          uniqueSets: [],
+          excludedRef: mysqlValuesColumnRef,
+          withTarget: false,
+        });
+
+        const executor = resolveExecutor(db, context);
+        if (plan.action === 'NOTHING') {
+          // INSERT IGNORE is the closest MySQL gets to DO NOTHING.
+          await executor.insert(table).ignore().values(input);
+        } else {
+          await executor.insert(table).values(input).onDuplicateKeyUpdate({ set: plan.set });
+        }
+
+        return { isSuccess: true };
+      } catch (e) {
+        throw toGraphQLError(e);
+      }
+    },
+    args: queryArgs,
+  };
+};
+
 const generateUpdate = (
   db: MySqlDatabase<any, any, any>,
   tableName: string,
@@ -403,7 +472,7 @@ export const generateSchemaData = <
   const outputs: Record<string, GraphQLObjectType> = {};
   // Every MySQL mutation returns it, so it only belongs in the type map when at least one
   // mutation is generated.
-  if (features.insert || features.update || features.delete) {
+  if (features.insert || features.upsert || features.update || features.delete) {
     outputs.MutationReturn = mutationReturnType;
   }
 
@@ -419,6 +488,8 @@ export const generateSchemaData = <
       aggregateFieldName,
       createArrayFieldName,
       createSingleFieldName,
+      upsertArrayFieldName,
+      upsertSingleFieldName,
       updateFieldName,
       deleteFieldName,
     } = computeResolverFieldNames(tableName, typeNameMapper, prefixes, suffixes);
@@ -453,6 +524,23 @@ export const generateSchemaData = <
       : undefined;
     const insertSingleGenerated = features.insert
       ? generateInsertSingle(db, tableName, schema[tableName] as MySqlTable, insertInput, createSingleFieldName)
+      : undefined;
+    // MySQL detects a conflict on any unique key, so unlike PostgreSQL and SQLite every
+    // table can be upserted — there is no target to validate.
+    const onConflictInput = features.upsert
+      ? generateOnConflictInput({
+          table: schema[tableName] as MySqlTable,
+          typeName,
+          uniqueSets: [],
+          tableFilters,
+          withTarget: false,
+        })
+      : undefined;
+    const upsertArrGenerated = onConflictInput
+      ? generateUpsert(db, schema[tableName] as MySqlTable, insertInput, onConflictInput, upsertArrayFieldName, false)
+      : undefined;
+    const upsertSingleGenerated = onConflictInput
+      ? generateUpsert(db, schema[tableName] as MySqlTable, insertInput, onConflictInput, upsertSingleFieldName, true)
       : undefined;
     const updateGenerated = features.update
       ? generateUpdate(
@@ -500,7 +588,14 @@ export const generateSchemaData = <
         resolve: aggregateGenerated.resolver,
       };
     }
-    for (const generated of [insertArrGenerated, insertSingleGenerated, updateGenerated, deleteGenerated]) {
+    for (const generated of [
+      insertArrGenerated,
+      insertSingleGenerated,
+      upsertArrGenerated,
+      upsertSingleGenerated,
+      updateGenerated,
+      deleteGenerated,
+    ]) {
       if (generated) {
         mutations[generated.name] = {
           type: mutationReturnType,
@@ -512,7 +607,9 @@ export const generateSchemaData = <
     // The insert/update inputs are still built (they type the mutations that survive) but
     // only reach the schema's type map when a mutation actually references them.
     const activeInputs = [
-      ...(features.insert ? [insertInput] : []),
+      // The insert input types the upsert mutations too, so either feature keeps it.
+      ...(features.insert || onConflictInput ? [insertInput] : []),
+      ...(onConflictInput ? [onConflictInput] : []),
       ...(features.update ? [updateInput] : []),
       tableFilters,
       tableOrder,

--- a/src/util/builders/mysql.ts
+++ b/src/util/builders/mysql.ts
@@ -24,7 +24,9 @@ import {
   generateTableTypes,
   getPrimaryKeyPropNamesFromConfig,
   pruneNonEagerRelations,
+  type RelationFilterBase,
   type RelationResolverFactory,
+  relationFilterCtx,
   runRelationalSelect,
   selectArrayArgs,
   selectSingleArgs,
@@ -47,6 +49,7 @@ const generateSelectArray = (
   fieldName: string,
   typeName: string,
   typeNameMapper?: TypeNameMapper,
+  filterCtx?: RelationFilterBase,
 ): CreatedResolver => {
   const queryBase = db.query[tableName as keyof typeof db.query] as unknown as
     | RelationalQueryBuilder<any, any, any>
@@ -77,6 +80,7 @@ const generateSelectArray = (
           parsedInfo,
           ...args,
           single: false,
+          filterCtx,
         });
       } catch (e) {
         throw toGraphQLError(e);
@@ -96,6 +100,7 @@ const generateSelectSingle = (
   fieldName: string,
   typeName: string,
   typeNameMapper?: TypeNameMapper,
+  filterCtx?: RelationFilterBase,
 ): CreatedResolver => {
   const queryBase = db.query[tableName as keyof typeof db.query] as unknown as
     | RelationalQueryBuilder<any, any, any>
@@ -126,6 +131,7 @@ const generateSelectSingle = (
           parsedInfo,
           ...args,
           single: true,
+          filterCtx,
         });
       } catch (e) {
         throw toGraphQLError(e);
@@ -205,6 +211,7 @@ const generateUpdate = (
   setArgs: GraphQLInputObjectType,
   filterArgs: GraphQLInputObjectType,
   fieldName: string,
+  filterCtx?: RelationFilterBase,
 ): CreatedResolver => {
   const queryArgs = {
     set: {
@@ -228,7 +235,7 @@ const generateUpdate = (
 
         let query = db.update(table).set(input);
         if (where) {
-          const filters = extractFilters(table, tableName, where);
+          const filters = extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName));
           query = query.where(filters) as any;
         }
 
@@ -249,6 +256,7 @@ const generateDelete = (
   table: MySqlTable,
   filterArgs: GraphQLInputObjectType,
   fieldName: string,
+  filterCtx?: RelationFilterBase,
 ): CreatedResolver => {
   const queryArgs = {
     where: {
@@ -264,7 +272,7 @@ const generateDelete = (
 
         let query = db.delete(table);
         if (where) {
-          const filters = extractFilters(table, tableName, where);
+          const filters = extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName));
           query = query.where(filters) as any;
         }
 
@@ -316,7 +324,9 @@ export const generateSchemaData = <
   // Pruned map for query resolvers' `with:`; type generation keeps the full map.
   const eagerRelations = pruneNonEagerRelations(namedRelations, shouldEagerLoad);
 
-  const resolverFactory: RelationResolverFactory = createRelationResolverFactory(db, tables);
+  const filterCtx: RelationFilterBase = { tables, relationMap: namedRelations };
+
+  const resolverFactory: RelationResolverFactory = createRelationResolverFactory(db, tables, filterCtx);
 
   // Fresh cache per generateSchemaData call — prevents type name collisions
   // when buildSchema() is called multiple times.
@@ -328,6 +338,7 @@ export const generateSchemaData = <
     relationTypeCache: new Map(),
     orderTypeCache: new WeakMap(),
     filterTypeCache: new WeakMap(),
+    listRelationFilterCache: new Map(),
   };
 
   const queries: ThunkObjMap<GraphQLFieldConfig<any, any>> = {};
@@ -390,6 +401,7 @@ export const generateSchemaData = <
       listFieldName,
       typeName,
       typeNameMapper,
+      filterCtx,
     );
     const selectSingleGenerated = generateSelectSingle(
       db,
@@ -401,6 +413,7 @@ export const generateSchemaData = <
       singleFieldName,
       typeName,
       typeNameMapper,
+      filterCtx,
     );
     const insertArrGenerated = generateInsertArray(
       db,
@@ -423,6 +436,7 @@ export const generateSchemaData = <
       updateInput,
       tableFilters,
       updateFieldName,
+      filterCtx,
     );
     const deleteGenerated = generateDelete(
       db,
@@ -430,6 +444,7 @@ export const generateSchemaData = <
       schema[tableName] as MySqlTable,
       tableFilters,
       deleteFieldName,
+      filterCtx,
     );
     const aggregateType = generateAggregateTypes(schema[tableName] as MySqlTable, tableName, typeName);
     const aggregateGenerated = generateAggregate(
@@ -439,6 +454,7 @@ export const generateSchemaData = <
       typeName,
       aggregateFieldName,
       tableFilters,
+      filterCtx,
     );
 
     queries[selectArrGenerated.name] = {

--- a/src/util/builders/mysql.ts
+++ b/src/util/builders/mysql.ts
@@ -33,8 +33,8 @@ import {
   type TypeNameMapper,
   toGraphQLError,
 } from '../builders/common.ts';
-
 import { remapFromGraphQLArrayInput, remapFromGraphQLSingleInput } from '../data-mappers/index.ts';
+import { generateAggregate, generateAggregateTypes } from './aggregates.ts';
 import type { CreatedResolver, Filters, TableNamedRelations, TableSelectArgs } from './types.ts';
 
 const generateSelectArray = (
@@ -373,6 +373,7 @@ export const generateSchemaData = <
       typeName,
       listFieldName,
       singleFieldName,
+      aggregateFieldName,
       createArrayFieldName,
       createSingleFieldName,
       updateFieldName,
@@ -430,6 +431,15 @@ export const generateSchemaData = <
       tableFilters,
       deleteFieldName,
     );
+    const aggregateType = generateAggregateTypes(schema[tableName] as MySqlTable, tableName, typeName);
+    const aggregateGenerated = generateAggregate(
+      db,
+      tableName,
+      schema[tableName] as MySqlTable,
+      typeName,
+      aggregateFieldName,
+      tableFilters,
+    );
 
     queries[selectArrGenerated.name] = {
       type: selectArrOutput,
@@ -440,6 +450,11 @@ export const generateSchemaData = <
       type: selectSingleOutput,
       args: selectSingleGenerated.args,
       resolve: selectSingleGenerated.resolver,
+    };
+    queries[aggregateGenerated.name] = {
+      type: new GraphQLNonNull(aggregateType),
+      args: aggregateGenerated.args,
+      resolve: aggregateGenerated.resolver,
     };
     mutations[insertArrGenerated.name] = {
       type: mutationReturnType,
@@ -465,6 +480,7 @@ export const generateSchemaData = <
       inputs[e.name] = e;
     });
     outputs[selectSingleOutput.name] = selectSingleOutput;
+    outputs[aggregateType.name] = aggregateType;
   }
 
   const fieldResolvers: Record<string, Record<string, any>> = {};

--- a/src/util/builders/mysql.ts
+++ b/src/util/builders/mysql.ts
@@ -14,7 +14,7 @@ import {
 import type { ResolveTree } from 'graphql-parse-resolve-info';
 import { parseResolveInfo } from 'graphql-parse-resolve-info';
 
-import type { BuildSchemaConfig, GeneratedEntities, MakeRequired } from '../../types.ts';
+import type { GeneratedEntities } from '../../types.ts';
 import {
   attachTargetPrimaryKeys,
   buildNamedRelations,
@@ -29,6 +29,8 @@ import {
   type RelationFilterBase,
   type RelationResolverFactory,
   relationFilterCtx,
+  resolveExecutor,
+  resolveQueryExecutor,
   runRelationalSelect,
   selectArrayArgs,
   selectSingleArgs,
@@ -39,7 +41,13 @@ import {
 } from '../builders/common.ts';
 import { remapFromGraphQLArrayInput, remapFromGraphQLSingleInput } from '../data-mappers/index.ts';
 import { createRelationAggregateFactory, generateAggregate, generateAggregateTypes } from './aggregates.ts';
-import type { CreatedResolver, Filters, TableNamedRelations, TableSelectArgs } from './types.ts';
+import type {
+  CreatedResolver,
+  Filters,
+  SchemaGeneratorOptions,
+  TableNamedRelations,
+  TableSelectArgs,
+} from './types.ts';
 
 const generateSelectArray = (
   db: MySqlDatabase<any, any, any>,
@@ -52,6 +60,7 @@ const generateSelectArray = (
   typeName: string,
   typeNameMapper?: TypeNameMapper,
   filterCtx?: RelationFilterBase,
+  distinctEnabled: boolean = true,
 ): CreatedResolver => {
   const queryBase = db.query[tableName as keyof typeof db.query] as unknown as
     | RelationalQueryBuilder<any, any, any>
@@ -64,15 +73,20 @@ const generateSelectArray = (
 
   const table = tables[tableName]!;
   const pkNames = mysqlPrimaryKeyPropNames(table as MySqlTable);
-  const queryArgs = selectArrayArgs(orderArgs, filterArgs, generateDistinctEnum(table, typeName));
+  const queryArgs = selectArrayArgs(
+    orderArgs,
+    filterArgs,
+    distinctEnabled ? generateDistinctEnum(table, typeName) : undefined,
+  );
 
   return {
     name: fieldName,
-    resolver: async (_source, args: Partial<TableSelectArgs>, _context, info) => {
+    resolver: async (_source, args: Partial<TableSelectArgs>, context, info) => {
       try {
         const parsedInfo = parseResolveInfo(info, { deep: true }) as ResolveTree;
+        const { executor, queryBase: requestQueryBase } = resolveQueryExecutor(db, context, tableName, queryBase);
         return await runRelationalSelect({
-          queryBase,
+          queryBase: requestQueryBase,
           tables,
           tableName,
           table,
@@ -84,7 +98,7 @@ const generateSelectArray = (
           single: false,
           filterCtx,
           pkNames,
-          db,
+          db: executor,
         });
       } catch (e) {
         throw toGraphQLError(e);
@@ -122,11 +136,12 @@ const generateSelectSingle = (
 
   return {
     name: fieldName,
-    resolver: async (_source, args: Partial<TableSelectArgs>, _context, info) => {
+    resolver: async (_source, args: Partial<TableSelectArgs>, context, info) => {
       try {
         const parsedInfo = parseResolveInfo(info, { deep: true }) as ResolveTree;
+        const { executor, queryBase: requestQueryBase } = resolveQueryExecutor(db, context, tableName, queryBase);
         return await runRelationalSelect({
-          queryBase,
+          queryBase: requestQueryBase,
           tables,
           tableName,
           table,
@@ -138,7 +153,7 @@ const generateSelectSingle = (
           single: true,
           filterCtx,
           pkNames,
-          db,
+          db: executor,
         });
       } catch (e) {
         throw toGraphQLError(e);
@@ -163,14 +178,14 @@ const generateInsertArray = (
 
   return {
     name: fieldName,
-    resolver: async (_source, args: { values: Record<string, any>[] }, _context, _info) => {
+    resolver: async (_source, args: { values: Record<string, any>[] }, context, _info) => {
       try {
         const input = remapFromGraphQLArrayInput(args.values, table);
         if (!input.length) {
           throw new GraphQLError('No values were provided!');
         }
 
-        await db.insert(table).values(input);
+        await resolveExecutor(db, context).insert(table).values(input);
 
         return { isSuccess: true };
       } catch (e) {
@@ -196,11 +211,11 @@ const generateInsertSingle = (
 
   return {
     name: fieldName,
-    resolver: async (_source, args: { values: Record<string, any> }, _context, _info) => {
+    resolver: async (_source, args: { values: Record<string, any> }, context, _info) => {
       try {
         const input = remapFromGraphQLSingleInput(args.values, table);
 
-        await db.insert(table).values(input);
+        await resolveExecutor(db, context).insert(table).values(input);
 
         return { isSuccess: true };
       } catch (e) {
@@ -231,7 +246,7 @@ const generateUpdate = (
 
   return {
     name: fieldName,
-    resolver: async (_source, args: { where?: Filters<Table>; set: Record<string, any> }, _context, _info) => {
+    resolver: async (_source, args: { where?: Filters<Table>; set: Record<string, any> }, context, _info) => {
       try {
         const { where, set } = args;
 
@@ -240,7 +255,8 @@ const generateUpdate = (
           throw new GraphQLError('Unable to update with no values specified!');
         }
 
-        let query = db.update(table).set(input);
+        const executor = resolveExecutor(db, context);
+        let query = executor.update(table).set(input);
         if (where) {
           const filters = extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName));
           query = query.where(filters) as any;
@@ -273,11 +289,12 @@ const generateDelete = (
 
   return {
     name: fieldName,
-    resolver: async (_source, args: { where?: Filters<Table> }, _context, _info) => {
+    resolver: async (_source, args: { where?: Filters<Table> }, context, _info) => {
       try {
         const { where } = args;
 
-        let query = db.delete(table);
+        const executor = resolveExecutor(db, context);
+        let query = executor.delete(table);
         if (where) {
           const filters = extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName));
           query = query.where(filters) as any;
@@ -305,12 +322,9 @@ export const generateSchemaData = <
   db: TDrizzleInstance,
   schema: TSchema,
   relations: TablesRelationalConfig,
-  relationsDepthLimit: number | undefined,
-  prefixes: MakeRequired<MakeRequired<BuildSchemaConfig>['prefixes']>,
-  suffixes: MakeRequired<MakeRequired<BuildSchemaConfig>['suffixes']>,
-  typeNameMapper?: TypeNameMapper,
-  shouldEagerLoad: (tableName: string, relationName: string) => boolean = () => true,
+  options: SchemaGeneratorOptions,
 ): GeneratedEntities<TDrizzleInstance, TSchema> => {
+  const { relationsDepthLimit, prefixes, suffixes, typeNameMapper, shouldEagerLoad, features } = options;
   const rawSchema = schema;
   const schemaEntries = Object.entries(rawSchema);
 
@@ -349,13 +363,11 @@ export const generateSchemaData = <
     aggregateTypeCache: new Map(),
   };
 
-  const relationAggregateFactory: RelationAggregateFactory = createRelationAggregateFactory(
-    db,
-    tables,
-    cacheCtx,
-    typeNameMapper,
-    filterCtx,
-  );
+  // Left undefined when the feature is off — generateTableTypes then emits no
+  // `${relation}Aggregate` fields at all.
+  const relationAggregateFactory: RelationAggregateFactory | undefined = features.relationAggregates
+    ? createRelationAggregateFactory(db, tables, cacheCtx, typeNameMapper, filterCtx)
+    : undefined;
 
   const queries: ThunkObjMap<GraphQLFieldConfig<any, any>> = {};
   const mutations: ThunkObjMap<GraphQLFieldConfig<any, any>> = {};
@@ -388,9 +400,12 @@ export const generateSchemaData = <
   });
 
   const inputs: Record<string, GraphQLInputObjectType> = {};
-  const outputs: Record<string, GraphQLObjectType> = {
-    MutationReturn: mutationReturnType,
-  };
+  const outputs: Record<string, GraphQLObjectType> = {};
+  // Every MySQL mutation returns it, so it only belongs in the type map when at least one
+  // mutation is generated.
+  if (features.insert || features.update || features.delete) {
+    outputs.MutationReturn = mutationReturnType;
+  }
 
   for (const [tableName, tableTypes] of Object.entries(gqlSchemaTypes)) {
     const { insertInput, updateInput, tableFilters, tableOrder } = tableTypes.inputs;
@@ -419,6 +434,7 @@ export const generateSchemaData = <
       typeName,
       typeNameMapper,
       filterCtx,
+      features.distinct,
     );
     const selectSingleGenerated = generateSelectSingle(
       db,
@@ -432,47 +448,40 @@ export const generateSchemaData = <
       typeNameMapper,
       filterCtx,
     );
-    const insertArrGenerated = generateInsertArray(
-      db,
-      tableName,
-      schema[tableName] as MySqlTable,
-      insertInput,
-      createArrayFieldName,
-    );
-    const insertSingleGenerated = generateInsertSingle(
-      db,
-      tableName,
-      schema[tableName] as MySqlTable,
-      insertInput,
-      createSingleFieldName,
-    );
-    const updateGenerated = generateUpdate(
-      db,
-      tableName,
-      schema[tableName] as MySqlTable,
-      updateInput,
-      tableFilters,
-      updateFieldName,
-      filterCtx,
-    );
-    const deleteGenerated = generateDelete(
-      db,
-      tableName,
-      schema[tableName] as MySqlTable,
-      tableFilters,
-      deleteFieldName,
-      filterCtx,
-    );
-    const aggregateType = generateAggregateTypes(schema[tableName] as MySqlTable, tableName, typeName, cacheCtx);
-    const aggregateGenerated = generateAggregate(
-      db,
-      tableName,
-      schema[tableName] as MySqlTable,
-      typeName,
-      aggregateFieldName,
-      tableFilters,
-      filterCtx,
-    );
+    const insertArrGenerated = features.insert
+      ? generateInsertArray(db, tableName, schema[tableName] as MySqlTable, insertInput, createArrayFieldName)
+      : undefined;
+    const insertSingleGenerated = features.insert
+      ? generateInsertSingle(db, tableName, schema[tableName] as MySqlTable, insertInput, createSingleFieldName)
+      : undefined;
+    const updateGenerated = features.update
+      ? generateUpdate(
+          db,
+          tableName,
+          schema[tableName] as MySqlTable,
+          updateInput,
+          tableFilters,
+          updateFieldName,
+          filterCtx,
+        )
+      : undefined;
+    const deleteGenerated = features.delete
+      ? generateDelete(db, tableName, schema[tableName] as MySqlTable, tableFilters, deleteFieldName, filterCtx)
+      : undefined;
+    const aggregateType = features.aggregates
+      ? generateAggregateTypes(schema[tableName] as MySqlTable, tableName, typeName, cacheCtx)
+      : undefined;
+    const aggregateGenerated = features.aggregates
+      ? generateAggregate(
+          db,
+          tableName,
+          schema[tableName] as MySqlTable,
+          typeName,
+          aggregateFieldName,
+          tableFilters,
+          filterCtx,
+        )
+      : undefined;
 
     queries[selectArrGenerated.name] = {
       type: selectArrOutput,
@@ -484,36 +493,37 @@ export const generateSchemaData = <
       args: selectSingleGenerated.args,
       resolve: selectSingleGenerated.resolver,
     };
-    queries[aggregateGenerated.name] = {
-      type: new GraphQLNonNull(aggregateType),
-      args: aggregateGenerated.args,
-      resolve: aggregateGenerated.resolver,
-    };
-    mutations[insertArrGenerated.name] = {
-      type: mutationReturnType,
-      args: insertArrGenerated.args,
-      resolve: insertArrGenerated.resolver,
-    };
-    mutations[insertSingleGenerated.name] = {
-      type: mutationReturnType,
-      args: insertSingleGenerated.args,
-      resolve: insertSingleGenerated.resolver,
-    };
-    mutations[updateGenerated.name] = {
-      type: mutationReturnType,
-      args: updateGenerated.args,
-      resolve: updateGenerated.resolver,
-    };
-    mutations[deleteGenerated.name] = {
-      type: mutationReturnType,
-      args: deleteGenerated.args,
-      resolve: deleteGenerated.resolver,
-    };
-    [insertInput, updateInput, tableFilters, tableOrder].forEach((e) => {
+    if (aggregateGenerated && aggregateType) {
+      queries[aggregateGenerated.name] = {
+        type: new GraphQLNonNull(aggregateType),
+        args: aggregateGenerated.args,
+        resolve: aggregateGenerated.resolver,
+      };
+    }
+    for (const generated of [insertArrGenerated, insertSingleGenerated, updateGenerated, deleteGenerated]) {
+      if (generated) {
+        mutations[generated.name] = {
+          type: mutationReturnType,
+          args: generated.args,
+          resolve: generated.resolver,
+        };
+      }
+    }
+    // The insert/update inputs are still built (they type the mutations that survive) but
+    // only reach the schema's type map when a mutation actually references them.
+    const activeInputs = [
+      ...(features.insert ? [insertInput] : []),
+      ...(features.update ? [updateInput] : []),
+      tableFilters,
+      tableOrder,
+    ];
+    activeInputs.forEach((e) => {
       inputs[e.name] = e;
     });
     outputs[selectSingleOutput.name] = selectSingleOutput;
-    outputs[aggregateType.name] = aggregateType;
+    if (aggregateType) {
+      outputs[aggregateType.name] = aggregateType;
+    }
   }
 
   const fieldResolvers: Record<string, Record<string, any>> = {};

--- a/src/util/builders/mysql.ts
+++ b/src/util/builders/mysql.ts
@@ -21,6 +21,7 @@ import {
   computeResolverFieldNames,
   createRelationResolverFactory,
   extractFilters,
+  generateDistinctEnum,
   generateTableTypes,
   getPrimaryKeyPropNamesFromConfig,
   pruneNonEagerRelations,
@@ -61,10 +62,9 @@ const generateSelectArray = (
     );
   }
 
-  const queryArgs = selectArrayArgs(orderArgs, filterArgs);
-
   const table = tables[tableName]!;
   const pkNames = mysqlPrimaryKeyPropNames(table as MySqlTable);
+  const queryArgs = selectArrayArgs(orderArgs, filterArgs, generateDistinctEnum(table, typeName));
 
   return {
     name: fieldName,
@@ -84,6 +84,7 @@ const generateSelectArray = (
           single: false,
           filterCtx,
           pkNames,
+          db,
         });
       } catch (e) {
         throw toGraphQLError(e);
@@ -137,6 +138,7 @@ const generateSelectSingle = (
           single: true,
           filterCtx,
           pkNames,
+          db,
         });
       } catch (e) {
         throw toGraphQLError(e);

--- a/src/util/builders/mysql.ts
+++ b/src/util/builders/mysql.ts
@@ -24,6 +24,7 @@ import {
   generateTableTypes,
   getPrimaryKeyPropNamesFromConfig,
   pruneNonEagerRelations,
+  type RelationAggregateFactory,
   type RelationFilterBase,
   type RelationResolverFactory,
   relationFilterCtx,
@@ -36,7 +37,7 @@ import {
   toGraphQLError,
 } from '../builders/common.ts';
 import { remapFromGraphQLArrayInput, remapFromGraphQLSingleInput } from '../data-mappers/index.ts';
-import { generateAggregate, generateAggregateTypes } from './aggregates.ts';
+import { createRelationAggregateFactory, generateAggregate, generateAggregateTypes } from './aggregates.ts';
 import type { CreatedResolver, Filters, TableNamedRelations, TableSelectArgs } from './types.ts';
 
 const generateSelectArray = (
@@ -339,7 +340,16 @@ export const generateSchemaData = <
     orderTypeCache: new WeakMap(),
     filterTypeCache: new WeakMap(),
     listRelationFilterCache: new Map(),
+    aggregateTypeCache: new Map(),
   };
+
+  const relationAggregateFactory: RelationAggregateFactory = createRelationAggregateFactory(
+    db,
+    tables,
+    cacheCtx,
+    typeNameMapper,
+    filterCtx,
+  );
 
   const queries: ThunkObjMap<GraphQLFieldConfig<any, any>> = {};
   const mutations: ThunkObjMap<GraphQLFieldConfig<any, any>> = {};
@@ -357,6 +367,7 @@ export const generateSchemaData = <
         prefixes.insert,
         prefixes.update,
         resolverFactory,
+        relationAggregateFactory,
       ),
     ]),
   );
@@ -446,7 +457,7 @@ export const generateSchemaData = <
       deleteFieldName,
       filterCtx,
     );
-    const aggregateType = generateAggregateTypes(schema[tableName] as MySqlTable, tableName, typeName);
+    const aggregateType = generateAggregateTypes(schema[tableName] as MySqlTable, tableName, typeName, cacheCtx);
     const aggregateGenerated = generateAggregate(
       db,
       tableName,

--- a/src/util/builders/mysql.ts
+++ b/src/util/builders/mysql.ts
@@ -64,6 +64,7 @@ const generateSelectArray = (
   const queryArgs = selectArrayArgs(orderArgs, filterArgs);
 
   const table = tables[tableName]!;
+  const pkNames = mysqlPrimaryKeyPropNames(table as MySqlTable);
 
   return {
     name: fieldName,
@@ -82,6 +83,7 @@ const generateSelectArray = (
           ...args,
           single: false,
           filterCtx,
+          pkNames,
         });
       } catch (e) {
         throw toGraphQLError(e);
@@ -115,6 +117,7 @@ const generateSelectSingle = (
   const queryArgs = selectSingleArgs(orderArgs, filterArgs);
 
   const table = tables[tableName]!;
+  const pkNames = mysqlPrimaryKeyPropNames(table as MySqlTable);
 
   return {
     name: fieldName,
@@ -133,6 +136,7 @@ const generateSelectSingle = (
           ...args,
           single: true,
           filterCtx,
+          pkNames,
         });
       } catch (e) {
         throw toGraphQLError(e);

--- a/src/util/builders/pg.ts
+++ b/src/util/builders/pg.ts
@@ -26,7 +26,9 @@ import {
   getPrimaryKeyPropNamesFromConfig,
   prepareMutationRelationColumns,
   pruneNonEagerRelations,
+  type RelationFilterBase,
   type RelationResolverFactory,
+  relationFilterCtx,
   runRelationalSelect,
   selectArrayArgs,
   selectSingleArgs,
@@ -54,6 +56,7 @@ const generateSelectArray = (
   fieldName: string,
   typeName: string,
   typeNameMapper?: TypeNameMapper,
+  filterCtx?: RelationFilterBase,
 ): CreatedResolver => {
   const queryBase = db.query[tableName as keyof typeof db.query] as unknown as
     | RelationalQueryBuilder<any, any, any>
@@ -82,6 +85,7 @@ const generateSelectArray = (
             parsedInfo,
             ...args,
             single: false,
+            filterCtx,
           });
         }
 
@@ -94,7 +98,7 @@ const generateSelectArray = (
         );
         let q = db.select(selectedColumnsSql).from(table);
         if (where) {
-          q = q.where(extractFilters(table, tableName, where)) as any;
+          q = q.where(extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName))) as any;
         }
         if (orderBy) {
           q = q.orderBy(...extractOrderBy(table, orderBy)) as any;
@@ -124,6 +128,7 @@ const generateSelectSingle = (
   fieldName: string,
   typeName: string,
   typeNameMapper?: TypeNameMapper,
+  filterCtx?: RelationFilterBase,
 ): CreatedResolver => {
   const queryBase = db.query[tableName as keyof typeof db.query] as unknown as
     | RelationalQueryBuilder<any, any, any>
@@ -152,6 +157,7 @@ const generateSelectSingle = (
             parsedInfo,
             ...args,
             single: true,
+            filterCtx,
           });
         }
 
@@ -163,7 +169,7 @@ const generateSelectSingle = (
         );
         let q = db.select(selectedColumnsSql).from(table);
         if (where) {
-          q = q.where(extractFilters(table, tableName, where)) as any;
+          q = q.where(extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName))) as any;
         }
         if (orderBy) {
           q = q.orderBy(...extractOrderBy(table, orderBy)) as any;
@@ -326,6 +332,7 @@ const generateUpdate = (
   fieldName: string,
   typeName: string,
   typeNameMapper?: TypeNameMapper,
+  filterCtx?: RelationFilterBase,
 ): CreatedResolver => {
   const queryArgs = {
     set: {
@@ -367,7 +374,7 @@ const generateUpdate = (
 
         let query = db.update(table).set(input);
         if (where) {
-          const filters = extractFilters(table, tableName, where);
+          const filters = extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName));
           query = query.where(filters) as any;
         }
 
@@ -395,6 +402,7 @@ const generateDelete = (
   filterArgs: GraphQLInputObjectType,
   fieldName: string,
   typeName: string,
+  filterCtx?: RelationFilterBase,
 ): CreatedResolver => {
   const queryArgs = {
     where: {
@@ -419,7 +427,7 @@ const generateDelete = (
 
         let query = db.delete(table);
         if (where) {
-          const filters = extractFilters(table, tableName, where);
+          const filters = extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName));
           query = query.where(filters) as any;
         }
 
@@ -475,7 +483,9 @@ export function generateSchemaData<
   // fields still exist and resolve lazily.
   const eagerRelations = pruneNonEagerRelations(namedRelations, shouldEagerLoad);
 
-  const resolverFactory: RelationResolverFactory = createRelationResolverFactory(db, tables);
+  const filterCtx: RelationFilterBase = { tables, relationMap: namedRelations };
+
+  const resolverFactory: RelationResolverFactory = createRelationResolverFactory(db, tables, filterCtx);
 
   // Fresh cache per generateSchemaData call — prevents type name collisions
   // when buildSchema() is called multiple times.
@@ -487,6 +497,7 @@ export function generateSchemaData<
     relationTypeCache: new Map(),
     orderTypeCache: new WeakMap(),
     filterTypeCache: new WeakMap(),
+    listRelationFilterCache: new Map(),
   };
 
   const queries: ThunkObjMap<GraphQLFieldConfig<any, any>> = {};
@@ -539,6 +550,7 @@ export function generateSchemaData<
       listFieldName,
       typeName,
       typeNameMapper,
+      filterCtx,
     );
     const selectSingleGenerated = generateSelectSingle(
       db,
@@ -550,6 +562,7 @@ export function generateSchemaData<
       singleFieldName,
       typeName,
       typeNameMapper,
+      filterCtx,
     );
     const insertArrGenerated = generateInsertArray(
       db,
@@ -586,6 +599,7 @@ export function generateSchemaData<
       updateFieldName,
       typeName,
       typeNameMapper,
+      filterCtx,
     );
     const deleteGenerated = generateDelete(
       db,
@@ -594,6 +608,7 @@ export function generateSchemaData<
       tableFilters,
       deleteFieldName,
       typeName,
+      filterCtx,
     );
     const aggregateType = generateAggregateTypes(schema[tableName] as PgTable, tableName, typeName);
     const aggregateGenerated = generateAggregate(
@@ -603,6 +618,7 @@ export function generateSchemaData<
       typeName,
       aggregateFieldName,
       tableFilters,
+      filterCtx,
     );
 
     queries[selectArrGenerated.name] = {

--- a/src/util/builders/pg.ts
+++ b/src/util/builders/pg.ts
@@ -25,6 +25,7 @@ import {
   generateTableTypes,
   getPrimaryKeyPropNamesFromConfig,
   prepareMutationRelationColumns,
+  primaryKeyOrderExprs,
   pruneNonEagerRelations,
   type RelationAggregateFactory,
   type RelationFilterBase,
@@ -68,6 +69,7 @@ const generateSelectArray = (
   const queryArgs = selectArrayArgs(orderArgs, filterArgs);
 
   const table = tables[tableName]!;
+  const pkNames = pgPrimaryKeyPropNames(table as PgTable);
 
   return {
     name: fieldName,
@@ -88,6 +90,7 @@ const generateSelectArray = (
             ...args,
             single: false,
             filterCtx,
+            pkNames,
           });
         }
 
@@ -105,6 +108,9 @@ const generateSelectArray = (
         }
         if (orderBy) {
           q = q.orderBy(...extractOrderBy(table, orderBy)) as any;
+        } else if ((offset != null || limit != null) && pkNames.length) {
+          // See runRelationalSelect: an unordered slice is not stable between requests.
+          q = q.orderBy(...primaryKeyOrderExprs(table, pkNames)) as any;
         }
         if (offset) {
           q = q.offset(offset) as any;
@@ -141,6 +147,7 @@ const generateSelectSingle = (
   const queryArgs = selectSingleArgs(orderArgs, filterArgs);
 
   const table = tables[tableName]!;
+  const pkNames = pgPrimaryKeyPropNames(table as PgTable);
 
   return {
     name: fieldName,
@@ -161,6 +168,7 @@ const generateSelectSingle = (
             ...args,
             single: true,
             filterCtx,
+            pkNames,
           });
         }
 
@@ -177,6 +185,9 @@ const generateSelectSingle = (
         }
         if (orderBy) {
           q = q.orderBy(...extractOrderBy(table, orderBy)) as any;
+        } else if (pkNames.length) {
+          // A single query is an implicit `limit 1` — order it so the row is deterministic.
+          q = q.orderBy(...primaryKeyOrderExprs(table, pkNames)) as any;
         }
         if (offset) {
           q = q.offset(offset) as any;

--- a/src/util/builders/pg.ts
+++ b/src/util/builders/pg.ts
@@ -12,7 +12,7 @@ import {
 } from 'graphql';
 import type { ResolveTree } from 'graphql-parse-resolve-info';
 import { parseResolveInfo } from 'graphql-parse-resolve-info';
-import type { BuildSchemaConfig, GeneratedEntities, MakeRequired } from '../../types.ts';
+import type { GeneratedEntities } from '../../types.ts';
 import {
   attachTargetPrimaryKeys,
   buildNamedRelations,
@@ -33,6 +33,8 @@ import {
   type RelationFilterBase,
   type RelationResolverFactory,
   relationFilterCtx,
+  resolveExecutor,
+  resolveQueryExecutor,
   runRelationalSelect,
   type SelectionCtx,
   selectArrayArgs,
@@ -50,7 +52,13 @@ import {
   remapToGraphQLSingleOutput,
 } from '../data-mappers/index.ts';
 import { createRelationAggregateFactory, generateAggregate, generateAggregateTypes } from './aggregates.ts';
-import type { CreatedResolver, Filters, TableNamedRelations, TableSelectArgs } from './types.ts';
+import type {
+  CreatedResolver,
+  Filters,
+  SchemaGeneratorOptions,
+  TableNamedRelations,
+  TableSelectArgs,
+} from './types.ts';
 
 const generateSelectArray = (
   db: PgAsyncDatabase<any, any, any>,
@@ -63,6 +71,7 @@ const generateSelectArray = (
   typeName: string,
   typeNameMapper?: TypeNameMapper,
   filterCtx?: RelationFilterBase,
+  distinctEnabled: boolean = true,
 ): CreatedResolver => {
   const queryBase = db.query[tableName as keyof typeof db.query] as unknown as
     | RelationalQueryBuilder<any, any, any>
@@ -71,17 +80,22 @@ const generateSelectArray = (
 
   const table = tables[tableName]!;
   const pkNames = pgPrimaryKeyPropNames(table as PgTable);
-  const queryArgs = selectArrayArgs(orderArgs, filterArgs, generateDistinctEnum(table, typeName));
+  const queryArgs = selectArrayArgs(
+    orderArgs,
+    filterArgs,
+    distinctEnabled ? generateDistinctEnum(table, typeName) : undefined,
+  );
 
   return {
     name: fieldName,
-    resolver: async (_source, args: Partial<TableSelectArgs>, _context, info) => {
+    resolver: async (_source, args: Partial<TableSelectArgs>, context, info) => {
       try {
         const parsedInfo = parseResolveInfo(info, { deep: true }) as ResolveTree;
+        const { executor, queryBase: requestQueryBase } = resolveQueryExecutor(db, context, tableName, queryBase);
 
-        if (queryBase) {
+        if (requestQueryBase) {
           return await runRelationalSelect({
-            queryBase,
+            queryBase: requestQueryBase,
             tables,
             tableName,
             table,
@@ -93,7 +107,7 @@ const generateSelectArray = (
             single: false,
             filterCtx,
             pkNames,
-            db,
+            db: executor,
           });
         }
 
@@ -114,7 +128,7 @@ const generateSelectArray = (
         let distinctKeys: Record<string, any>[] | undefined;
         if (distinct?.length) {
           distinctKeys = await selectDistinctKeys({
-            db,
+            db: executor,
             table,
             tableName,
             distinct,
@@ -129,7 +143,7 @@ const generateSelectArray = (
           }
         }
 
-        let q = db.select(selectedColumnsSql).from(table);
+        let q = executor.select(selectedColumnsSql).from(table);
         if (distinctKeys) {
           q = q.where(primaryKeyRestriction(table, pkNames, distinctKeys)) as any;
         } else if (whereSql) {
@@ -185,13 +199,14 @@ const generateSelectSingle = (
 
   return {
     name: fieldName,
-    resolver: async (_source, args: Partial<TableSelectArgs>, _context, info) => {
+    resolver: async (_source, args: Partial<TableSelectArgs>, context, info) => {
       try {
         const parsedInfo = parseResolveInfo(info, { deep: true }) as ResolveTree;
+        const { executor, queryBase: requestQueryBase } = resolveQueryExecutor(db, context, tableName, queryBase);
 
-        if (queryBase) {
+        if (requestQueryBase) {
           return await runRelationalSelect({
-            queryBase,
+            queryBase: requestQueryBase,
             tables,
             tableName,
             table,
@@ -203,7 +218,7 @@ const generateSelectSingle = (
             single: true,
             filterCtx,
             pkNames,
-            db,
+            db: executor,
           });
         }
 
@@ -214,7 +229,7 @@ const generateSelectSingle = (
           table,
           { tableName, relationMap, tables },
         );
-        let q = db.select(selectedColumnsSql).from(table);
+        let q = executor.select(selectedColumnsSql).from(table);
         if (where) {
           q = q.where(extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName))) as any;
         }
@@ -265,7 +280,7 @@ const generateInsertArray = (
 
   return {
     name: fieldName,
-    resolver: async (_source, args: { values: Record<string, any>[] }, _context, info) => {
+    resolver: async (_source, args: { values: Record<string, any>[] }, context, info) => {
       try {
         const input = remapFromGraphQLArrayInput(args.values, table);
         if (!input.length) {
@@ -287,14 +302,15 @@ const generateInsertArray = (
           parsedInfo,
         });
 
-        let query = db.insert(table).values(input).returning(columns);
+        const executor = resolveExecutor(db, context);
+        let query = executor.insert(table).values(input).returning(columns);
         if (conflictDoNothing) {
           query = query.onConflictDoNothing() as any;
         }
         const result = await query;
 
         const enriched = hasRelations
-          ? await eagerLoadMutationRelations(db, tableName, result, pkNames, withParams)
+          ? await eagerLoadMutationRelations(executor, tableName, result, pkNames, withParams)
           : result;
 
         return remapToGraphQLArrayOutput(enriched, tableName, table, relationMap);
@@ -329,7 +345,7 @@ const generateInsertSingle = (
 
   return {
     name: fieldName,
-    resolver: async (_source, args: { values: Record<string, any> }, _context, info) => {
+    resolver: async (_source, args: { values: Record<string, any> }, context, info) => {
       try {
         const input = remapFromGraphQLSingleInput(args.values, table);
 
@@ -348,7 +364,8 @@ const generateInsertSingle = (
           parsedInfo,
         });
 
-        let query = db.insert(table).values(input).returning(columns);
+        const executor = resolveExecutor(db, context);
+        let query = executor.insert(table).values(input).returning(columns);
         if (conflictDoNothing) {
           query = query.onConflictDoNothing() as any;
         }
@@ -359,7 +376,7 @@ const generateInsertSingle = (
         }
 
         const enriched = hasRelations
-          ? await eagerLoadMutationRelations(db, tableName, result, pkNames, withParams)
+          ? await eagerLoadMutationRelations(executor, tableName, result, pkNames, withParams)
           : result;
 
         return remapToGraphQLSingleOutput(enriched[0], tableName, table, relationMap);
@@ -398,7 +415,7 @@ const generateUpdate = (
 
   return {
     name: fieldName,
-    resolver: async (_source, args: { where?: Filters<Table>; set: Record<string, any> }, _context, info) => {
+    resolver: async (_source, args: { where?: Filters<Table>; set: Record<string, any> }, context, info) => {
       try {
         const { where, set } = args;
 
@@ -422,7 +439,8 @@ const generateUpdate = (
           throw new GraphQLError('Unable to update with no values specified!');
         }
 
-        let query = db.update(table).set(input);
+        const executor = resolveExecutor(db, context);
+        let query = executor.update(table).set(input);
         if (where) {
           const filters = extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName));
           query = query.where(filters) as any;
@@ -433,7 +451,7 @@ const generateUpdate = (
         const result = await query;
 
         const enriched = hasRelations
-          ? await eagerLoadMutationRelations(db, tableName, result, pkNames, withParams)
+          ? await eagerLoadMutationRelations(executor, tableName, result, pkNames, withParams)
           : result;
 
         return remapToGraphQLArrayOutput(enriched, tableName, table, relationMap);
@@ -463,7 +481,7 @@ const generateDelete = (
 
   return {
     name: fieldName,
-    resolver: async (_source, args: { where?: Filters<Table> }, _context, info) => {
+    resolver: async (_source, args: { where?: Filters<Table> }, context, info) => {
       try {
         const { where } = args;
 
@@ -477,7 +495,8 @@ const generateDelete = (
           selectionCtx,
         );
 
-        let query = db.delete(table);
+        const executor = resolveExecutor(db, context);
+        let query = executor.delete(table);
         if (where) {
           const filters = extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName));
           query = query.where(filters) as any;
@@ -506,13 +525,10 @@ export function generateSchemaData<
   db: TDrizzleInstance,
   schema: TSchema,
   relations: TRelations,
-  relationsDepthLimit: number | undefined,
-  prefixes: MakeRequired<MakeRequired<BuildSchemaConfig>['prefixes']>,
-  suffixes: MakeRequired<MakeRequired<BuildSchemaConfig>['suffixes']>,
-  conflictDoNothing: boolean = false,
-  typeNameMapper?: TypeNameMapper,
-  shouldEagerLoad: (tableName: string, relationName: string) => boolean = () => true,
+  options: SchemaGeneratorOptions,
 ): GeneratedEntities<TDrizzleInstance, TSchema> {
+  const { relationsDepthLimit, prefixes, suffixes, conflictDoNothing, typeNameMapper, shouldEagerLoad, features } =
+    options;
   const schemaEntries = Object.entries(schema);
   const tableEntries = schemaEntries.filter(([_key, value]) => is(value, PgTable)) as [string, PgTable][];
   const tables = Object.fromEntries(tableEntries) as Record<string, PgTable>;
@@ -553,13 +569,11 @@ export function generateSchemaData<
     aggregateTypeCache: new Map(),
   };
 
-  const relationAggregateFactory: RelationAggregateFactory = createRelationAggregateFactory(
-    db,
-    tables,
-    cacheCtx,
-    typeNameMapper,
-    filterCtx,
-  );
+  // Left undefined when the feature is off — generateTableTypes then emits no
+  // `${relation}Aggregate` fields at all.
+  const relationAggregateFactory: RelationAggregateFactory | undefined = features.relationAggregates
+    ? createRelationAggregateFactory(db, tables, cacheCtx, typeNameMapper, filterCtx)
+    : undefined;
 
   const queries: ThunkObjMap<GraphQLFieldConfig<any, any>> = {};
   const mutations: ThunkObjMap<GraphQLFieldConfig<any, any>> = {};
@@ -613,6 +627,7 @@ export function generateSchemaData<
       typeName,
       typeNameMapper,
       filterCtx,
+      features.distinct,
     );
     const selectSingleGenerated = generateSelectSingle(
       db,
@@ -626,63 +641,75 @@ export function generateSchemaData<
       typeNameMapper,
       filterCtx,
     );
-    const insertArrGenerated = generateInsertArray(
-      db,
-      tableName,
-      schema[tableName] as PgTable,
-      tables,
-      eagerRelations,
-      insertInput,
-      createArrayFieldName,
-      typeName,
-      typeNameMapper,
-      conflictDoNothing,
-    );
-    const insertSingleGenerated = generateInsertSingle(
-      db,
-      tableName,
-      schema[tableName] as PgTable,
-      tables,
-      eagerRelations,
-      insertInput,
-      createSingleFieldName,
-      typeName,
-      typeNameMapper,
-      conflictDoNothing,
-    );
-    const updateGenerated = generateUpdate(
-      db,
-      tableName,
-      schema[tableName] as PgTable,
-      tables,
-      eagerRelations,
-      updateInput,
-      tableFilters,
-      updateFieldName,
-      typeName,
-      typeNameMapper,
-      filterCtx,
-    );
-    const deleteGenerated = generateDelete(
-      db,
-      tableName,
-      schema[tableName] as PgTable,
-      tableFilters,
-      deleteFieldName,
-      typeName,
-      filterCtx,
-      { tableName, relationMap: namedRelations, tables },
-    );
-    const aggregateType = generateAggregateTypes(schema[tableName] as PgTable, tableName, typeName, cacheCtx);
-    const aggregateGenerated = generateAggregate(
-      db,
-      tableName,
-      schema[tableName] as PgTable,
-      typeName,
-      aggregateFieldName,
-      tableFilters,
-      filterCtx,
-    );
+    const insertArrGenerated = features.insert
+      ? generateInsertArray(
+          db,
+          tableName,
+          schema[tableName] as PgTable,
+          tables,
+          eagerRelations,
+          insertInput,
+          createArrayFieldName,
+          typeName,
+          typeNameMapper,
+          conflictDoNothing,
+        )
+      : undefined;
+    const insertSingleGenerated = features.insert
+      ? generateInsertSingle(
+          db,
+          tableName,
+          schema[tableName] as PgTable,
+          tables,
+          eagerRelations,
+          insertInput,
+          createSingleFieldName,
+          typeName,
+          typeNameMapper,
+          conflictDoNothing,
+        )
+      : undefined;
+    const updateGenerated = features.update
+      ? generateUpdate(
+          db,
+          tableName,
+          schema[tableName] as PgTable,
+          tables,
+          eagerRelations,
+          updateInput,
+          tableFilters,
+          updateFieldName,
+          typeName,
+          typeNameMapper,
+          filterCtx,
+        )
+      : undefined;
+    const deleteGenerated = features.delete
+      ? generateDelete(
+          db,
+          tableName,
+          schema[tableName] as PgTable,
+          tableFilters,
+          deleteFieldName,
+          typeName,
+          filterCtx,
+          { tableName, relationMap: namedRelations, tables },
+        )
+      : undefined;
+    const aggregateType = features.aggregates
+      ? generateAggregateTypes(schema[tableName] as PgTable, tableName, typeName, cacheCtx)
+      : undefined;
+    const aggregateGenerated = features.aggregates
+      ? generateAggregate(
+          db,
+          tableName,
+          schema[tableName] as PgTable,
+          typeName,
+          aggregateFieldName,
+          tableFilters,
+          filterCtx,
+        )
+      : undefined;
 
     queries[selectArrGenerated.name] = {
       type: selectArrOutput,
@@ -694,37 +721,57 @@ export function generateSchemaData<
       args: selectSingleGenerated.args,
       resolve: selectSingleGenerated.resolver,
     };
-    queries[aggregateGenerated.name] = {
-      type: new GraphQLNonNull(aggregateType),
-      args: aggregateGenerated.args,
-      resolve: aggregateGenerated.resolver,
-    };
-    mutations[insertArrGenerated.name] = {
-      type: arrTableItemOutput,
-      args: insertArrGenerated.args,
-      resolve: insertArrGenerated.resolver,
-    };
-    mutations[insertSingleGenerated.name] = {
-      type: singleTableItemOutput,
-      args: insertSingleGenerated.args,
-      resolve: insertSingleGenerated.resolver,
-    };
-    mutations[updateGenerated.name] = {
-      type: arrTableItemOutput,
-      args: updateGenerated.args,
-      resolve: updateGenerated.resolver,
-    };
-    mutations[deleteGenerated.name] = {
-      type: arrTableItemOutput,
-      args: deleteGenerated.args,
-      resolve: deleteGenerated.resolver,
-    };
-    [insertInput, updateInput, tableFilters, tableOrder].forEach((e) => {
+    if (aggregateGenerated && aggregateType) {
+      queries[aggregateGenerated.name] = {
+        type: new GraphQLNonNull(aggregateType),
+        args: aggregateGenerated.args,
+        resolve: aggregateGenerated.resolver,
+      };
+    }
+    if (insertArrGenerated) {
+      mutations[insertArrGenerated.name] = {
+        type: arrTableItemOutput,
+        args: insertArrGenerated.args,
+        resolve: insertArrGenerated.resolver,
+      };
+    }
+    if (insertSingleGenerated) {
+      mutations[insertSingleGenerated.name] = {
+        type: singleTableItemOutput,
+        args: insertSingleGenerated.args,
+        resolve: insertSingleGenerated.resolver,
+      };
+    }
+    if (updateGenerated) {
+      mutations[updateGenerated.name] = {
+        type: arrTableItemOutput,
+        args: updateGenerated.args,
+        resolve: updateGenerated.resolver,
+      };
+    }
+    if (deleteGenerated) {
+      mutations[deleteGenerated.name] = {
+        type: arrTableItemOutput,
+        args: deleteGenerated.args,
+        resolve: deleteGenerated.resolver,
+      };
+    }
+    // The insert/update inputs are still built (they type the mutations that survive) but
+    // only reach the schema's type map when a mutation actually references them.
+    const activeInputs = [
+      ...(features.insert ? [insertInput] : []),
+      ...(features.update ? [updateInput] : []),
+      tableFilters,
+      tableOrder,
+    ];
+    activeInputs.forEach((e) => {
       inputs[e.name] = e;
     });
     outputs[selectSingleOutput.name] = selectSingleOutput;
     outputs[singleTableItemOutput.name] = singleTableItemOutput;
-    outputs[aggregateType.name] = aggregateType;
+    if (aggregateType) {
+      outputs[aggregateType.name] = aggregateType;
+    }
   }
 
   const fieldResolvers: Record<string, Record<string, any>> = {};

--- a/src/util/builders/pg.ts
+++ b/src/util/builders/pg.ts
@@ -35,13 +35,13 @@ import {
   type TypeNameMapper,
   toGraphQLError,
 } from '../builders/common.ts';
-
 import {
   remapFromGraphQLArrayInput,
   remapFromGraphQLSingleInput,
   remapToGraphQLArrayOutput,
   remapToGraphQLSingleOutput,
 } from '../data-mappers/index.ts';
+import { generateAggregate, generateAggregateTypes } from './aggregates.ts';
 import type { CreatedResolver, Filters, TableNamedRelations, TableSelectArgs } from './types.ts';
 
 const generateSelectArray = (
@@ -522,6 +522,7 @@ export function generateSchemaData<
       typeName,
       listFieldName,
       singleFieldName,
+      aggregateFieldName,
       createArrayFieldName,
       createSingleFieldName,
       updateFieldName,
@@ -594,6 +595,15 @@ export function generateSchemaData<
       deleteFieldName,
       typeName,
     );
+    const aggregateType = generateAggregateTypes(schema[tableName] as PgTable, tableName, typeName);
+    const aggregateGenerated = generateAggregate(
+      db,
+      tableName,
+      schema[tableName] as PgTable,
+      typeName,
+      aggregateFieldName,
+      tableFilters,
+    );
 
     queries[selectArrGenerated.name] = {
       type: selectArrOutput,
@@ -604,6 +614,11 @@ export function generateSchemaData<
       type: selectSingleOutput,
       args: selectSingleGenerated.args,
       resolve: selectSingleGenerated.resolver,
+    };
+    queries[aggregateGenerated.name] = {
+      type: new GraphQLNonNull(aggregateType),
+      args: aggregateGenerated.args,
+      resolve: aggregateGenerated.resolver,
     };
     mutations[insertArrGenerated.name] = {
       type: arrTableItemOutput,
@@ -630,6 +645,7 @@ export function generateSchemaData<
     });
     outputs[selectSingleOutput.name] = selectSingleOutput;
     outputs[singleTableItemOutput.name] = singleTableItemOutput;
+    outputs[aggregateType.name] = aggregateType;
   }
 
   const fieldResolvers: Record<string, Record<string, any>> = {};

--- a/src/util/builders/pg.ts
+++ b/src/util/builders/pg.ts
@@ -26,10 +26,12 @@ import {
   getPrimaryKeyPropNamesFromConfig,
   prepareMutationRelationColumns,
   pruneNonEagerRelations,
+  type RelationAggregateFactory,
   type RelationFilterBase,
   type RelationResolverFactory,
   relationFilterCtx,
   runRelationalSelect,
+  type SelectionCtx,
   selectArrayArgs,
   selectSingleArgs,
   type TablesRelationalConfig,
@@ -43,7 +45,7 @@ import {
   remapToGraphQLArrayOutput,
   remapToGraphQLSingleOutput,
 } from '../data-mappers/index.ts';
-import { generateAggregate, generateAggregateTypes } from './aggregates.ts';
+import { createRelationAggregateFactory, generateAggregate, generateAggregateTypes } from './aggregates.ts';
 import type { CreatedResolver, Filters, TableNamedRelations, TableSelectArgs } from './types.ts';
 
 const generateSelectArray = (
@@ -95,6 +97,7 @@ const generateSelectArray = (
         const selectedColumnsSql = extractSelectedColumnsFromTreeSQLFormat<PgColumn>(
           parsedInfo.fieldsByTypeName[typeName]!,
           table,
+          { tableName, relationMap, tables },
         );
         let q = db.select(selectedColumnsSql).from(table);
         if (where) {
@@ -166,6 +169,7 @@ const generateSelectSingle = (
         const selectedColumnsSql = extractSelectedColumnsFromTreeSQLFormat<PgColumn>(
           parsedInfo.fieldsByTypeName[typeName]!,
           table,
+          { tableName, relationMap, tables },
         );
         let q = db.select(selectedColumnsSql).from(table);
         if (where) {
@@ -403,6 +407,7 @@ const generateDelete = (
   fieldName: string,
   typeName: string,
   filterCtx?: RelationFilterBase,
+  selectionCtx?: SelectionCtx,
 ): CreatedResolver => {
   const queryArgs = {
     where: {
@@ -423,6 +428,7 @@ const generateDelete = (
         const columns = extractSelectedColumnsFromTreeSQLFormat<PgColumn>(
           parsedInfo.fieldsByTypeName[typeName]!,
           table,
+          selectionCtx,
         );
 
         let query = db.delete(table);
@@ -498,7 +504,16 @@ export function generateSchemaData<
     orderTypeCache: new WeakMap(),
     filterTypeCache: new WeakMap(),
     listRelationFilterCache: new Map(),
+    aggregateTypeCache: new Map(),
   };
+
+  const relationAggregateFactory: RelationAggregateFactory = createRelationAggregateFactory(
+    db,
+    tables,
+    cacheCtx,
+    typeNameMapper,
+    filterCtx,
+  );
 
   const queries: ThunkObjMap<GraphQLFieldConfig<any, any>> = {};
   const mutations: ThunkObjMap<GraphQLFieldConfig<any, any>> = {};
@@ -517,6 +532,7 @@ export function generateSchemaData<
         prefixes.insert,
         prefixes.update,
         resolverFactory,
+        relationAggregateFactory,
       ),
     ]),
   );
@@ -609,8 +625,9 @@ export function generateSchemaData<
       deleteFieldName,
       typeName,
       filterCtx,
+      { tableName, relationMap: namedRelations, tables },
     );
-    const aggregateType = generateAggregateTypes(schema[tableName] as PgTable, tableName, typeName);
+    const aggregateType = generateAggregateTypes(schema[tableName] as PgTable, tableName, typeName, cacheCtx);
     const aggregateGenerated = generateAggregate(
       db,
       tableName,

--- a/src/util/builders/pg.ts
+++ b/src/util/builders/pg.ts
@@ -22,10 +22,12 @@ import {
   extractFilters,
   extractOrderBy,
   extractSelectedColumnsFromTreeSQLFormat,
+  generateDistinctEnum,
   generateTableTypes,
   getPrimaryKeyPropNamesFromConfig,
   prepareMutationRelationColumns,
   primaryKeyOrderExprs,
+  primaryKeyRestriction,
   pruneNonEagerRelations,
   type RelationAggregateFactory,
   type RelationFilterBase,
@@ -34,6 +36,7 @@ import {
   runRelationalSelect,
   type SelectionCtx,
   selectArrayArgs,
+  selectDistinctKeys,
   selectSingleArgs,
   type TablesRelationalConfig,
   type TypeCacheCtx,
@@ -66,10 +69,9 @@ const generateSelectArray = (
     | undefined;
   // Tables without relations won't have db.query support — fall back to basic select.
 
-  const queryArgs = selectArrayArgs(orderArgs, filterArgs);
-
   const table = tables[tableName]!;
   const pkNames = pgPrimaryKeyPropNames(table as PgTable);
+  const queryArgs = selectArrayArgs(orderArgs, filterArgs, generateDistinctEnum(table, typeName));
 
   return {
     name: fieldName,
@@ -91,32 +93,64 @@ const generateSelectArray = (
             single: false,
             filterCtx,
             pkNames,
+            db,
           });
         }
 
         // Fallback for tables without relational query builder support.
         // Use SQL column objects (not Record<string,true>) so db.select() receives valid expressions.
-        const { offset, limit, orderBy, where } = args;
+        const { offset, limit, orderBy, where, distinct } = args;
         const selectedColumnsSql = extractSelectedColumnsFromTreeSQLFormat<PgColumn>(
           parsedInfo.fieldsByTypeName[typeName]!,
           table,
           { tableName, relationMap, tables },
         );
+        const whereSql = where
+          ? extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName))
+          : undefined;
+
+        // `distinct` picks the surviving rows in its own pass; the main query is then narrowed
+        // to those primary keys and re-orders them the same way. See runRelationalSelect.
+        let distinctKeys: Record<string, any>[] | undefined;
+        if (distinct?.length) {
+          distinctKeys = await selectDistinctKeys({
+            db,
+            table,
+            tableName,
+            distinct,
+            pkNames,
+            where: whereSql,
+            orderBy,
+            limit,
+            offset,
+          });
+          if (!distinctKeys.length) {
+            return [];
+          }
+        }
+
         let q = db.select(selectedColumnsSql).from(table);
-        if (where) {
-          q = q.where(extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName))) as any;
+        if (distinctKeys) {
+          q = q.where(primaryKeyRestriction(table, pkNames, distinctKeys)) as any;
+        } else if (whereSql) {
+          q = q.where(whereSql) as any;
         }
         if (orderBy) {
-          q = q.orderBy(...extractOrderBy(table, orderBy)) as any;
-        } else if ((offset != null || limit != null) && pkNames.length) {
+          q = q.orderBy(
+            ...extractOrderBy(table, orderBy),
+            ...(distinctKeys ? primaryKeyOrderExprs(table, pkNames) : []),
+          ) as any;
+        } else if ((distinctKeys || offset != null || limit != null) && pkNames.length) {
           // See runRelationalSelect: an unordered slice is not stable between requests.
           q = q.orderBy(...primaryKeyOrderExprs(table, pkNames)) as any;
         }
-        if (offset) {
-          q = q.offset(offset) as any;
-        }
-        if (limit) {
-          q = q.limit(limit) as any;
+        if (!distinctKeys) {
+          if (offset) {
+            q = q.offset(offset) as any;
+          }
+          if (limit) {
+            q = q.limit(limit) as any;
+          }
         }
         return remapToGraphQLArrayOutput(await q, tableName, table, relationMap);
       } catch (e) {
@@ -169,6 +203,7 @@ const generateSelectSingle = (
             single: true,
             filterCtx,
             pkNames,
+            db,
           });
         }
 

--- a/src/util/builders/pg.ts
+++ b/src/util/builders/pg.ts
@@ -19,12 +19,16 @@ import {
   computeResolverFieldNames,
   createRelationResolverFactory,
   eagerLoadMutationRelations,
+  excludedColumnRef,
   extractFilters,
   extractOrderBy,
   extractSelectedColumnsFromTreeSQLFormat,
   generateDistinctEnum,
+  generateOnConflictInput,
   generateTableTypes,
   getPrimaryKeyPropNamesFromConfig,
+  getUniqueColumnSets,
+  type OnConflictArg,
   prepareMutationRelationColumns,
   primaryKeyOrderExprs,
   primaryKeyRestriction,
@@ -33,6 +37,7 @@ import {
   type RelationFilterBase,
   type RelationResolverFactory,
   relationFilterCtx,
+  resolveConflictPlan,
   resolveExecutor,
   resolveQueryExecutor,
   runRelationalSelect,
@@ -388,6 +393,107 @@ const generateInsertSingle = (
   };
 };
 
+/**
+ * `upsert<Table>` / `upsert<Table>Single` — an insert that resolves a unique-key conflict
+ * the way the request's `onConflict` argument asks, rather than failing.
+ *
+ * Shares the insert input: an upsert supplies a whole row, same as a create.
+ */
+const generateUpsert = (
+  db: PgAsyncDatabase<any, any, any>,
+  tableName: string,
+  table: PgTable,
+  tables: Record<string, Table>,
+  relationMap: Record<string, Record<string, TableNamedRelations>>,
+  baseType: GraphQLInputObjectType,
+  onConflictType: GraphQLInputObjectType,
+  uniqueSets: string[][],
+  fieldName: string,
+  typeName: string,
+  single: boolean,
+  typeNameMapper?: TypeNameMapper,
+  filterCtx?: RelationFilterBase,
+): CreatedResolver => {
+  const queryArgs: GraphQLFieldConfigArgumentMap = {
+    values: {
+      type: single ? new GraphQLNonNull(baseType) : new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(baseType))),
+    },
+    onConflict: {
+      type: onConflictType,
+      description: 'How a conflicting row is resolved. Defaults to overwriting it on the primary key.',
+    },
+  };
+
+  const pkNames = pgPrimaryKeyPropNames(table);
+
+  return {
+    name: fieldName,
+    resolver: async (
+      _source,
+      args: { values: Record<string, any> | Record<string, any>[]; onConflict?: OnConflictArg },
+      context,
+      info,
+    ) => {
+      try {
+        const input = single
+          ? [remapFromGraphQLSingleInput(args.values as Record<string, any>, table)]
+          : remapFromGraphQLArrayInput(args.values as Record<string, any>[], table);
+        if (!input.length) {
+          throw new GraphQLError('No values were provided!');
+        }
+
+        const parsedInfo = parseResolveInfo(info, { deep: true }) as ResolveTree;
+
+        const { columns, hasRelations, withParams } = prepareMutationRelationColumns({
+          relationMap,
+          tables,
+          tableName,
+          typeName,
+          typeNameMapper,
+          table,
+          pkNames,
+          parsedInfo,
+        });
+
+        const plan = resolveConflictPlan({
+          table,
+          values: input,
+          onConflict: args.onConflict,
+          pkNames,
+          uniqueSets,
+          excludedRef: excludedColumnRef,
+          withTarget: true,
+          buildWhere: (where) => extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName)),
+        });
+
+        const executor = resolveExecutor(db, context);
+        let query = executor.insert(table).values(input).returning(columns);
+        query =
+          plan.action === 'NOTHING'
+            ? (query.onConflictDoNothing(plan.target ? { target: plan.target } : undefined) as any)
+            : (query.onConflictDoUpdate({ target: plan.target!, set: plan.set, setWhere: plan.setWhere }) as any);
+
+        const result = await query;
+
+        if (single && !result[0]) {
+          return undefined;
+        }
+
+        const enriched = hasRelations
+          ? await eagerLoadMutationRelations(executor, tableName, result, pkNames, withParams)
+          : result;
+
+        return single
+          ? remapToGraphQLSingleOutput(enriched[0], tableName, table, relationMap)
+          : remapToGraphQLArrayOutput(enriched, tableName, table, relationMap);
+      } catch (e) {
+        throw toGraphQLError(e);
+      }
+    },
+    args: queryArgs,
+  };
+};
+
 const generateUpdate = (
   db: PgAsyncDatabase<any, any, any>,
   tableName: string,
@@ -612,6 +718,8 @@ export function generateSchemaData<
       aggregateFieldName,
       createArrayFieldName,
       createSingleFieldName,
+      upsertArrayFieldName,
+      upsertSingleFieldName,
       updateFieldName,
       deleteFieldName,
     } = computeResolverFieldNames(tableName, typeNameMapper, prefixes, suffixes);
@@ -667,6 +775,52 @@ export function generateSchemaData<
           typeName,
           typeNameMapper,
           conflictDoNothing,
+        )
+      : undefined;
+    // An upsert needs something to conflict on, so a table with no primary key and no
+    // unique constraint gets no upsert mutations rather than ones that always fail.
+    const uniqueSets = features.upsert ? getUniqueColumnSets(schema[tableName] as PgTable, getTableConfig) : [];
+    const onConflictInput = features.upsert
+      ? generateOnConflictInput({
+          table: schema[tableName] as PgTable,
+          typeName,
+          uniqueSets,
+          tableFilters,
+          withTarget: true,
+        })
+      : undefined;
+    const upsertArrGenerated = onConflictInput
+      ? generateUpsert(
+          db,
+          tableName,
+          schema[tableName] as PgTable,
+          tables,
+          eagerRelations,
+          insertInput,
+          onConflictInput,
+          uniqueSets,
+          upsertArrayFieldName,
+          typeName,
+          false,
+          typeNameMapper,
+          filterCtx,
+        )
+      : undefined;
+    const upsertSingleGenerated = onConflictInput
+      ? generateUpsert(
+          db,
+          tableName,
+          schema[tableName] as PgTable,
+          tables,
+          eagerRelations,
+          insertInput,
+          onConflictInput,
+          uniqueSets,
+          upsertSingleFieldName,
+          typeName,
+          true,
+          typeNameMapper,
+          filterCtx,
         )
       : undefined;
     const updateGenerated = features.update
@@ -742,6 +896,20 @@ export function generateSchemaData<
         resolve: insertSingleGenerated.resolver,
       };
     }
+    if (upsertArrGenerated) {
+      mutations[upsertArrGenerated.name] = {
+        type: arrTableItemOutput,
+        args: upsertArrGenerated.args,
+        resolve: upsertArrGenerated.resolver,
+      };
+    }
+    if (upsertSingleGenerated) {
+      mutations[upsertSingleGenerated.name] = {
+        type: singleTableItemOutput,
+        args: upsertSingleGenerated.args,
+        resolve: upsertSingleGenerated.resolver,
+      };
+    }
     if (updateGenerated) {
       mutations[updateGenerated.name] = {
         type: arrTableItemOutput,
@@ -759,7 +927,9 @@ export function generateSchemaData<
     // The insert/update inputs are still built (they type the mutations that survive) but
     // only reach the schema's type map when a mutation actually references them.
     const activeInputs = [
-      ...(features.insert ? [insertInput] : []),
+      // The insert input types the upsert mutations too, so either feature keeps it.
+      ...(features.insert || onConflictInput ? [insertInput] : []),
+      ...(onConflictInput ? [onConflictInput] : []),
       ...(features.update ? [updateInput] : []),
       tableFilters,
       tableOrder,

--- a/src/util/builders/sqlite.ts
+++ b/src/util/builders/sqlite.ts
@@ -72,6 +72,7 @@ const generateSelectArray = (
   const queryArgs = selectArrayArgs(orderArgs, filterArgs);
 
   const table = tables[tableName]!;
+  const pkNames = sqlitePrimaryKeyPropNames(table as SQLiteTable);
 
   return {
     name: fieldName,
@@ -90,6 +91,7 @@ const generateSelectArray = (
           ...args,
           single: false,
           filterCtx,
+          pkNames,
         });
       } catch (e) {
         throw toGraphQLError(e);
@@ -123,6 +125,7 @@ const generateSelectSingle = (
   const queryArgs = selectSingleArgs(orderArgs, filterArgs);
 
   const table = tables[tableName]!;
+  const pkNames = sqlitePrimaryKeyPropNames(table as SQLiteTable);
 
   return {
     name: fieldName,
@@ -141,6 +144,7 @@ const generateSelectSingle = (
           ...args,
           single: true,
           filterCtx,
+          pkNames,
         });
       } catch (e) {
         throw toGraphQLError(e);

--- a/src/util/builders/sqlite.ts
+++ b/src/util/builders/sqlite.ts
@@ -35,13 +35,13 @@ import {
   type TypeNameMapper,
   toGraphQLError,
 } from '../builders/common.ts';
-
 import {
   remapFromGraphQLArrayInput,
   remapFromGraphQLSingleInput,
   remapToGraphQLArrayOutput,
   remapToGraphQLSingleOutput,
 } from '../data-mappers/index.ts';
+import { generateAggregate, generateAggregateTypes } from './aggregates.ts';
 import type { CreatedResolver, Filters, TableNamedRelations, TableSelectArgs } from './types.ts';
 
 const generateSelectArray = (
@@ -465,6 +465,7 @@ export const generateSchemaData = <
       typeName,
       listFieldName,
       singleFieldName,
+      aggregateFieldName,
       createArrayFieldName,
       createSingleFieldName,
       updateFieldName,
@@ -535,6 +536,15 @@ export const generateSchemaData = <
       deleteFieldName,
       typeName,
     );
+    const aggregateType = generateAggregateTypes(schema[tableName] as SQLiteTable, tableName, typeName);
+    const aggregateGenerated = generateAggregate(
+      db,
+      tableName,
+      schema[tableName] as SQLiteTable,
+      typeName,
+      aggregateFieldName,
+      tableFilters,
+    );
 
     queries[selectArrGenerated.name] = {
       type: selectArrOutput,
@@ -545,6 +555,11 @@ export const generateSchemaData = <
       type: selectSingleOutput,
       args: selectSingleGenerated.args,
       resolve: selectSingleGenerated.resolver,
+    };
+    queries[aggregateGenerated.name] = {
+      type: new GraphQLNonNull(aggregateType),
+      args: aggregateGenerated.args,
+      resolve: aggregateGenerated.resolver,
     };
     mutations[insertArrGenerated.name] = {
       type: arrTableItemOutput,
@@ -571,6 +586,7 @@ export const generateSchemaData = <
     });
     outputs[selectSingleOutput.name] = selectSingleOutput;
     outputs[singleTableItemOutput.name] = singleTableItemOutput;
+    outputs[aggregateType.name] = aggregateType;
   }
 
   const fieldResolvers: Record<string, Record<string, any>> = {};

--- a/src/util/builders/sqlite.ts
+++ b/src/util/builders/sqlite.ts
@@ -13,7 +13,7 @@ import {
 import type { ResolveTree } from 'graphql-parse-resolve-info';
 import { parseResolveInfo } from 'graphql-parse-resolve-info';
 
-import type { BuildSchemaConfig, GeneratedEntities, MakeRequired } from '../../types.ts';
+import type { GeneratedEntities } from '../../types.ts';
 import {
   attachTargetPrimaryKeys,
   buildNamedRelations,
@@ -31,6 +31,8 @@ import {
   type RelationFilterBase,
   type RelationResolverFactory,
   relationFilterCtx,
+  resolveExecutor,
+  resolveQueryExecutor,
   runRelationalSelect,
   type SelectionCtx,
   selectArrayArgs,
@@ -47,7 +49,13 @@ import {
   remapToGraphQLSingleOutput,
 } from '../data-mappers/index.ts';
 import { createRelationAggregateFactory, generateAggregate, generateAggregateTypes } from './aggregates.ts';
-import type { CreatedResolver, Filters, TableNamedRelations, TableSelectArgs } from './types.ts';
+import type {
+  CreatedResolver,
+  Filters,
+  SchemaGeneratorOptions,
+  TableNamedRelations,
+  TableSelectArgs,
+} from './types.ts';
 
 const generateSelectArray = (
   db: BaseSQLiteDatabase<any, any, any, any>,
@@ -60,6 +68,7 @@ const generateSelectArray = (
   typeName: string,
   typeNameMapper?: TypeNameMapper,
   filterCtx?: RelationFilterBase,
+  distinctEnabled: boolean = true,
 ): CreatedResolver => {
   const queryBase = db.query[tableName as keyof typeof db.query] as unknown as
     | RelationalQueryBuilder<any, any, any>
@@ -72,15 +81,20 @@ const generateSelectArray = (
 
   const table = tables[tableName]!;
   const pkNames = sqlitePrimaryKeyPropNames(table as SQLiteTable);
-  const queryArgs = selectArrayArgs(orderArgs, filterArgs, generateDistinctEnum(table, typeName));
+  const queryArgs = selectArrayArgs(
+    orderArgs,
+    filterArgs,
+    distinctEnabled ? generateDistinctEnum(table, typeName) : undefined,
+  );
 
   return {
     name: fieldName,
-    resolver: async (_source: any, args: Partial<TableSelectArgs>, _context: any, info: GraphQLResolveInfo) => {
+    resolver: async (_source: any, args: Partial<TableSelectArgs>, context: any, info: GraphQLResolveInfo) => {
       try {
         const parsedInfo = parseResolveInfo(info, { deep: true }) as ResolveTree;
+        const { executor, queryBase: requestQueryBase } = resolveQueryExecutor(db, context, tableName, queryBase);
         return await runRelationalSelect({
-          queryBase,
+          queryBase: requestQueryBase,
           tables,
           tableName,
           table,
@@ -92,7 +106,7 @@ const generateSelectArray = (
           single: false,
           filterCtx,
           pkNames,
-          db,
+          db: executor,
         });
       } catch (e) {
         throw toGraphQLError(e);
@@ -130,11 +144,12 @@ const generateSelectSingle = (
 
   return {
     name: fieldName,
-    resolver: async (_source, args: Partial<TableSelectArgs>, _context, info) => {
+    resolver: async (_source, args: Partial<TableSelectArgs>, context, info) => {
       try {
         const parsedInfo = parseResolveInfo(info, { deep: true }) as ResolveTree;
+        const { executor, queryBase: requestQueryBase } = resolveQueryExecutor(db, context, tableName, queryBase);
         return await runRelationalSelect({
-          queryBase,
+          queryBase: requestQueryBase,
           tables,
           tableName,
           table,
@@ -146,7 +161,7 @@ const generateSelectSingle = (
           single: true,
           filterCtx,
           pkNames,
-          db,
+          db: executor,
         });
       } catch (e) {
         throw toGraphQLError(e);
@@ -170,6 +185,7 @@ const generateInsertArray = (
   fieldName: string,
   typeName: string,
   typeNameMapper?: TypeNameMapper,
+  conflictDoNothing: boolean = false,
 ): CreatedResolver => {
   const queryArgs: GraphQLFieldConfigArgumentMap = {
     values: {
@@ -183,7 +199,7 @@ const generateInsertArray = (
 
   return {
     name: fieldName,
-    resolver: async (_source, args: { values: Record<string, any>[] }, _context, info) => {
+    resolver: async (_source, args: { values: Record<string, any>[] }, context, info) => {
       try {
         const input = remapFromGraphQLArrayInput(args.values, table);
         if (!input.length) {
@@ -205,10 +221,15 @@ const generateInsertArray = (
           parsedInfo,
         });
 
-        const result = await db.insert(table).values(input).returning(columns).onConflictDoNothing();
+        const executor = resolveExecutor(db, context);
+        let query = executor.insert(table).values(input).returning(columns);
+        if (conflictDoNothing) {
+          query = query.onConflictDoNothing() as any;
+        }
+        const result = await query;
 
         const enriched = hasRelations
-          ? await eagerLoadMutationRelations(db, tableName, result, pkNames, withParams)
+          ? await eagerLoadMutationRelations(executor, tableName, result, pkNames, withParams)
           : result;
 
         return remapToGraphQLArrayOutput(enriched, tableName, table, relationMap);
@@ -230,6 +251,7 @@ const generateInsertSingle = (
   fieldName: string,
   typeName: string,
   typeNameMapper?: TypeNameMapper,
+  conflictDoNothing: boolean = false,
 ): CreatedResolver => {
   const queryArgs: GraphQLFieldConfigArgumentMap = {
     values: {
@@ -242,7 +264,7 @@ const generateInsertSingle = (
 
   return {
     name: fieldName,
-    resolver: async (_source, args: { values: Record<string, any> }, _context, info) => {
+    resolver: async (_source, args: { values: Record<string, any> }, context, info) => {
       try {
         const input = remapFromGraphQLSingleInput(args.values, table);
 
@@ -260,14 +282,19 @@ const generateInsertSingle = (
           pkNames,
           parsedInfo,
         });
-        const result = await db.insert(table).values(input).returning(columns).onConflictDoNothing();
+        const executor = resolveExecutor(db, context);
+        let query = executor.insert(table).values(input).returning(columns);
+        if (conflictDoNothing) {
+          query = query.onConflictDoNothing() as any;
+        }
+        const result = await query;
 
         if (!result[0]) {
           return undefined;
         }
 
         const enriched = hasRelations
-          ? await eagerLoadMutationRelations(db, tableName, result, pkNames, withParams)
+          ? await eagerLoadMutationRelations(executor, tableName, result, pkNames, withParams)
           : result;
 
         return remapToGraphQLSingleOutput(enriched[0], tableName, table, relationMap);
@@ -306,7 +333,7 @@ const generateUpdate = (
 
   return {
     name: fieldName,
-    resolver: async (_source, args: { where?: Filters<Table>; set: Record<string, any> }, _context, info) => {
+    resolver: async (_source, args: { where?: Filters<Table>; set: Record<string, any> }, context, info) => {
       try {
         const { where, set } = args;
 
@@ -330,7 +357,8 @@ const generateUpdate = (
           throw new GraphQLError('Unable to update with no values specified!');
         }
 
-        let query = db.update(table).set(input);
+        const executor = resolveExecutor(db, context);
+        let query = executor.update(table).set(input);
         if (where) {
           const filters = extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName));
           query = query.where(filters) as any;
@@ -341,7 +369,7 @@ const generateUpdate = (
         const result = await query;
 
         const enriched = hasRelations
-          ? await eagerLoadMutationRelations(db, tableName, result, pkNames, withParams)
+          ? await eagerLoadMutationRelations(executor, tableName, result, pkNames, withParams)
           : result;
 
         return remapToGraphQLArrayOutput(enriched, tableName, table, relationMap);
@@ -371,7 +399,7 @@ const generateDelete = (
 
   return {
     name: fieldName,
-    resolver: async (_source, args: { where?: Filters<Table> }, _context, info) => {
+    resolver: async (_source, args: { where?: Filters<Table> }, context, info) => {
       try {
         const { where } = args;
 
@@ -385,7 +413,8 @@ const generateDelete = (
           selectionCtx,
         );
 
-        let query = db.delete(table);
+        const executor = resolveExecutor(db, context);
+        let query = executor.delete(table);
         if (where) {
           const filters = extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName));
           query = query.where(filters) as any;
@@ -411,12 +440,10 @@ export const generateSchemaData = <
   db: TDrizzleInstance,
   schema: TSchema,
   relations: TablesRelationalConfig,
-  relationsDepthLimit: number | undefined,
-  prefixes: MakeRequired<MakeRequired<BuildSchemaConfig>['prefixes']>,
-  suffixes: MakeRequired<MakeRequired<BuildSchemaConfig>['suffixes']>,
-  typeNameMapper?: TypeNameMapper,
-  shouldEagerLoad: (tableName: string, relationName: string) => boolean = () => true,
+  options: SchemaGeneratorOptions,
 ): GeneratedEntities<TDrizzleInstance, TSchema> => {
+  const { relationsDepthLimit, prefixes, suffixes, conflictDoNothing, typeNameMapper, shouldEagerLoad, features } =
+    options;
   const rawSchema = schema;
   const schemaEntries = Object.entries(rawSchema);
 
@@ -455,13 +482,11 @@ export const generateSchemaData = <
     aggregateTypeCache: new Map(),
   };
 
-  const relationAggregateFactory: RelationAggregateFactory = createRelationAggregateFactory(
-    db,
-    tables,
-    cacheCtx,
-    typeNameMapper,
-    filterCtx,
-  );
+  // Left undefined when the feature is off — generateTableTypes then emits no
+  // `${relation}Aggregate` fields at all.
+  const relationAggregateFactory: RelationAggregateFactory | undefined = features.relationAggregates
+    ? createRelationAggregateFactory(db, tables, cacheCtx, typeNameMapper, filterCtx)
+    : undefined;
 
   const queries: ThunkObjMap<GraphQLFieldConfig<any, any>> = {};
   const mutations: ThunkObjMap<GraphQLFieldConfig<any, any>> = {};
@@ -514,6 +539,7 @@ export const generateSchemaData = <
       typeName,
       typeNameMapper,
       filterCtx,
+      features.distinct,
     );
     const selectSingleGenerated = generateSelectSingle(
       db,
@@ -527,61 +553,75 @@ export const generateSchemaData = <
       typeNameMapper,
       filterCtx,
     );
-    const insertArrGenerated = generateInsertArray(
-      db,
-      tableName,
-      schema[tableName] as SQLiteTable,
-      tables,
-      eagerRelations,
-      insertInput,
-      createArrayFieldName,
-      typeName,
-      typeNameMapper,
-    );
-    const insertSingleGenerated = generateInsertSingle(
-      db,
-      tableName,
-      schema[tableName] as SQLiteTable,
-      tables,
-      eagerRelations,
-      insertInput,
-      createSingleFieldName,
-      typeName,
-      typeNameMapper,
-    );
-    const updateGenerated = generateUpdate(
-      db,
-      tableName,
-      schema[tableName] as SQLiteTable,
-      tables,
-      eagerRelations,
-      updateInput,
-      tableFilters,
-      updateFieldName,
-      typeName,
-      typeNameMapper,
-      filterCtx,
-    );
-    const deleteGenerated = generateDelete(
-      db,
-      tableName,
-      schema[tableName] as SQLiteTable,
-      tableFilters,
-      deleteFieldName,
-      typeName,
-      filterCtx,
-      { tableName, relationMap: namedRelations, tables },
-    );
-    const aggregateType = generateAggregateTypes(schema[tableName] as SQLiteTable, tableName, typeName, cacheCtx);
-    const aggregateGenerated = generateAggregate(
-      db,
-      tableName,
-      schema[tableName] as SQLiteTable,
-      typeName,
-      aggregateFieldName,
-      tableFilters,
-      filterCtx,
-    );
+    const insertArrGenerated = features.insert
+      ? generateInsertArray(
+          db,
+          tableName,
+          schema[tableName] as SQLiteTable,
+          tables,
+          eagerRelations,
+          insertInput,
+          createArrayFieldName,
+          typeName,
+          typeNameMapper,
+          conflictDoNothing,
+        )
+      : undefined;
+    const insertSingleGenerated = features.insert
+      ? generateInsertSingle(
+          db,
+          tableName,
+          schema[tableName] as SQLiteTable,
+          tables,
+          eagerRelations,
+          insertInput,
+          createSingleFieldName,
+          typeName,
+          typeNameMapper,
+          conflictDoNothing,
+        )
+      : undefined;
+    const updateGenerated = features.update
+      ? generateUpdate(
+          db,
+          tableName,
+          schema[tableName] as SQLiteTable,
+          tables,
+          eagerRelations,
+          updateInput,
+          tableFilters,
+          updateFieldName,
+          typeName,
+          typeNameMapper,
+          filterCtx,
+        )
+      : undefined;
+    const deleteGenerated = features.delete
+      ? generateDelete(
+          db,
+          tableName,
+          schema[tableName] as SQLiteTable,
+          tableFilters,
+          deleteFieldName,
+          typeName,
+          filterCtx,
+          { tableName, relationMap: namedRelations, tables },
+        )
+      : undefined;
+    const aggregateType = features.aggregates
+      ? generateAggregateTypes(schema[tableName] as SQLiteTable, tableName, typeName, cacheCtx)
+      : undefined;
+    const aggregateGenerated = features.aggregates
+      ? generateAggregate(
+          db,
+          tableName,
+          schema[tableName] as SQLiteTable,
+          typeName,
+          aggregateFieldName,
+          tableFilters,
+          filterCtx,
+        )
+      : undefined;
 
     queries[selectArrGenerated.name] = {
       type: selectArrOutput,
@@ -593,37 +633,57 @@ export const generateSchemaData = <
       args: selectSingleGenerated.args,
       resolve: selectSingleGenerated.resolver,
     };
-    queries[aggregateGenerated.name] = {
-      type: new GraphQLNonNull(aggregateType),
-      args: aggregateGenerated.args,
-      resolve: aggregateGenerated.resolver,
-    };
-    mutations[insertArrGenerated.name] = {
-      type: arrTableItemOutput,
-      args: insertArrGenerated.args,
-      resolve: insertArrGenerated.resolver,
-    };
-    mutations[insertSingleGenerated.name] = {
-      type: singleTableItemOutput,
-      args: insertSingleGenerated.args,
-      resolve: insertSingleGenerated.resolver,
-    };
-    mutations[updateGenerated.name] = {
-      type: arrTableItemOutput,
-      args: updateGenerated.args,
-      resolve: updateGenerated.resolver,
-    };
-    mutations[deleteGenerated.name] = {
-      type: arrTableItemOutput,
-      args: deleteGenerated.args,
-      resolve: deleteGenerated.resolver,
-    };
-    [insertInput, updateInput, tableFilters, tableOrder].forEach((e) => {
+    if (aggregateGenerated && aggregateType) {
+      queries[aggregateGenerated.name] = {
+        type: new GraphQLNonNull(aggregateType),
+        args: aggregateGenerated.args,
+        resolve: aggregateGenerated.resolver,
+      };
+    }
+    if (insertArrGenerated) {
+      mutations[insertArrGenerated.name] = {
+        type: arrTableItemOutput,
+        args: insertArrGenerated.args,
+        resolve: insertArrGenerated.resolver,
+      };
+    }
+    if (insertSingleGenerated) {
+      mutations[insertSingleGenerated.name] = {
+        type: singleTableItemOutput,
+        args: insertSingleGenerated.args,
+        resolve: insertSingleGenerated.resolver,
+      };
+    }
+    if (updateGenerated) {
+      mutations[updateGenerated.name] = {
+        type: arrTableItemOutput,
+        args: updateGenerated.args,
+        resolve: updateGenerated.resolver,
+      };
+    }
+    if (deleteGenerated) {
+      mutations[deleteGenerated.name] = {
+        type: arrTableItemOutput,
+        args: deleteGenerated.args,
+        resolve: deleteGenerated.resolver,
+      };
+    }
+    // The insert/update inputs are still built (they type the mutations that survive) but
+    // only reach the schema's type map when a mutation actually references them.
+    const activeInputs = [
+      ...(features.insert ? [insertInput] : []),
+      ...(features.update ? [updateInput] : []),
+      tableFilters,
+      tableOrder,
+    ];
+    activeInputs.forEach((e) => {
       inputs[e.name] = e;
     });
     outputs[selectSingleOutput.name] = selectSingleOutput;
     outputs[singleTableItemOutput.name] = singleTableItemOutput;
-    outputs[aggregateType.name] = aggregateType;
+    if (aggregateType) {
+      outputs[aggregateType.name] = aggregateType;
+    }
   }
 
   const fieldResolvers: Record<string, Record<string, any>> = {};

--- a/src/util/builders/sqlite.ts
+++ b/src/util/builders/sqlite.ts
@@ -26,10 +26,12 @@ import {
   getPrimaryKeyPropNamesFromConfig,
   prepareMutationRelationColumns,
   pruneNonEagerRelations,
+  type RelationAggregateFactory,
   type RelationFilterBase,
   type RelationResolverFactory,
   relationFilterCtx,
   runRelationalSelect,
+  type SelectionCtx,
   selectArrayArgs,
   selectSingleArgs,
   type TablesRelationalConfig,
@@ -43,7 +45,7 @@ import {
   remapToGraphQLArrayOutput,
   remapToGraphQLSingleOutput,
 } from '../data-mappers/index.ts';
-import { generateAggregate, generateAggregateTypes } from './aggregates.ts';
+import { createRelationAggregateFactory, generateAggregate, generateAggregateTypes } from './aggregates.ts';
 import type { CreatedResolver, Filters, TableNamedRelations, TableSelectArgs } from './types.ts';
 
 const generateSelectArray = (
@@ -353,6 +355,7 @@ const generateDelete = (
   fieldName: string,
   typeName: string,
   filterCtx?: RelationFilterBase,
+  selectionCtx?: SelectionCtx,
 ): CreatedResolver => {
   const queryArgs = {
     where: {
@@ -373,6 +376,7 @@ const generateDelete = (
         const columns = extractSelectedColumnsFromTreeSQLFormat<SQLiteColumn>(
           parsedInfo.fieldsByTypeName[typeName]!,
           table,
+          selectionCtx,
         );
 
         let query = db.delete(table);
@@ -442,7 +446,16 @@ export const generateSchemaData = <
     orderTypeCache: new WeakMap(),
     filterTypeCache: new WeakMap(),
     listRelationFilterCache: new Map(),
+    aggregateTypeCache: new Map(),
   };
+
+  const relationAggregateFactory: RelationAggregateFactory = createRelationAggregateFactory(
+    db,
+    tables,
+    cacheCtx,
+    typeNameMapper,
+    filterCtx,
+  );
 
   const queries: ThunkObjMap<GraphQLFieldConfig<any, any>> = {};
   const mutations: ThunkObjMap<GraphQLFieldConfig<any, any>> = {};
@@ -460,6 +473,7 @@ export const generateSchemaData = <
         prefixes.insert,
         prefixes.update,
         resolverFactory,
+        relationAggregateFactory,
       ),
     ]),
   );
@@ -550,8 +564,9 @@ export const generateSchemaData = <
       deleteFieldName,
       typeName,
       filterCtx,
+      { tableName, relationMap: namedRelations, tables },
     );
-    const aggregateType = generateAggregateTypes(schema[tableName] as SQLiteTable, tableName, typeName);
+    const aggregateType = generateAggregateTypes(schema[tableName] as SQLiteTable, tableName, typeName, cacheCtx);
     const aggregateGenerated = generateAggregate(
       db,
       tableName,

--- a/src/util/builders/sqlite.ts
+++ b/src/util/builders/sqlite.ts
@@ -26,7 +26,9 @@ import {
   getPrimaryKeyPropNamesFromConfig,
   prepareMutationRelationColumns,
   pruneNonEagerRelations,
+  type RelationFilterBase,
   type RelationResolverFactory,
+  relationFilterCtx,
   runRelationalSelect,
   selectArrayArgs,
   selectSingleArgs,
@@ -54,6 +56,7 @@ const generateSelectArray = (
   fieldName: string,
   typeName: string,
   typeNameMapper?: TypeNameMapper,
+  filterCtx?: RelationFilterBase,
 ): CreatedResolver => {
   const queryBase = db.query[tableName as keyof typeof db.query] as unknown as
     | RelationalQueryBuilder<any, any, any>
@@ -84,6 +87,7 @@ const generateSelectArray = (
           parsedInfo,
           ...args,
           single: false,
+          filterCtx,
         });
       } catch (e) {
         throw toGraphQLError(e);
@@ -103,6 +107,7 @@ const generateSelectSingle = (
   fieldName: string,
   typeName: string,
   typeNameMapper?: TypeNameMapper,
+  filterCtx?: RelationFilterBase,
 ): CreatedResolver => {
   const queryBase = db.query[tableName as keyof typeof db.query] as unknown as
     | RelationalQueryBuilder<any, any, any>
@@ -133,6 +138,7 @@ const generateSelectSingle = (
           parsedInfo,
           ...args,
           single: true,
+          filterCtx,
         });
       } catch (e) {
         throw toGraphQLError(e);
@@ -276,6 +282,7 @@ const generateUpdate = (
   fieldName: string,
   typeName: string,
   typeNameMapper?: TypeNameMapper,
+  filterCtx?: RelationFilterBase,
 ): CreatedResolver => {
   const queryArgs = {
     set: {
@@ -317,7 +324,7 @@ const generateUpdate = (
 
         let query = db.update(table).set(input);
         if (where) {
-          const filters = extractFilters(table, tableName, where);
+          const filters = extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName));
           query = query.where(filters) as any;
         }
 
@@ -345,6 +352,7 @@ const generateDelete = (
   filterArgs: GraphQLInputObjectType,
   fieldName: string,
   typeName: string,
+  filterCtx?: RelationFilterBase,
 ): CreatedResolver => {
   const queryArgs = {
     where: {
@@ -369,7 +377,7 @@ const generateDelete = (
 
         let query = db.delete(table);
         if (where) {
-          const filters = extractFilters(table, tableName, where);
+          const filters = extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName));
           query = query.where(filters) as any;
         }
 
@@ -419,7 +427,9 @@ export const generateSchemaData = <
   // Pruned map for query/mutation resolvers' `with:`; type generation keeps the full map.
   const eagerRelations = pruneNonEagerRelations(namedRelations, shouldEagerLoad);
 
-  const resolverFactory: RelationResolverFactory = createRelationResolverFactory(db, tables);
+  const filterCtx: RelationFilterBase = { tables, relationMap: namedRelations };
+
+  const resolverFactory: RelationResolverFactory = createRelationResolverFactory(db, tables, filterCtx);
 
   // Fresh cache per generateSchemaData call — prevents type name collisions
   // when buildSchema() is called multiple times.
@@ -431,6 +441,7 @@ export const generateSchemaData = <
     relationTypeCache: new Map(),
     orderTypeCache: new WeakMap(),
     filterTypeCache: new WeakMap(),
+    listRelationFilterCache: new Map(),
   };
 
   const queries: ThunkObjMap<GraphQLFieldConfig<any, any>> = {};
@@ -482,6 +493,7 @@ export const generateSchemaData = <
       listFieldName,
       typeName,
       typeNameMapper,
+      filterCtx,
     );
     const selectSingleGenerated = generateSelectSingle(
       db,
@@ -493,6 +505,7 @@ export const generateSchemaData = <
       singleFieldName,
       typeName,
       typeNameMapper,
+      filterCtx,
     );
     const insertArrGenerated = generateInsertArray(
       db,
@@ -527,6 +540,7 @@ export const generateSchemaData = <
       updateFieldName,
       typeName,
       typeNameMapper,
+      filterCtx,
     );
     const deleteGenerated = generateDelete(
       db,
@@ -535,6 +549,7 @@ export const generateSchemaData = <
       tableFilters,
       deleteFieldName,
       typeName,
+      filterCtx,
     );
     const aggregateType = generateAggregateTypes(schema[tableName] as SQLiteTable, tableName, typeName);
     const aggregateGenerated = generateAggregate(
@@ -544,6 +559,7 @@ export const generateSchemaData = <
       typeName,
       aggregateFieldName,
       tableFilters,
+      filterCtx,
     );
 
     queries[selectArrGenerated.name] = {

--- a/src/util/builders/sqlite.ts
+++ b/src/util/builders/sqlite.ts
@@ -20,17 +20,22 @@ import {
   computeResolverFieldNames,
   createRelationResolverFactory,
   eagerLoadMutationRelations,
+  excludedColumnRef,
   extractFilters,
   extractSelectedColumnsFromTreeSQLFormat,
   generateDistinctEnum,
+  generateOnConflictInput,
   generateTableTypes,
   getPrimaryKeyPropNamesFromConfig,
+  getUniqueColumnSets,
+  type OnConflictArg,
   prepareMutationRelationColumns,
   pruneNonEagerRelations,
   type RelationAggregateFactory,
   type RelationFilterBase,
   type RelationResolverFactory,
   relationFilterCtx,
+  resolveConflictPlan,
   resolveExecutor,
   resolveQueryExecutor,
   runRelationalSelect,
@@ -306,6 +311,107 @@ const generateInsertSingle = (
   };
 };
 
+/**
+ * `upsert<Table>` / `upsert<Table>Single` — an insert that resolves a unique-key conflict
+ * the way the request's `onConflict` argument asks, rather than failing.
+ *
+ * Shares the insert input: an upsert supplies a whole row, same as a create.
+ */
+const generateUpsert = (
+  db: BaseSQLiteDatabase<any, any, any, any>,
+  tableName: string,
+  table: SQLiteTable,
+  tables: Record<string, Table>,
+  relationMap: Record<string, Record<string, TableNamedRelations>>,
+  baseType: GraphQLInputObjectType,
+  onConflictType: GraphQLInputObjectType,
+  uniqueSets: string[][],
+  fieldName: string,
+  typeName: string,
+  single: boolean,
+  typeNameMapper?: TypeNameMapper,
+  filterCtx?: RelationFilterBase,
+): CreatedResolver => {
+  const queryArgs: GraphQLFieldConfigArgumentMap = {
+    values: {
+      type: single ? new GraphQLNonNull(baseType) : new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(baseType))),
+    },
+    onConflict: {
+      type: onConflictType,
+      description: 'How a conflicting row is resolved. Defaults to overwriting it on the primary key.',
+    },
+  };
+
+  const pkNames = sqlitePrimaryKeyPropNames(table);
+
+  return {
+    name: fieldName,
+    resolver: async (
+      _source,
+      args: { values: Record<string, any> | Record<string, any>[]; onConflict?: OnConflictArg },
+      context,
+      info,
+    ) => {
+      try {
+        const input = single
+          ? [remapFromGraphQLSingleInput(args.values as Record<string, any>, table)]
+          : remapFromGraphQLArrayInput(args.values as Record<string, any>[], table);
+        if (!input.length) {
+          throw new GraphQLError('No values were provided!');
+        }
+
+        const parsedInfo = parseResolveInfo(info, { deep: true }) as ResolveTree;
+
+        const { columns, hasRelations, withParams } = prepareMutationRelationColumns({
+          relationMap,
+          tables,
+          tableName,
+          typeName,
+          typeNameMapper,
+          table,
+          pkNames,
+          parsedInfo,
+        });
+
+        const plan = resolveConflictPlan({
+          table,
+          values: input,
+          onConflict: args.onConflict,
+          pkNames,
+          uniqueSets,
+          excludedRef: excludedColumnRef,
+          withTarget: true,
+          buildWhere: (where) => extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName)),
+        });
+
+        const executor = resolveExecutor(db, context);
+        let query = executor.insert(table).values(input).returning(columns);
+        query =
+          plan.action === 'NOTHING'
+            ? (query.onConflictDoNothing(plan.target ? { target: plan.target } : undefined) as any)
+            : (query.onConflictDoUpdate({ target: plan.target!, set: plan.set, setWhere: plan.setWhere }) as any);
+
+        const result = await query;
+
+        if (single && !result[0]) {
+          return undefined;
+        }
+
+        const enriched = hasRelations
+          ? await eagerLoadMutationRelations(executor, tableName, result, pkNames, withParams)
+          : result;
+
+        return single
+          ? remapToGraphQLSingleOutput(enriched[0], tableName, table, relationMap)
+          : remapToGraphQLArrayOutput(enriched, tableName, table, relationMap);
+      } catch (e) {
+        throw toGraphQLError(e);
+      }
+    },
+    args: queryArgs,
+  };
+};
+
 const generateUpdate = (
   db: BaseSQLiteDatabase<any, any, any, any>,
   tableName: string,
@@ -524,6 +630,8 @@ export const generateSchemaData = <
       aggregateFieldName,
       createArrayFieldName,
       createSingleFieldName,
+      upsertArrayFieldName,
+      upsertSingleFieldName,
       updateFieldName,
       deleteFieldName,
     } = computeResolverFieldNames(tableName, typeNameMapper, prefixes, suffixes);
@@ -579,6 +687,52 @@ export const generateSchemaData = <
           typeName,
           typeNameMapper,
           conflictDoNothing,
+        )
+      : undefined;
+    // An upsert needs something to conflict on, so a table with no primary key and no
+    // unique constraint gets no upsert mutations rather than ones that always fail.
+    const uniqueSets = features.upsert ? getUniqueColumnSets(schema[tableName] as SQLiteTable, getTableConfig) : [];
+    const onConflictInput = features.upsert
+      ? generateOnConflictInput({
+          table: schema[tableName] as SQLiteTable,
+          typeName,
+          uniqueSets,
+          tableFilters,
+          withTarget: true,
+        })
+      : undefined;
+    const upsertArrGenerated = onConflictInput
+      ? generateUpsert(
+          db,
+          tableName,
+          schema[tableName] as SQLiteTable,
+          tables,
+          eagerRelations,
+          insertInput,
+          onConflictInput,
+          uniqueSets,
+          upsertArrayFieldName,
+          typeName,
+          false,
+          typeNameMapper,
+          filterCtx,
+        )
+      : undefined;
+    const upsertSingleGenerated = onConflictInput
+      ? generateUpsert(
+          db,
+          tableName,
+          schema[tableName] as SQLiteTable,
+          tables,
+          eagerRelations,
+          insertInput,
+          onConflictInput,
+          uniqueSets,
+          upsertSingleFieldName,
+          typeName,
+          true,
+          typeNameMapper,
+          filterCtx,
         )
       : undefined;
     const updateGenerated = features.update
@@ -654,6 +808,20 @@ export const generateSchemaData = <
         resolve: insertSingleGenerated.resolver,
       };
     }
+    if (upsertArrGenerated) {
+      mutations[upsertArrGenerated.name] = {
+        type: arrTableItemOutput,
+        args: upsertArrGenerated.args,
+        resolve: upsertArrGenerated.resolver,
+      };
+    }
+    if (upsertSingleGenerated) {
+      mutations[upsertSingleGenerated.name] = {
+        type: singleTableItemOutput,
+        args: upsertSingleGenerated.args,
+        resolve: upsertSingleGenerated.resolver,
+      };
+    }
     if (updateGenerated) {
       mutations[updateGenerated.name] = {
         type: arrTableItemOutput,
@@ -671,7 +839,9 @@ export const generateSchemaData = <
     // The insert/update inputs are still built (they type the mutations that survive) but
     // only reach the schema's type map when a mutation actually references them.
     const activeInputs = [
-      ...(features.insert ? [insertInput] : []),
+      // The insert input types the upsert mutations too, so either feature keeps it.
+      ...(features.insert || onConflictInput ? [insertInput] : []),
+      ...(onConflictInput ? [onConflictInput] : []),
       ...(features.update ? [updateInput] : []),
       tableFilters,
       tableOrder,

--- a/src/util/builders/sqlite.ts
+++ b/src/util/builders/sqlite.ts
@@ -22,6 +22,7 @@ import {
   eagerLoadMutationRelations,
   extractFilters,
   extractSelectedColumnsFromTreeSQLFormat,
+  generateDistinctEnum,
   generateTableTypes,
   getPrimaryKeyPropNamesFromConfig,
   prepareMutationRelationColumns,
@@ -69,10 +70,9 @@ const generateSelectArray = (
     );
   }
 
-  const queryArgs = selectArrayArgs(orderArgs, filterArgs);
-
   const table = tables[tableName]!;
   const pkNames = sqlitePrimaryKeyPropNames(table as SQLiteTable);
+  const queryArgs = selectArrayArgs(orderArgs, filterArgs, generateDistinctEnum(table, typeName));
 
   return {
     name: fieldName,
@@ -92,6 +92,7 @@ const generateSelectArray = (
           single: false,
           filterCtx,
           pkNames,
+          db,
         });
       } catch (e) {
         throw toGraphQLError(e);
@@ -145,6 +146,7 @@ const generateSelectSingle = (
           single: true,
           filterCtx,
           pkNames,
+          db,
         });
       } catch (e) {
         throw toGraphQLError(e);

--- a/src/util/builders/types.ts
+++ b/src/util/builders/types.ts
@@ -31,6 +31,7 @@ export type TableSelectArgs = {
   limit: number;
   where: Filters<Table>;
   orderBy: OrderByArgs<Table>;
+  distinct: string[];
 };
 
 export type ProcessedTableSelectArgs = {

--- a/src/util/builders/types.ts
+++ b/src/util/builders/types.ts
@@ -15,6 +15,33 @@ import type { ConvertedColumn, ConvertedRelationColumnWithArgs } from '../type-c
 //   ConvertedRelationColumnWithArgs,
 // } from "../type-converter/index.ts";
 
+/**
+ * Which generated features a build includes, after `BuildSchemaConfig.features` has been
+ * merged with the defaults. Every flag is resolved — the builders never see `undefined`.
+ */
+export type GeneratorFeatures = {
+  aggregates: boolean;
+  relationAggregates: boolean;
+  distinct: boolean;
+  insert: boolean;
+  update: boolean;
+  delete: boolean;
+};
+
+/**
+ * Everything a dialect generator needs beyond the database, schema and relations, which
+ * stay positional so their generic parameters still infer. Assembled by `buildSchema`.
+ */
+export type SchemaGeneratorOptions = {
+  relationsDepthLimit: number | undefined;
+  prefixes: { insert: string; update: string; delete: string };
+  suffixes: { list: string; single: string };
+  conflictDoNothing: boolean;
+  typeNameMapper?: (tableName: string) => { singular: string; plural: string } | undefined;
+  shouldEagerLoad: (tableName: string, relationName: string) => boolean;
+  features: GeneratorFeatures;
+};
+
 export type TableNamedRelations = {
   relation: Relation;
   targetTableName: string;

--- a/src/util/builders/types.ts
+++ b/src/util/builders/types.ts
@@ -26,6 +26,7 @@ export type GeneratorFeatures = {
   insert: boolean;
   update: boolean;
   delete: boolean;
+  upsert: boolean;
 };
 
 /**
@@ -34,7 +35,7 @@ export type GeneratorFeatures = {
  */
 export type SchemaGeneratorOptions = {
   relationsDepthLimit: number | undefined;
-  prefixes: { insert: string; update: string; delete: string };
+  prefixes: { insert: string; update: string; delete: string; upsert: string };
   suffixes: { list: string; single: string };
   conflictDoNothing: boolean;
   typeNameMapper?: (tableName: string) => { singular: string; plural: string } | undefined;

--- a/src/util/data-mappers/index.ts
+++ b/src/util/data-mappers/index.ts
@@ -3,6 +3,11 @@ import { type Column, getTableColumns, is, One, type Table } from 'drizzle-orm';
 import { GraphQLError } from 'graphql';
 import type { TableNamedRelations } from '../builders/index.ts';
 
+// drizzle-orm v1 uses compound dataType strings (e.g. "object json"), so inclusion rather
+// than equality. PgGeometryObject is stored as json but has its own object type.
+const isJsonColumn = (column: Column): boolean =>
+  ((column as any).dataType ?? '').includes('json') && (column as any).columnType !== 'PgGeometryObject';
+
 export const remapToGraphQLCore = (
   key: string,
   value: any,
@@ -41,6 +46,13 @@ export const remapToGraphQLCore = (
 
   // For non-relation fields, require a column definition.
   if (!column) {
+    return value;
+  }
+
+  // JSON columns are carried by the `JSON` scalar, which transports the parsed value as-is.
+  // This has to come before the array/object branches below, which would otherwise walk into
+  // the value and remap its contents as if they were column values.
+  if (isJsonColumn(column)) {
     return value;
   }
 
@@ -174,19 +186,12 @@ export const remapFromGraphQLCore = (value: any, column: Column, columnName: str
     }
   }
 
-  // JSON columns (SQLite: "object json", PG: "json").
+  // JSON columns (SQLite: "object json", PG: "json"). The `JSON` scalar has already parsed
+  // the literal, so the value goes to the driver untouched — parsing it again here would
+  // wrongly reject a JSON value that happens to be a string, like `"hello"`.
   // PgGeometryObject is already handled by the switch case below.
   if (dataType.includes('json') && (column as any).columnType !== 'PgGeometryObject') {
-    if (typeof value !== 'string') {
-      return value;
-    }
-    try {
-      return JSON.parse(value);
-    } catch (e) {
-      throw new GraphQLError(
-        `Invalid JSON in field '${columnName}':\n${e instanceof Error ? e.message : 'Unknown error'}`,
-      );
-    }
+    return value;
   }
 
   switch (dataType) {

--- a/src/util/scalars/index.ts
+++ b/src/util/scalars/index.ts
@@ -1,0 +1,52 @@
+import { GraphQLError, GraphQLScalarType, Kind } from 'graphql';
+import { GraphQLDate, GraphQLDateTime, GraphQLJSON, GraphQLUUID } from 'graphql-scalars';
+
+const asDecimalString = (value: unknown): string => {
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isInteger(value)) {
+      throw new GraphQLError(`BigInt cannot represent non-integer value: ${value}`);
+    }
+    if (!Number.isSafeInteger(value)) {
+      throw new GraphQLError(
+        `BigInt cannot represent the number ${value} without precision loss — pass it as a string instead`,
+      );
+    }
+    return String(value);
+  }
+
+  if (typeof value === 'string') {
+    if (!/^-?\d+$/.test(value)) {
+      throw new GraphQLError(`BigInt cannot represent non-integer value: "${value}"`);
+    }
+    return value;
+  }
+
+  throw new GraphQLError(`BigInt cannot represent value: ${JSON.stringify(value)}`);
+};
+
+/**
+ * A 64-bit integer. Always transported as a decimal string, in both directions, so no value
+ * is ever silently rounded by JSON's double-precision numbers. `graphql-scalars`' own
+ * `GraphQLBigInt` is deliberately not used: it emits numbers for safe integers and strings
+ * for everything else, so a client cannot know which it will get.
+ */
+export const GraphQLBigIntString = new GraphQLScalarType<string, string>({
+  name: 'BigInt',
+  description:
+    'A 64-bit integer, transported as a decimal string so that values beyond ' +
+    "JavaScript's safe integer range survive the round-trip intact.",
+  serialize: asDecimalString,
+  parseValue: asDecimalString,
+  parseLiteral: (ast) => {
+    if (ast.kind !== Kind.STRING && ast.kind !== Kind.INT) {
+      throw new GraphQLError(`BigInt cannot represent a ${ast.kind}`, { nodes: ast });
+    }
+    return asDecimalString(ast.value);
+  },
+});
+
+export { GraphQLDate, GraphQLDateTime, GraphQLJSON, GraphQLUUID };

--- a/src/util/type-converter/index.ts
+++ b/src/util/type-converter/index.ts
@@ -1,7 +1,7 @@
 import type { Column } from 'drizzle-orm';
 import { extractExtendedColumnType, is } from 'drizzle-orm';
 import { MySqlInt, MySqlSerial } from 'drizzle-orm/mysql-core';
-import { PgDate, PgDateString, PgInteger, PgSerial, PgTimestamp, PgTimestampString } from 'drizzle-orm/pg-core';
+import { PgDate, PgDateString, PgInteger, PgSerial, PgTimestamp, PgTimestampString, PgUUID } from 'drizzle-orm/pg-core';
 import { SQLiteInteger } from 'drizzle-orm/sqlite-core';
 import {
   GraphQLBoolean,
@@ -15,8 +15,8 @@ import {
   type GraphQLScalarType,
   GraphQLString,
 } from 'graphql';
-import { GraphQLDate, GraphQLDateTime } from 'graphql-scalars';
 import { capitalize } from '../case-ops/index.ts';
+import { GraphQLBigIntString, GraphQLDate, GraphQLDateTime, GraphQLJSON, GraphQLUUID } from '../scalars/index.ts';
 import type { ConvertedColumn } from './types.ts';
 
 const allowedNameChars = /^[a-zA-Z0-9_]+$/;
@@ -85,7 +85,7 @@ const columnToGraphQLCore = (
               type: new GraphQLList(new GraphQLNonNull(GraphQLInt)),
               description: 'Buffer',
             }
-          : { type: GraphQLString, description: 'JSON' };
+          : { type: GraphQLJSON, description: 'JSON' };
     case 'string':
       if (column.enumValues?.length) {
         return { type: generateEnumCached(column, columnName, tableName) };
@@ -93,6 +93,9 @@ const columnToGraphQLCore = (
 
       if (column instanceof PgTimestamp || column instanceof PgTimestampString) {
         return { type: GraphQLDateTime, description: 'DateTime' };
+      }
+      if (column instanceof PgUUID) {
+        return { type: GraphQLUUID, description: 'UUID' };
       }
       if (column instanceof PgDateString) {
         // For input, accept any string (drivers truncate ISO timestamps to date on write).
@@ -102,7 +105,7 @@ const columnToGraphQLCore = (
 
       return { type: GraphQLString, description: 'String' };
     case 'bigint':
-      return { type: GraphQLString, description: 'BigInt' };
+      return { type: GraphQLBigIntString, description: 'BigInt' };
     case 'number': {
       // integer().array() columns keep columnType=PgInteger but gain a `dimensions` property.
       // drizzle-orm's extractExtendedColumnType still returns 'number' for them, so we

--- a/tests/mysql.test.ts
+++ b/tests/mysql.test.ts
@@ -5,7 +5,7 @@ import { drizzle, type MySql2Database } from 'drizzle-orm/mysql2';
 import getPort from 'get-port';
 import {
   GraphQLInputObjectType,
-  type GraphQLList,
+  GraphQLList,
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLScalarType,
@@ -2766,6 +2766,11 @@ describe.sequential('Returned data tests', () => {
                         type: z.instanceof(GraphQLInputObjectType),
                       })
                       .strict(),
+                    distinct: z
+                      .object({
+                        type: z.instanceof(GraphQLList),
+                      })
+                      .strict(),
                   })
                   .strict(),
                 resolve: z.function(),
@@ -2819,6 +2824,11 @@ describe.sequential('Returned data tests', () => {
                     where: z
                       .object({
                         type: z.instanceof(GraphQLInputObjectType),
+                      })
+                      .strict(),
+                    distinct: z
+                      .object({
+                        type: z.instanceof(GraphQLList),
                       })
                       .strict(),
                   })
@@ -2876,6 +2886,11 @@ describe.sequential('Returned data tests', () => {
                         type: z.instanceof(GraphQLInputObjectType),
                       })
                       .strict(),
+                    distinct: z
+                      .object({
+                        type: z.instanceof(GraphQLList),
+                      })
+                      .strict(),
                   })
                   .strict(),
                 resolve: z.function(),
@@ -2905,6 +2920,51 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 type: z.instanceof(GraphQLObjectType),
+              })
+              .strict(),
+            usersAggregate: z
+              .object({
+                args: z
+                  .object({
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
+            customersAggregate: z
+              .object({
+                args: z
+                  .object({
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
+            postsAggregate: z
+              .object({
+                args: z
+                  .object({
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
           })
@@ -3114,6 +3174,9 @@ describe.sequential('Returned data tests', () => {
             Posts: z.instanceof(GraphQLObjectType),
             Customers: z.instanceof(GraphQLObjectType),
             MutationReturn: z.instanceof(GraphQLObjectType),
+            UsersAggregate: z.instanceof(GraphQLObjectType),
+            CustomersAggregate: z.instanceof(GraphQLObjectType),
+            PostsAggregate: z.instanceof(GraphQLObjectType),
           })
           .strict(),
         inputs: z

--- a/tests/mysql.test.ts
+++ b/tests/mysql.test.ts
@@ -10,6 +10,7 @@ import {
   GraphQLObjectType,
   GraphQLScalarType,
   GraphQLSchema,
+  graphql,
 } from 'graphql';
 import { createYoga } from 'graphql-yoga';
 import * as mysql from 'mysql2/promise';
@@ -36,6 +37,7 @@ interface Context {
   db: MySql2Database<typeof schema>;
   client: mysql.Connection;
   schema: GraphQLSchema;
+  upsertSchema: GraphQLSchema;
   entities: GeneratedEntities<MySql2Database<typeof schema>>;
   server: Server;
   gql: GraphQLClient;
@@ -106,6 +108,8 @@ beforeAll(async (_t) => {
   });
 
   const { schema: gqlSchema, entities } = buildSchema(ctx.db);
+  // Upsert is opt-in, so it needs a schema of its own.
+  ctx.upsertSchema = buildSchema(ctx.db, { features: { upsert: true } }).schema;
   const yoga = createYoga({
     schema: gqlSchema,
   });
@@ -4665,5 +4669,76 @@ describe.sequential('__typename with data tests', async () => {
     const data = await ctx.db.select().from(schema.Customers);
 
     expect(data).toStrictEqual([]);
+  });
+});
+
+describe.sequential('Upsert tests', () => {
+  const upsert = (source: string) => graphql({ schema: ctx.upsertSchema, source, contextValue: {} });
+  const users = () => ctx.db.select().from(schema.Users).orderBy(schema.Users.id);
+
+  it('inserts a row that does not conflict', async () => {
+    const result = await upsert(`mutation { upsertUsersSingle(values: { id: 100, name: "NewUser" }) { isSuccess } }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.['upsertUsersSingle']).toMatchObject({ isSuccess: true });
+    expect((await users()).find((u) => u.id === 100)?.name).toBe('NewUser');
+  });
+
+  it('overwrites the conflicting row', async () => {
+    const result = await upsert(
+      `mutation { upsertUsersSingle(values: { id: 1, name: "Replaced", profession: "Upserted" }) { isSuccess } }`,
+    );
+
+    expect(result.errors).toBeUndefined();
+    const first = (await users()).find((u) => u.id === 1)!;
+    expect(first.name).toBe('Replaced');
+    expect(first.profession).toBe('Upserted');
+  });
+
+  it('leaves the existing row alone when the action is NOTHING', async () => {
+    const result = await upsert(`mutation {
+      upsertUsersSingle(values: { id: 1, name: "Ignored" }, onConflict: { action: NOTHING }) { isSuccess }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect((await users()).find((u) => u.id === 1)?.name).toBe('FirstUser');
+  });
+
+  it('updates each row of a batch with its own values', async () => {
+    const result = await upsert(`mutation {
+      upsertUsers(values: [
+        { id: 1, name: "OneUpserted" },
+        { id: 2, name: "TwoUpserted" },
+        { id: 300, name: "Inserted" }
+      ]) { isSuccess }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    const rows = await users();
+    expect(rows.find((u) => u.id === 1)?.name).toBe('OneUpserted');
+    expect(rows.find((u) => u.id === 2)?.name).toBe('TwoUpserted');
+    expect(rows.find((u) => u.id === 300)?.name).toBe('Inserted');
+  });
+
+  it('overwrites only the listed columns', async () => {
+    const result = await upsert(`mutation {
+      upsertUsersSingle(
+        values: { id: 1, name: "Fresh", profession: "Fresher" }
+        onConflict: { update: [profession] }
+      ) { isSuccess }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    const first = (await users()).find((u) => u.id === 1)!;
+    expect(first.name).toBe('FirstUser');
+    expect(first.profession).toBe('Fresher');
+  });
+
+  it('rejects an update column the values do not supply', async () => {
+    const result = await upsert(`mutation {
+      upsertUsersSingle(values: { id: 1, name: "Fresh" }, onConflict: { update: [profession] }) { isSuccess }
+    }`);
+
+    expect(result.errors?.[0]?.message).toContain('which the values do not supply');
   });
 });

--- a/tests/pg.test.ts
+++ b/tests/pg.test.ts
@@ -5,7 +5,7 @@ import { drizzle, type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import getPort from 'get-port';
 import {
   GraphQLInputObjectType,
-  type GraphQLList,
+  GraphQLList,
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLScalarType,
@@ -2339,6 +2339,11 @@ describe.sequential('Returned data tests', () => {
                         type: z.instanceof(GraphQLInputObjectType),
                       })
                       .strict(),
+                    distinct: z
+                      .object({
+                        type: z.instanceof(GraphQLList),
+                      })
+                      .strict(),
                   })
                   .strict(),
                 resolve: z.function(),
@@ -2392,6 +2397,11 @@ describe.sequential('Returned data tests', () => {
                     where: z
                       .object({
                         type: z.instanceof(GraphQLInputObjectType),
+                      })
+                      .strict(),
+                    distinct: z
+                      .object({
+                        type: z.instanceof(GraphQLList),
                       })
                       .strict(),
                   })
@@ -2449,6 +2459,11 @@ describe.sequential('Returned data tests', () => {
                         type: z.instanceof(GraphQLInputObjectType),
                       })
                       .strict(),
+                    distinct: z
+                      .object({
+                        type: z.instanceof(GraphQLList),
+                      })
+                      .strict(),
                   })
                   .strict(),
                 resolve: z.function(),
@@ -2504,6 +2519,11 @@ describe.sequential('Returned data tests', () => {
                         type: z.instanceof(GraphQLInputObjectType),
                       })
                       .strict(),
+                    distinct: z
+                      .object({
+                        type: z.instanceof(GraphQLList),
+                      })
+                      .strict(),
                   })
                   .strict(),
                 resolve: z.function(),
@@ -2533,6 +2553,66 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 type: z.instanceof(GraphQLObjectType),
+              })
+              .strict(),
+            usersAggregate: z
+              .object({
+                args: z
+                  .object({
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
+            customersAggregate: z
+              .object({
+                args: z
+                  .object({
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
+            postsAggregate: z
+              .object({
+                args: z
+                  .object({
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
+            tagsAggregate: z
+              .object({
+                args: z
+                  .object({
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
           })
@@ -2807,6 +2887,10 @@ describe.sequential('Returned data tests', () => {
             Posts: z.instanceof(GraphQLObjectType),
             Customers: z.instanceof(GraphQLObjectType),
             Tags: z.instanceof(GraphQLObjectType),
+            UsersAggregate: z.instanceof(GraphQLObjectType),
+            CustomersAggregate: z.instanceof(GraphQLObjectType),
+            PostsAggregate: z.instanceof(GraphQLObjectType),
+            TagsAggregate: z.instanceof(GraphQLObjectType),
           })
           .strict(),
         inputs: z

--- a/tests/pglite/aggregate.test.ts
+++ b/tests/pglite/aggregate.test.ts
@@ -1,0 +1,170 @@
+import type { GraphQLObjectType } from 'graphql';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { type Context, createCtx, setupServer, setupTables, teardownServer, teardownTables } from './common';
+
+const DATA_DIR = `./tests/.temp/pgdata-aggregate-${Date.now()}`;
+const ctx: Context = createCtx();
+
+beforeAll(async () => {
+  await setupServer(ctx, 4017, DATA_DIR);
+});
+afterAll(async () => {
+  await teardownServer(ctx, DATA_DIR);
+});
+beforeEach(async () => {
+  await setupTables(ctx);
+});
+afterEach(async () => {
+  await teardownTables(ctx);
+});
+
+describe.sequential('aggregate queries', () => {
+  it('counts all rows', async () => {
+    const result = await ctx.gql.queryGql(`{ usersAggregate { count } }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.usersAggregate).toEqual({ count: 3 });
+  });
+
+  it('counts rows matching a where filter', async () => {
+    const result = await ctx.gql.queryGql(`{
+      postsAggregate(where: { authorId: { eq: 1 } }) { count }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.postsAggregate).toEqual({ count: 4 });
+  });
+
+  it('computes avg, sum, min, and max on numeric columns', async () => {
+    const result = await ctx.gql.queryGql(`{
+      postsAggregate {
+        count
+        avg { id }
+        sum { id }
+        min { id }
+        max { id }
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.postsAggregate).toEqual({
+      count: 6,
+      avg: { id: 3.5 },
+      sum: { id: 21 },
+      min: { id: 1 },
+      max: { id: 6 },
+    });
+  });
+
+  it('applies the where filter to all aggregations', async () => {
+    const result = await ctx.gql.queryGql(`{
+      postsAggregate(where: { authorId: { eq: 5 } }) {
+        count
+        sum { id }
+        min { id }
+        max { id }
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.postsAggregate).toEqual({
+      count: 2,
+      sum: { id: 9 },
+      min: { id: 4 },
+      max: { id: 5 },
+    });
+  });
+
+  it('computes min and max on text and timestamp columns', async () => {
+    const result = await ctx.gql.queryGql(`{
+      usersAggregate {
+        min { name createdAt }
+        max { name createdAt }
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.usersAggregate).toEqual({
+      min: { name: 'FifthUser', createdAt: '2024-04-02T06:44:41.785Z' },
+      max: { name: 'SecondUser', createdAt: '2024-04-02T06:44:41.785Z' },
+    });
+  });
+
+  it('returns zero count and null aggregates for an empty table', async () => {
+    const result = await ctx.gql.queryGql(`{
+      tagsAggregate {
+        count
+        avg { id }
+        sum { id }
+        min { name }
+        max { name }
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.tagsAggregate).toEqual({
+      count: 0,
+      avg: { id: null },
+      sum: { id: null },
+      min: { name: null },
+      max: { name: null },
+    });
+  });
+
+  it('returns null aggregates when the where filter matches no rows', async () => {
+    const result = await ctx.gql.queryGql(`{
+      usersAggregate(where: { name: { eq: "Nobody" } }) {
+        count
+        avg { id }
+        min { name }
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.usersAggregate).toEqual({
+      count: 0,
+      avg: { id: null },
+      min: { name: null },
+    });
+  });
+
+  it('supports field aliases', async () => {
+    const result = await ctx.gql.queryGql(`{
+      postsAggregate {
+        total: count
+        highest: max { postId: id }
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.postsAggregate).toEqual({
+      total: 6,
+      highest: { postId: 6 },
+    });
+  });
+
+  it('only exposes numeric columns on avg/sum and orderable columns on min/max', () => {
+    const avgType = ctx.schema.getType('UserAvgAggregate') as GraphQLObjectType;
+    expect(Object.keys(avgType.getFields())).toEqual(['id']);
+
+    const minType = ctx.schema.getType('UserMinAggregate') as GraphQLObjectType;
+    const minFields = Object.keys(minType.getFields());
+    expect(minFields).toContain('name');
+    expect(minFields).toContain('createdAt');
+    expect(minFields).toContain('id');
+    // Booleans, arrays, geometry, and vector columns are not orderable.
+    expect(minFields).not.toContain('isConfirmed');
+    expect(minFields).not.toContain('a');
+    expect(minFields).not.toContain('vector');
+    expect(minFields).not.toContain('geoXy');
+    expect(minFields).not.toContain('geoTuple');
+  });
+
+  it('rejects unknown aggregate columns at validation time', async () => {
+    const result = await ctx.gql.queryGql(`{
+      usersAggregate { avg { name } }
+    }`);
+
+    expect(result.errors).toBeDefined();
+  });
+});

--- a/tests/pglite/aggregate.test.ts
+++ b/tests/pglite/aggregate.test.ts
@@ -143,6 +143,85 @@ describe.sequential('aggregate queries', () => {
     });
   });
 
+  it('counts non-null values per column', async () => {
+    // Only the first user has `initials`; `isConfirmed` is set on that user alone too.
+    const result = await ctx.gql.queryGql(`{
+      usersAggregate {
+        count
+        countNonNull { id initials isConfirmed }
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.usersAggregate).toEqual({
+      count: 3,
+      countNonNull: { id: 3, initials: 1, isConfirmed: 1 },
+    });
+  });
+
+  it('counts distinct values per column', async () => {
+    const result = await ctx.gql.queryGql(`{
+      postsAggregate {
+        count
+        countDistinct { authorId content }
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.postsAggregate).toEqual({
+      count: 6,
+      countDistinct: { authorId: 2, content: 4 },
+    });
+  });
+
+  it('applies the where filter to the per-column counts', async () => {
+    const result = await ctx.gql.queryGql(`{
+      postsAggregate(where: { authorId: { eq: 5 } }) {
+        countNonNull { content }
+        countDistinct { authorId }
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.postsAggregate).toEqual({
+      countNonNull: { content: 2 },
+      countDistinct: { authorId: 1 },
+    });
+  });
+
+  it('returns zero per-column counts for an empty table', async () => {
+    const result = await ctx.gql.queryGql(`{
+      tagsAggregate {
+        countNonNull { id name }
+        countDistinct { id name }
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.tagsAggregate).toEqual({
+      countNonNull: { id: 0, name: 0 },
+      countDistinct: { id: 0, name: 0 },
+    });
+  });
+
+  it('exposes every column on countNonNull but only orderable ones on countDistinct', () => {
+    const countNonNullType = ctx.schema.getType('UserCountNonNullAggregate') as GraphQLObjectType;
+    const countNonNullFields = Object.keys(countNonNullType.getFields());
+    expect(countNonNullFields).toContain('isConfirmed');
+    expect(countNonNullFields).toContain('vector');
+    expect(countNonNullFields).toContain('geoXy');
+
+    const countDistinctType = ctx.schema.getType('UserCountDistinctAggregate') as GraphQLObjectType;
+    const countDistinctFields = Object.keys(countDistinctType.getFields());
+    expect(countDistinctFields).toContain('name');
+    expect(countDistinctFields).not.toContain('isConfirmed');
+    expect(countDistinctFields).not.toContain('vector');
+
+    // Counts are never null, so every field on both types is non-nullable.
+    expect(countNonNullType.getFields()['id']!.type.toString()).toBe('Int!');
+    expect(countDistinctType.getFields()['id']!.type.toString()).toBe('Int!');
+  });
+
   it('only exposes numeric columns on avg/sum and orderable columns on min/max', () => {
     const avgType = ctx.schema.getType('UserAvgAggregate') as GraphQLObjectType;
     expect(Object.keys(avgType.getFields())).toEqual(['id']);

--- a/tests/pglite/arguments.test.ts
+++ b/tests/pglite/arguments.test.ts
@@ -149,6 +149,42 @@ describe.sequential('Arguments tests', async () => {
     });
   });
 
+  it('Defaults an unordered paginated query to primary key order', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				posts(limit: 3) {
+					id
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({ data: { posts: [{ id: 1 }, { id: 2 }, { id: 3 }] } });
+  });
+
+  it('Defaults an unordered single query to primary key order', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				post {
+					id
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({ data: { post: { id: 1 } } });
+  });
+
+  it('Keeps an explicit orderBy over the primary key default', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				posts(limit: 3, orderBy: { id: { direction: desc, priority: 1 } }) {
+					id
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({ data: { posts: [{ id: 6 }, { id: 5 }, { id: 4 }] } });
+  });
+
   it('Filters - top level AND', async () => {
     const res = await ctx.gql.queryGql(/* GraphQL */ `
 			{

--- a/tests/pglite/distinct.test.ts
+++ b/tests/pglite/distinct.test.ts
@@ -1,0 +1,177 @@
+import type { GraphQLEnumType, GraphQLObjectType } from 'graphql';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { type Context, createCtx, setupServer, setupTables, teardownServer, teardownTables } from './common';
+
+const DATA_DIR = `./tests/.temp/pgdata-distinct-${Date.now()}`;
+const ctx: Context = createCtx();
+
+beforeAll(async () => {
+  await setupServer(ctx, 4020, DATA_DIR);
+});
+afterAll(async () => {
+  await teardownServer(ctx, DATA_DIR);
+});
+beforeEach(async () => {
+  await setupTables(ctx);
+});
+afterEach(async () => {
+  await teardownTables(ctx);
+});
+
+// Seed recap: posts 1/2/3/6 belong to user 1 with contents 1/2/3/4MESSAGE, posts 4/5 belong to
+// user 5 with contents 1/2MESSAGE. So `content` has 4 distinct values and `authorId` has 2.
+describe.sequential('distinct', () => {
+  it('keeps the first row of each distinct value', async () => {
+    const result = await ctx.gql.queryGql(`{
+      posts(distinct: [content]) { id content }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.posts).toEqual([
+      { id: 1, content: '1MESSAGE' },
+      { id: 2, content: '2MESSAGE' },
+      { id: 3, content: '3MESSAGE' },
+      { id: 6, content: '4MESSAGE' },
+    ]);
+  });
+
+  it('picks the first row according to the requested order', async () => {
+    const result = await ctx.gql.queryGql(`{
+      posts(distinct: [content], orderBy: { id: { direction: desc, priority: 1 } }) { id content }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.posts).toEqual([
+      { id: 6, content: '4MESSAGE' },
+      { id: 5, content: '2MESSAGE' },
+      { id: 4, content: '1MESSAGE' },
+      { id: 3, content: '3MESSAGE' },
+    ]);
+  });
+
+  it('treats several columns as one combined key', async () => {
+    const result = await ctx.gql.queryGql(`{
+      posts(distinct: [content, authorId]) { id }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    // Every (content, authorId) pair in the seed is unique, so nothing is dropped.
+    expect(result.data?.posts).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }, { id: 6 }]);
+  });
+
+  it('collapses rows that share a value', async () => {
+    const result = await ctx.gql.queryGql(`{
+      posts(distinct: [authorId]) { id authorId }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.posts).toEqual([
+      { id: 1, authorId: 1 },
+      { id: 4, authorId: 5 },
+    ]);
+  });
+
+  it('applies limit and offset after the rows are made distinct', async () => {
+    const result = await ctx.gql.queryGql(`{
+      posts(distinct: [content], limit: 2, offset: 1) { id content }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.posts).toEqual([
+      { id: 2, content: '2MESSAGE' },
+      { id: 3, content: '3MESSAGE' },
+    ]);
+  });
+
+  it('filters before making rows distinct', async () => {
+    const result = await ctx.gql.queryGql(`{
+      posts(where: { authorId: { eq: 5 } }, distinct: [content]) { id content }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.posts).toEqual([
+      { id: 4, content: '1MESSAGE' },
+      { id: 5, content: '2MESSAGE' },
+    ]);
+  });
+
+  it('accepts a relation filter alongside distinct', async () => {
+    const result = await ctx.gql.queryGql(`{
+      posts(where: { author: { name: { eq: "FifthUser" } } }, distinct: [content]) { id }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.posts).toEqual([{ id: 4 }, { id: 5 }]);
+  });
+
+  it('returns an empty list when the filter matches nothing', async () => {
+    const result = await ctx.gql.queryGql(`{
+      posts(where: { content: { eq: "NOPE" } }, distinct: [content]) { id }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.posts).toEqual([]);
+  });
+
+  it('eagerly loads relations of the surviving rows', async () => {
+    const result = await ctx.gql.queryGql(`{
+      posts(distinct: [authorId]) {
+        id
+        author { name }
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.posts).toEqual([
+      { id: 1, author: { name: 'FirstUser' } },
+      { id: 4, author: { name: 'FifthUser' } },
+    ]);
+  });
+
+  it('aggregates relations of the surviving rows', async () => {
+    const result = await ctx.gql.queryGql(`{
+      users(distinct: [id]) {
+        id
+        postsAggregate { count }
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([
+      { id: 1, postsAggregate: { count: 4 } },
+      { id: 2, postsAggregate: { count: 0 } },
+      { id: 5, postsAggregate: { count: 2 } },
+    ]);
+  });
+
+  it('is ignored when the list is empty', async () => {
+    const result = await ctx.gql.queryGql(`{
+      posts(distinct: []) { id }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.posts).toHaveLength(6);
+  });
+
+  describe('schema shape', () => {
+    const queries = () => ctx.entities.queries as unknown as Record<string, { args: Record<string, { type: any }> }>;
+
+    it('exposes distinct on list queries only', () => {
+      expect(queries()['posts']!.args['distinct']).toBeDefined();
+      expect(queries()['post']!.args['distinct']).toBeUndefined();
+      expect(queries()['postsAggregate']!.args['distinct']).toBeUndefined();
+    });
+
+    it('takes a list of the table column enum', () => {
+      const listType = queries()['posts']!.args['distinct']!.type;
+      const enumType = listType.ofType.ofType as GraphQLEnumType;
+
+      const postFields = (ctx.entities.types as unknown as Record<string, GraphQLObjectType>)['Post']!.getFields();
+
+      expect(enumType.name).toBe('PostDistinctColumn');
+      // Every column, and only columns — relation fields are not distinctable.
+      expect(enumType.getValues().map((value) => value.name)).toEqual(['id', 'content', 'authorId']);
+      expect(Object.keys(postFields)).toContain('author');
+    });
+  });
+});

--- a/tests/pglite/error-hook.test.ts
+++ b/tests/pglite/error-hook.test.ts
@@ -1,0 +1,154 @@
+import { PGlite } from '@electric-sql/pglite';
+import { buildRelations, createRelationsHelper, sql } from 'drizzle-orm';
+import { integer, pgTable, text } from 'drizzle-orm/pg-core';
+import { drizzle } from 'drizzle-orm/pglite';
+import { GraphQLError, type GraphQLSchema, graphql } from 'graphql';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { buildSchema } from '@/index';
+
+const Authors = pgTable('authors', { id: integer('id').primaryKey(), name: text('name') });
+const Books = pgTable('books', {
+  id: integer('id').primaryKey(),
+  title: text('title').notNull(),
+  authorId: integer('author_id'),
+});
+const r = createRelationsHelper({ Authors, Books });
+const relations = buildRelations(
+  { Authors, Books },
+  {
+    Authors: { books: r.many.Books({ from: r.Authors.id, to: r.Books.authorId }) },
+    Books: { author: r.one.Authors({ from: r.Books.authorId, to: r.Authors.id }) },
+  },
+);
+const schema = { Authors, Books, relations };
+
+const DATA_DIR = `./tests/.temp/pgdata-error-hook-${Date.now()}`;
+let pglite: PGlite;
+let db: any;
+
+const run = (s: GraphQLSchema, source: string) => graphql({ schema: s, source, contextValue: {} });
+
+// A unique-violation on the primary key. Drizzle rethrows driver errors with the full SQL
+// and the bound parameters in the message, which is exactly what the default keeps out of a
+// response.
+const DUPLICATE = `mutation { createAuthorsSingle(values: { id: 1, name: "again" }) { id } }`;
+
+beforeAll(async () => {
+  pglite = new PGlite(DATA_DIR);
+  await pglite.waitReady;
+  db = (drizzle as any)({ client: pglite, schema, relations, logger: !!process.env['LOG_SQL'] });
+
+  await db.execute(sql`CREATE TABLE "authors" ("id" integer PRIMARY KEY NOT NULL, "name" text);`);
+  await db.execute(
+    sql`CREATE TABLE "books" ("id" integer PRIMARY KEY NOT NULL, "title" text NOT NULL, "author_id" integer);`,
+  );
+});
+
+afterAll(async () => {
+  await pglite?.close().catch(() => {});
+});
+
+beforeEach(async () => {
+  await db.execute(sql`TRUNCATE "books";`);
+  await db.execute(sql`TRUNCATE "authors" CASCADE;`);
+  await db.insert(Authors).values([{ id: 1, name: 'First' }]);
+  await db.insert(Books).values([{ id: 1, title: 'A', authorId: 1 }]);
+});
+
+describe.sequential('default error handling', () => {
+  it('replaces a database error with a generic message', async () => {
+    const { schema: gqlSchema } = buildSchema(db);
+    const res = await run(gqlSchema, DUPLICATE);
+
+    expect(res.errors).toHaveLength(1);
+    expect(res.errors![0]!.message).toBe('Internal server error');
+    expect(res.errors![0]!.extensions['code']).toBe('INTERNAL_SERVER_ERROR');
+    // Nothing about the table, the constraint, or the offending value survives.
+    expect(JSON.stringify(res)).not.toMatch(/Failed query|insert into|params:/i);
+  });
+
+  it('keeps the original error reachable for server-side logging', async () => {
+    const { schema: gqlSchema } = buildSchema(db);
+    const res = await run(gqlSchema, DUPLICATE);
+
+    // graphql-js locates the thrown error, so ours sits one level down.
+    const masked = res.errors![0]!.originalError as GraphQLError;
+    expect(masked.message).toBe('Internal server error');
+    expect(masked.originalError?.message).toMatch(/Failed query: insert into "authors"/);
+  });
+
+  it("passes through drizzle-graphql's own errors unchanged", async () => {
+    const { schema: gqlSchema } = buildSchema(db);
+    const res = await run(gqlSchema, `mutation { updateAuthors(set: {}) { id } }`);
+
+    expect(res.errors![0]!.message).toMatch(/Unable to update with no values specified/);
+  });
+
+  it('masks errors raised by a relation field resolver too', async () => {
+    const { schema: gqlSchema } = buildSchema(db, { eagerLoadRelations: false });
+    // The lazy relation loader queries "books" on its own — dropping it makes that query,
+    // and only that query, fail.
+    await db.execute(sql`DROP TABLE "books";`);
+    try {
+      const res = await run(gqlSchema, `{ authors { id books { id } } }`);
+      expect(res.errors?.[0]?.message).toBe('Internal server error');
+      expect(JSON.stringify(res)).not.toMatch(/does not exist/i);
+    } finally {
+      await db.execute(
+        sql`CREATE TABLE "books" ("id" integer PRIMARY KEY NOT NULL, "title" text NOT NULL, "author_id" integer);`,
+      );
+    }
+  });
+});
+
+describe.sequential('onError hook', () => {
+  it('is called with the raw error and can be used purely for logging', async () => {
+    const seen: unknown[] = [];
+    const { schema: gqlSchema } = buildSchema(db, {
+      onError: (error) => {
+        seen.push(error);
+      },
+    });
+
+    const res = await run(gqlSchema, DUPLICATE);
+
+    expect(seen).toHaveLength(1);
+    expect((seen[0] as Error).message).toMatch(/Failed query: insert into "authors"/);
+    // Returning nothing falls through to the default.
+    expect(res.errors![0]!.message).toBe('Internal server error');
+  });
+
+  it('surfaces an error it returns', async () => {
+    const { schema: gqlSchema } = buildSchema(db, {
+      onError: () => new GraphQLError('Something went wrong', { extensions: { code: 'DB_ERROR' } }),
+    });
+
+    const res = await run(gqlSchema, DUPLICATE);
+
+    expect(res.errors![0]!.message).toBe('Something went wrong');
+    expect(res.errors![0]!.extensions['code']).toBe('DB_ERROR');
+  });
+
+  it('can opt back into raw database messages', async () => {
+    const { schema: gqlSchema } = buildSchema(db, { onError: (error) => error as Error });
+
+    const res = await run(gqlSchema, DUPLICATE);
+
+    expect(res.errors![0]!.message).toMatch(/Failed query: insert into "authors"/);
+  });
+
+  it("also sees drizzle-graphql's own errors", async () => {
+    const seen: string[] = [];
+    const { schema: gqlSchema } = buildSchema(db, {
+      onError: (error) => {
+        seen.push((error as Error).message);
+      },
+    });
+
+    const res = await run(gqlSchema, `mutation { updateAuthors(set: {}) { id } }`);
+
+    expect(seen).toEqual(['Unable to update with no values specified!']);
+    // Still passed through by the default, not masked.
+    expect(res.errors![0]!.message).toMatch(/Unable to update with no values specified/);
+  });
+});

--- a/tests/pglite/features.test.ts
+++ b/tests/pglite/features.test.ts
@@ -1,0 +1,154 @@
+import { PGlite } from '@electric-sql/pglite';
+import { drizzle, type PgliteDatabase } from 'drizzle-orm/pglite';
+import type { GraphQLObjectType, GraphQLSchema } from 'graphql';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildSchema, type SchemaFeatures } from '@/index';
+import * as schema from '../schema/pg';
+
+// buildSchema only reads the drizzle metadata, so these tests never touch the database:
+// one in-memory client is enough to build as many schemas as we like.
+let pglite: PGlite;
+let db: PgliteDatabase<typeof schema>;
+
+const build = (features?: SchemaFeatures) => buildSchema(db, features ? { features } : undefined);
+
+const queryFields = (gqlSchema: GraphQLSchema) => gqlSchema.getQueryType()!.getFields();
+const userFields = (gqlSchema: GraphQLSchema) => (gqlSchema.getType('Users') as GraphQLObjectType).getFields();
+
+beforeAll(async () => {
+  pglite = new PGlite();
+  await pglite.waitReady;
+  db = drizzle({ client: pglite, schema, relations: schema.relations });
+});
+
+afterAll(async () => {
+  await pglite.close().catch(console.error);
+});
+
+describe('features: defaults', () => {
+  it('generates every feature when no features block is given', () => {
+    const gqlSchema = build().schema;
+    const mutations = gqlSchema.getMutationType()!.getFields();
+
+    expect(queryFields(gqlSchema)['usersAggregate']).toBeDefined();
+    expect(queryFields(gqlSchema)['users']!.args.map((a) => a.name)).toContain('distinct');
+    expect(userFields(gqlSchema)['postsAggregate']).toBeDefined();
+    expect(mutations['createUsers']).toBeDefined();
+    expect(mutations['updateUsers']).toBeDefined();
+    expect(mutations['deleteUsers']).toBeDefined();
+  });
+
+  it('treats an empty features block the same as no features block', () => {
+    const gqlSchema = build({}).schema;
+
+    expect(queryFields(gqlSchema)['usersAggregate']).toBeDefined();
+    expect(queryFields(gqlSchema)['users']!.args.map((a) => a.name)).toContain('distinct');
+    expect(gqlSchema.getMutationType()!.getFields()['createUsers']).toBeDefined();
+  });
+});
+
+describe('features: aggregates', () => {
+  it('omits the aggregate queries and their output types when off', () => {
+    const { schema: gqlSchema, entities } = build({ aggregates: false });
+
+    expect(queryFields(gqlSchema)['usersAggregate']).toBeUndefined();
+    expect(gqlSchema.getType('UsersAggregate')).toBeUndefined();
+    expect(Object.keys(entities.queries).some((name) => name.endsWith('Aggregate'))).toBe(false);
+    // The list and single queries are untouched.
+    expect(queryFields(gqlSchema)['users']).toBeDefined();
+    expect(queryFields(gqlSchema)['usersSingle']).toBeDefined();
+  });
+
+  it('keeps relation aggregates, which are a separate switch', () => {
+    expect(userFields(build({ aggregates: false }).schema)['postsAggregate']).toBeDefined();
+  });
+});
+
+describe('features: relationAggregates', () => {
+  it('omits the per-relation aggregate fields when off', () => {
+    const gqlSchema = build({ relationAggregates: false }).schema;
+
+    expect(userFields(gqlSchema)['postsAggregate']).toBeUndefined();
+    // The relation itself is still there, and root aggregates are a separate switch.
+    expect(userFields(gqlSchema)['posts']).toBeDefined();
+    expect(queryFields(gqlSchema)['usersAggregate']).toBeDefined();
+  });
+});
+
+describe('features: distinct', () => {
+  it('omits the distinct argument and its enum when off', () => {
+    const gqlSchema = build({ distinct: false }).schema;
+
+    expect(queryFields(gqlSchema)['users']!.args.map((a) => a.name)).not.toContain('distinct');
+    expect(gqlSchema.getType('UsersDistinctColumn')).toBeUndefined();
+    // Other list arguments survive.
+    expect(queryFields(gqlSchema)['users']!.args.map((a) => a.name)).toEqual(
+      expect.arrayContaining(['where', 'orderBy', 'offset', 'limit']),
+    );
+  });
+});
+
+describe('features: mutations', () => {
+  it('omits insert mutations and the insert input when insert is off', () => {
+    const { schema: gqlSchema, entities } = build({ insert: false });
+    const mutations = gqlSchema.getMutationType()!.getFields();
+
+    expect(mutations['createUsers']).toBeUndefined();
+    expect(mutations['createUsersSingle']).toBeUndefined();
+    expect(gqlSchema.getType('CreateUsersInput')).toBeUndefined();
+    expect(entities.inputs['CreateUsersInput']).toBeUndefined();
+    expect(mutations['updateUsers']).toBeDefined();
+    expect(mutations['deleteUsers']).toBeDefined();
+  });
+
+  it('omits update mutations and the update input when update is off', () => {
+    const { schema: gqlSchema, entities } = build({ update: false });
+    const mutations = gqlSchema.getMutationType()!.getFields();
+
+    expect(mutations['updateUsers']).toBeUndefined();
+    expect(gqlSchema.getType('UpdateUsersInput')).toBeUndefined();
+    expect(entities.inputs['UpdateUsersInput']).toBeUndefined();
+    expect(mutations['createUsers']).toBeDefined();
+  });
+
+  it('omits delete mutations when delete is off', () => {
+    const mutations = build({ delete: false }).schema.getMutationType()!.getFields();
+
+    expect(mutations['deleteUsers']).toBeUndefined();
+    expect(mutations['createUsers']).toBeDefined();
+  });
+
+  it('omits the Mutation type entirely when every mutation feature is off', () => {
+    const { schema: gqlSchema, entities } = build({ insert: false, update: false, delete: false });
+
+    expect(gqlSchema.getMutationType()).toBeUndefined();
+    expect(Object.keys(entities.mutations)).toHaveLength(0);
+    // Queries are unaffected.
+    expect(queryFields(gqlSchema)['users']).toBeDefined();
+  });
+});
+
+describe('features: everything optional turned off', () => {
+  it('still builds a valid query-only schema', () => {
+    const gqlSchema = build({
+      aggregates: false,
+      relationAggregates: false,
+      distinct: false,
+      insert: false,
+      update: false,
+      delete: false,
+    }).schema;
+
+    expect(Object.keys(queryFields(gqlSchema)).sort()).toEqual([
+      'customers',
+      'customersSingle',
+      'posts',
+      'postsSingle',
+      'tags',
+      'tagsSingle',
+      'users',
+      'usersSingle',
+    ]);
+    expect(gqlSchema.getMutationType()).toBeUndefined();
+  });
+});

--- a/tests/pglite/features.test.ts
+++ b/tests/pglite/features.test.ts
@@ -36,6 +36,8 @@ describe('features: defaults', () => {
     expect(mutations['createUsers']).toBeDefined();
     expect(mutations['updateUsers']).toBeDefined();
     expect(mutations['deleteUsers']).toBeDefined();
+    // Upsert is the one flag that is off unless asked for.
+    expect(mutations['upsertUsers']).toBeUndefined();
   });
 
   it('treats an empty features block the same as no features block', () => {
@@ -125,6 +127,25 @@ describe('features: mutations', () => {
     expect(Object.keys(entities.mutations)).toHaveLength(0);
     // Queries are unaffected.
     expect(queryFields(gqlSchema)['users']).toBeDefined();
+  });
+});
+
+describe('features: upsert', () => {
+  it('adds the upsert mutations and their conflict input when on', () => {
+    const { schema: gqlSchema, entities } = build({ upsert: true });
+    const mutations = gqlSchema.getMutationType()!.getFields();
+
+    expect(mutations['upsertUsers']).toBeDefined();
+    expect(mutations['upsertUsersSingle']).toBeDefined();
+    expect(gqlSchema.getType('UsersOnConflict')).toBeDefined();
+    expect(entities.inputs['UsersOnConflict']).toBeDefined();
+  });
+
+  it('keeps the insert input, which types the upsert values, even with insert off', () => {
+    const gqlSchema = build({ upsert: true, insert: false }).schema;
+
+    expect(gqlSchema.getMutationType()!.getFields()['createUsers']).toBeUndefined();
+    expect(gqlSchema.getType('CreateUsersInput')).toBeDefined();
   });
 });
 

--- a/tests/pglite/mysql-schema.test.ts
+++ b/tests/pglite/mysql-schema.test.ts
@@ -42,6 +42,25 @@ const entities = generateMySQL(mockDb, tableSchema, schema.relations, {
     insert: true,
     update: true,
     delete: true,
+    upsert: false,
+  },
+}) as any;
+
+// Upsert is opt-in, so a second generation is needed to inspect its shape.
+const upsertEntities = generateMySQL(mockDb, tableSchema, schema.relations, {
+  relationsDepthLimit: undefined,
+  prefixes: { ...prefixes, upsert: 'upsert' },
+  suffixes,
+  conflictDoNothing: false,
+  shouldEagerLoad: () => true,
+  features: {
+    aggregates: true,
+    relationAggregates: true,
+    distinct: true,
+    insert: true,
+    update: true,
+    delete: true,
+    upsert: true,
   },
 }) as any;
 
@@ -104,6 +123,23 @@ describe('MySQL mutations are returnless', () => {
   it('delete mutations return MutationReturn', () => {
     expect(entities.mutations['deleteUsers'].type).toBe(entities.types['MutationReturn']);
     expect(entities.mutations['deletePosts'].type).toBe(entities.types['MutationReturn']);
+  });
+
+  it('generates no upsert mutations unless the feature is on', () => {
+    expect(entities.mutations['upsertUsers']).toBeUndefined();
+    expect(entities.types['UsersOnConflict']).toBeUndefined();
+  });
+
+  it('upsert mutations return MutationReturn like every other MySQL mutation', () => {
+    expect(upsertEntities.mutations['upsertUsers'].type).toBe(upsertEntities.types['MutationReturn']);
+    expect(upsertEntities.mutations['upsertUsersSingle'].type).toBe(upsertEntities.types['MutationReturn']);
+  });
+
+  it('omits target and where from the conflict input, which MySQL cannot express', () => {
+    const onConflict = upsertEntities.inputs['UsersOnConflict'];
+    expect(Object.keys(onConflict.getFields()).sort()).toEqual(['action', 'update']);
+    // Every table is upsertable on MySQL — a conflict needs no declared target.
+    expect(upsertEntities.mutations['upsertPosts']).toBeDefined();
   });
 
   it('all 6 mutations exist per table (array+single insert, update, delete)', () => {

--- a/tests/pglite/mysql-schema.test.ts
+++ b/tests/pglite/mysql-schema.test.ts
@@ -93,6 +93,53 @@ describe('MySQL mutations are returnless', () => {
   });
 });
 
+// ── aggregates ────────────────────────────────────────────────────────────────
+
+describe('MySQL generated aggregate queries', () => {
+  it('generates an aggregate query per table', () => {
+    const queryKeys = Object.keys(entities.queries);
+    expect(queryKeys).toContain('usersAggregate');
+    expect(queryKeys).toContain('customersAggregate');
+    expect(queryKeys).toContain('postsAggregate');
+  });
+
+  it('aggregate query returns a non-null aggregate type and takes only a where arg', () => {
+    const query = entities.queries['usersAggregate'];
+    expect(query.type).toBeInstanceOf(GraphQLNonNull);
+    expect(query.type.ofType).toBe(entities.types['UsersAggregate']);
+    expect(Object.keys(query.args)).toEqual(['where']);
+    expect(query.args['where'].type).toBe(entities.inputs['UsersFilters']);
+  });
+
+  it('aggregate type exposes count plus the aggregation groups', () => {
+    const fields = entities.types['UsersAggregate'].getFields();
+    expect(Object.keys(fields)).toEqual(['count', 'avg', 'sum', 'min', 'max']);
+    expect(fields['count'].type).toBeInstanceOf(GraphQLNonNull);
+  });
+
+  it('avg/sum only cover numeric columns', () => {
+    const fields = entities.types['UsersAggregate'].getFields();
+    expect(Object.keys(fields['avg'].type.getFields())).toEqual(['id']);
+    expect(Object.keys(fields['sum'].type.getFields())).toEqual(['id']);
+  });
+
+  it('min/max cover orderable columns, including dates, enums, and bigints', () => {
+    const fields = entities.types['UsersAggregate'].getFields();
+    const minFields = Object.keys(fields['min'].type.getFields());
+
+    expect(minFields).toContain('id');
+    expect(minFields).toContain('name');
+    expect(minFields).toContain('bigint');
+    expect(minFields).toContain('birthdayString');
+    expect(minFields).toContain('birthdayDate');
+    expect(minFields).toContain('createdAt');
+    expect(minFields).toContain('role');
+    // Booleans have no useful ordering.
+    expect(minFields).not.toContain('isConfirmed');
+    expect(Object.keys(fields['max'].type.getFields())).toEqual(minFields);
+  });
+});
+
 // ── types and inputs ──────────────────────────────────────────────────────────
 
 describe('MySQL generated types and inputs', () => {

--- a/tests/pglite/mysql-schema.test.ts
+++ b/tests/pglite/mysql-schema.test.ts
@@ -29,7 +29,21 @@ const tableSchema = { Users: schema.Users, Customers: schema.Customers, Posts: s
 const prefixes = { insert: 'create', delete: 'delete', update: 'update' };
 const suffixes = { list: '', single: 'Single' };
 
-const entities = generateMySQL(mockDb, tableSchema, schema.relations, undefined, prefixes, suffixes) as any;
+const entities = generateMySQL(mockDb, tableSchema, schema.relations, {
+  relationsDepthLimit: undefined,
+  prefixes,
+  suffixes,
+  conflictDoNothing: false,
+  shouldEagerLoad: () => true,
+  features: {
+    aggregates: true,
+    relationAggregates: true,
+    distinct: true,
+    insert: true,
+    update: true,
+    delete: true,
+  },
+}) as any;
 
 // ── query structure ───────────────────────────────────────────────────────────
 

--- a/tests/pglite/mysql-schema.test.ts
+++ b/tests/pglite/mysql-schema.test.ts
@@ -53,6 +53,18 @@ describe('MySQL generated queries', () => {
     const usersQuery = entities.queries['users'];
     expect(usersQuery.type).toBeInstanceOf(GraphQLNonNull);
   });
+
+  it('list queries take a distinct arg listing the table columns', () => {
+    const distinctArg = entities.queries['posts'].args['distinct'];
+    expect(distinctArg).toBeDefined();
+    expect(distinctArg.type.ofType.ofType.name).toBe('PostsDistinctColumn');
+    expect(distinctArg.type.ofType.ofType.getValues().map((value: { name: string }) => value.name)).toEqual([
+      'id',
+      'content',
+      'authorId',
+    ]);
+    expect(entities.queries['postsSingle'].args['distinct']).toBeUndefined();
+  });
 });
 
 // ── mutation structure — returnless (MySQL-specific) ─────────────────────────

--- a/tests/pglite/mysql-schema.test.ts
+++ b/tests/pglite/mysql-schema.test.ts
@@ -113,7 +113,7 @@ describe('MySQL generated aggregate queries', () => {
 
   it('aggregate type exposes count plus the aggregation groups', () => {
     const fields = entities.types['UsersAggregate'].getFields();
-    expect(Object.keys(fields)).toEqual(['count', 'avg', 'sum', 'min', 'max']);
+    expect(Object.keys(fields)).toEqual(['count', 'avg', 'sum', 'min', 'max', 'countNonNull', 'countDistinct']);
     expect(fields['count'].type).toBeInstanceOf(GraphQLNonNull);
   });
 

--- a/tests/pglite/relation-aggregate.test.ts
+++ b/tests/pglite/relation-aggregate.test.ts
@@ -1,0 +1,202 @@
+import type { GraphQLNonNull, GraphQLObjectType } from 'graphql';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { type Context, createCtx, setupServer, setupTables, teardownServer, teardownTables } from './common';
+
+const DATA_DIR = `./tests/.temp/pgdata-relation-aggregate-${Date.now()}`;
+const ctx: Context = createCtx();
+
+beforeAll(async () => {
+  await setupServer(ctx, 4019, DATA_DIR);
+});
+afterAll(async () => {
+  await teardownServer(ctx, DATA_DIR);
+});
+beforeEach(async () => {
+  await setupTables(ctx);
+});
+afterEach(async () => {
+  await teardownTables(ctx);
+});
+
+// Seed recap: user 1 (FirstUser) wrote posts 1,2,3,6; user 5 (FifthUser) wrote posts 4,5;
+// user 2 (SecondUser) wrote none. Customers 1 and 2 belong to users 1 and 2.
+describe.sequential('relation aggregates', () => {
+  it('counts related rows per parent', async () => {
+    const result = await ctx.gql.queryGql(`{
+      users(orderBy: { id: { direction: asc, priority: 1 } }) {
+        id
+        postsAggregate { count }
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([
+      { id: 1, postsAggregate: { count: 4 } },
+      { id: 2, postsAggregate: { count: 0 } },
+      { id: 5, postsAggregate: { count: 2 } },
+    ]);
+  });
+
+  it('computes the full aggregate set per parent', async () => {
+    const result = await ctx.gql.queryGql(`{
+      users(where: { id: { eq: 1 } }) {
+        id
+        postsAggregate {
+          count
+          avg { id }
+          sum { id }
+          min { id content }
+          max { id content }
+        }
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([
+      {
+        id: 1,
+        postsAggregate: {
+          count: 4,
+          avg: { id: 3 },
+          sum: { id: 12 },
+          min: { id: 1, content: '1MESSAGE' },
+          max: { id: 6, content: '4MESSAGE' },
+        },
+      },
+    ]);
+  });
+
+  it('returns count 0 and null aggregates for a parent with no related rows', async () => {
+    const result = await ctx.gql.queryGql(`{
+      users(where: { id: { eq: 2 } }) {
+        postsAggregate {
+          count
+          avg { id }
+          min { content }
+          max { content }
+        }
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([
+      {
+        postsAggregate: {
+          count: 0,
+          avg: { id: null },
+          min: { content: null },
+          max: { content: null },
+        },
+      },
+    ]);
+  });
+
+  it('applies the where argument to the related rows only', async () => {
+    const result = await ctx.gql.queryGql(`{
+      users(orderBy: { id: { direction: asc, priority: 1 } }) {
+        id
+        postsAggregate(where: { content: { eq: "1MESSAGE" } }) { count }
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([
+      { id: 1, postsAggregate: { count: 1 } },
+      { id: 2, postsAggregate: { count: 0 } },
+      { id: 5, postsAggregate: { count: 1 } },
+    ]);
+  });
+
+  it('accepts relation filters inside the where argument', async () => {
+    const result = await ctx.gql.queryGql(`{
+      users(where: { id: { eq: 1 } }) {
+        postsAggregate(where: { author: { name: { eq: "SecondUser" } } }) { count }
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([{ postsAggregate: { count: 0 } }]);
+  });
+
+  it('keeps differently-filtered aliases of the same field independent', async () => {
+    const result = await ctx.gql.queryGql(`{
+      users(orderBy: { id: { direction: asc, priority: 1 } }) {
+        id
+        all: postsAggregate { count }
+        firstMessage: postsAggregate(where: { content: { eq: "1MESSAGE" } }) { count }
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([
+      { id: 1, all: { count: 4 }, firstMessage: { count: 1 } },
+      { id: 2, all: { count: 0 }, firstMessage: { count: 0 } },
+      { id: 5, all: { count: 2 }, firstMessage: { count: 1 } },
+    ]);
+  });
+
+  it('works alongside the relation itself being selected', async () => {
+    const result = await ctx.gql.queryGql(`{
+      users(where: { id: { eq: 5 } }) {
+        posts(orderBy: { id: { direction: asc, priority: 1 } }) { id }
+        postsAggregate { count }
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([
+      {
+        posts: [{ id: 4 }, { id: 5 }],
+        postsAggregate: { count: 2 },
+      },
+    ]);
+  });
+
+  it('aggregates a to-many relation reached through another table', async () => {
+    const result = await ctx.gql.queryGql(`{
+      customers(orderBy: { id: { direction: asc, priority: 1 } }) {
+        id
+        postsAggregate { count }
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.customers).toEqual([
+      { id: 1, postsAggregate: { count: 4 } },
+      { id: 2, postsAggregate: { count: 0 } },
+    ]);
+  });
+
+  it('aggregates relations on a delete mutation payload', async () => {
+    // `Posts.authorId` has no foreign key, so the posts outlive the deleted author.
+    const result = await ctx.gql.queryGql(`mutation {
+      deleteUser(where: { id: { eq: 5 } }) {
+        id
+        postsAggregate { count }
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.deleteUser).toEqual([{ id: 5, postsAggregate: { count: 2 } }]);
+  });
+
+  describe('schema shape', () => {
+    const type = (name: string) => (ctx.entities.types as unknown as Record<string, GraphQLObjectType>)[name]!;
+
+    it('adds an aggregate field for to-many relations only', () => {
+      const fields = type('User').getFields();
+
+      expect(fields['postsAggregate']).toBeDefined();
+      // `customer` is a to-one relation — nothing to aggregate over.
+      expect(fields['customerAggregate']).toBeUndefined();
+    });
+
+    it('reuses the target table root aggregate type', () => {
+      const field = type('User').getFields()['postsAggregate']!;
+      const fieldType = (field.type as GraphQLNonNull<GraphQLObjectType>).ofType;
+
+      expect(fieldType).toBe(type('PostAggregate'));
+      expect(field.args.map((arg) => arg.name)).toEqual(['where']);
+    });
+  });
+});

--- a/tests/pglite/relation-aggregate.test.ts
+++ b/tests/pglite/relation-aggregate.test.ts
@@ -167,6 +167,25 @@ describe.sequential('relation aggregates', () => {
     ]);
   });
 
+  it('exposes the per-column counts on a relation aggregate', async () => {
+    const result = await ctx.gql.queryGql(`{
+      users(orderBy: { id: { direction: asc, priority: 1 } }) {
+        id
+        postsAggregate {
+          countNonNull { content }
+          countDistinct { content }
+        }
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([
+      { id: 1, postsAggregate: { countNonNull: { content: 4 }, countDistinct: { content: 4 } } },
+      { id: 2, postsAggregate: { countNonNull: { content: 0 }, countDistinct: { content: 0 } } },
+      { id: 5, postsAggregate: { countNonNull: { content: 2 }, countDistinct: { content: 2 } } },
+    ]);
+  });
+
   it('aggregates relations on a delete mutation payload', async () => {
     // `Posts.authorId` has no foreign key, so the posts outlive the deleted author.
     const result = await ctx.gql.queryGql(`mutation {

--- a/tests/pglite/relation-filters.test.ts
+++ b/tests/pglite/relation-filters.test.ts
@@ -1,0 +1,210 @@
+import type { GraphQLInputObjectType } from 'graphql';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { type Context, createCtx, setupServer, setupTables, teardownServer, teardownTables } from './common';
+
+const DATA_DIR = `./tests/.temp/pgdata-relation-filters-${Date.now()}`;
+const ctx: Context = createCtx();
+
+beforeAll(async () => {
+  await setupServer(ctx, 4018, DATA_DIR);
+});
+afterAll(async () => {
+  await teardownServer(ctx, DATA_DIR);
+});
+beforeEach(async () => {
+  await setupTables(ctx);
+});
+afterEach(async () => {
+  await teardownTables(ctx);
+});
+
+// Seed recap: user 1 (FirstUser) wrote posts 1,2,3,6; user 5 (FifthUser) wrote posts 4,5;
+// user 2 (SecondUser) wrote none. Customers 1 and 2 belong to users 1 and 2.
+describe.sequential('relation filters', () => {
+  it('filters a table by a to-many relation with `some`', async () => {
+    const result = await ctx.gql.queryGql(`{
+      users(where: { posts: { some: { content: { eq: "3MESSAGE" } } } }, orderBy: { id: { direction: asc, priority: 1 } }) {
+        id
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([{ id: 1 }]);
+  });
+
+  it('filters a table by a to-many relation with `none`', async () => {
+    const result = await ctx.gql.queryGql(`{
+      users(where: { posts: { none: {} } }) { id }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([{ id: 2 }]);
+  });
+
+  it('filters a table by a to-many relation with `every`', async () => {
+    // Users 1 and 5 both have posts that are not "1MESSAGE"; user 2 matches vacuously.
+    const result = await ctx.gql.queryGql(`{
+      users(where: { posts: { every: { content: { eq: "1MESSAGE" } } } }) { id }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([{ id: 2 }]);
+  });
+
+  it('combines several match modes on one relation', async () => {
+    const result = await ctx.gql.queryGql(`{
+      users(where: {
+        posts: {
+          some: { content: { eq: "1MESSAGE" } }
+          none: { content: { eq: "3MESSAGE" } }
+        }
+      }) { id }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([{ id: 5 }]);
+  });
+
+  it('filters a table by a to-one relation', async () => {
+    const result = await ctx.gql.queryGql(`{
+      posts(where: { author: { name: { eq: "FifthUser" } } }, orderBy: { id: { direction: asc, priority: 1 } }) {
+        id
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.posts).toEqual([{ id: 4 }, { id: 5 }]);
+  });
+
+  it('filters through nested relations', async () => {
+    const result = await ctx.gql.queryGql(`{
+      users(where: { posts: { some: { author: { name: { eq: "FirstUser" } } } } }) { id }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([{ id: 1 }]);
+  });
+
+  it('ANDs a relation filter with column filters', async () => {
+    const result = await ctx.gql.queryGql(`{
+      users(where: { name: { like: "F%" }, posts: { some: { content: { eq: "2MESSAGE" } } } }, orderBy: { id: { direction: asc, priority: 1 } }) {
+        id
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([{ id: 1 }, { id: 5 }]);
+  });
+
+  it('supports relation filters inside OR', async () => {
+    const result = await ctx.gql.queryGql(`{
+      users(
+        where: { OR: [{ name: { eq: "SecondUser" } }, { posts: { some: { content: { eq: "3MESSAGE" } } } }] }
+        orderBy: { id: { direction: asc, priority: 1 } }
+      ) { id }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([{ id: 1 }, { id: 2 }]);
+  });
+
+  it('applies relation filters to single queries', async () => {
+    const result = await ctx.gql.queryGql(`{
+      customer(where: { user: { name: { eq: "SecondUser" } } }) { id address }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.customer).toEqual({ id: 2, address: 'AdTwo' });
+  });
+
+  it('applies relation filters to aggregate queries', async () => {
+    const result = await ctx.gql.queryGql(`{
+      usersAggregate(where: { posts: { some: {} } }) { count }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.usersAggregate).toEqual({ count: 2 });
+  });
+
+  it('applies relation filters to a relation field argument', async () => {
+    const result = await ctx.gql.queryGql(`{
+      user(where: { id: { eq: 1 } }) {
+        id
+        posts(where: { author: { name: { eq: "SecondUser" } } }) { id }
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.user).toEqual({ id: 1, posts: [] });
+  });
+
+  it('applies relation filters to delete mutations', async () => {
+    const result = await ctx.gql.queryGql(`mutation {
+      deletePost(where: { author: { name: { eq: "FifthUser" } } }) { id }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.deletePost).toEqual([{ id: 4 }, { id: 5 }]);
+
+    const remaining = await ctx.gql.queryGql(`{ postsAggregate { count } }`);
+    expect(remaining.data?.postsAggregate).toEqual({ count: 4 });
+  });
+
+  it('applies relation filters to update mutations', async () => {
+    const result = await ctx.gql.queryGql(`mutation {
+      updatePost(set: { content: "UPDATED" }, where: { author: { name: { eq: "FifthUser" } } }) { id content }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.updatePost).toEqual([
+      { id: 4, content: 'UPDATED' },
+      { id: 5, content: 'UPDATED' },
+    ]);
+  });
+
+  it('an empty relation filter does not restrict the result', async () => {
+    const result = await ctx.gql.queryGql(`{
+      users(where: { posts: { some: {} } }, orderBy: { id: { direction: asc, priority: 1 } }) { id }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([{ id: 1 }, { id: 5 }]);
+  });
+
+  describe('schema shape', () => {
+    // `entities.inputs` is keyed by the real GraphQL type name, which the typeNameMapper
+    // singularises — the static type can't know that, so index it as a plain record.
+    const input = (name: string) => (ctx.entities.inputs as unknown as Record<string, GraphQLInputObjectType>)[name]!;
+
+    it('exposes to-many relations as a some/none/every wrapper', () => {
+      const fields = input('UserFilters').getFields();
+
+      expect(fields['posts']).toBeDefined();
+      const postsFilter = fields['posts']!.type as GraphQLInputObjectType;
+      expect(postsFilter.name).toBe('PostListRelationFilter');
+      expect(Object.keys(postsFilter.getFields())).toEqual(['some', 'none', 'every']);
+      expect(postsFilter.getFields()['some']!.type).toBe(input('PostFilters'));
+    });
+
+    it('exposes to-one relations as the target filter input directly', () => {
+      const fields = input('PostFilters').getFields();
+
+      expect(fields['author']!.type).toBe(input('UserFilters'));
+      expect(fields['customer']!.type).toBe(input('CustomerFilters'));
+    });
+
+    it('leaves relation fields off tables that have no relations', () => {
+      const fields = input('TagFilters').getFields();
+
+      expect(Object.keys(fields).sort()).toEqual(['OR', 'description', 'id', 'name']);
+    });
+
+    it('offers relation filters in the OR variant too', () => {
+      const orField = input('UserFilters').getFields()['OR']!;
+      const orType = (orField.type as any).ofType.ofType as GraphQLInputObjectType;
+
+      expect(orType.name).toBe('UserFiltersOr');
+      expect(orType.getFields()['posts']).toBeDefined();
+    });
+  });
+});

--- a/tests/pglite/returned-data.test.ts
+++ b/tests/pglite/returned-data.test.ts
@@ -1,4 +1,11 @@
-import { GraphQLInputObjectType, GraphQLNonNull, GraphQLObjectType, GraphQLScalarType, GraphQLSchema } from 'graphql';
+import {
+  GraphQLInputObjectType,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLScalarType,
+  GraphQLSchema,
+} from 'graphql';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import z from 'zod';
 import { createMinimalCtx, type MinimalContext, setupMinimal, teardownMinimal } from './common';
@@ -48,6 +55,11 @@ describe.sequential('Returned data tests', () => {
                     where: z
                       .object({
                         type: z.instanceof(GraphQLInputObjectType),
+                      })
+                      .strict(),
+                    distinct: z
+                      .object({
+                        type: z.instanceof(GraphQLList),
                       })
                       .strict(),
                   })
@@ -105,6 +117,11 @@ describe.sequential('Returned data tests', () => {
                         type: z.instanceof(GraphQLInputObjectType),
                       })
                       .strict(),
+                    distinct: z
+                      .object({
+                        type: z.instanceof(GraphQLList),
+                      })
+                      .strict(),
                   })
                   .strict(),
                 resolve: z.function(),
@@ -160,6 +177,11 @@ describe.sequential('Returned data tests', () => {
                         type: z.instanceof(GraphQLInputObjectType),
                       })
                       .strict(),
+                    distinct: z
+                      .object({
+                        type: z.instanceof(GraphQLList),
+                      })
+                      .strict(),
                   })
                   .strict(),
                 resolve: z.function(),
@@ -213,6 +235,11 @@ describe.sequential('Returned data tests', () => {
                     where: z
                       .object({
                         type: z.instanceof(GraphQLInputObjectType),
+                      })
+                      .strict(),
+                    distinct: z
+                      .object({
+                        type: z.instanceof(GraphQLList),
                       })
                       .strict(),
                   })

--- a/tests/pglite/returned-data.test.ts
+++ b/tests/pglite/returned-data.test.ts
@@ -246,6 +246,66 @@ describe.sequential('Returned data tests', () => {
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
+            usersAggregate: z
+              .object({
+                args: z
+                  .object({
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
+            postsAggregate: z
+              .object({
+                args: z
+                  .object({
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
+            customersAggregate: z
+              .object({
+                args: z
+                  .object({
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
+            tagsAggregate: z
+              .object({
+                args: z
+                  .object({
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
           })
           .strict(),
         mutations: z
@@ -522,6 +582,10 @@ describe.sequential('Returned data tests', () => {
             Customer: z.instanceof(GraphQLObjectType),
             Tag: z.instanceof(GraphQLObjectType),
             Tag: z.instanceof(GraphQLObjectType),
+            UserAggregate: z.instanceof(GraphQLObjectType),
+            PostAggregate: z.instanceof(GraphQLObjectType),
+            CustomerAggregate: z.instanceof(GraphQLObjectType),
+            TagAggregate: z.instanceof(GraphQLObjectType),
           })
           .strict(),
         inputs: z

--- a/tests/pglite/scalars.test.ts
+++ b/tests/pglite/scalars.test.ts
@@ -1,0 +1,185 @@
+import { PGlite } from '@electric-sql/pglite';
+import { buildRelations, sql } from 'drizzle-orm';
+import { bigint, jsonb, pgTable, text, uuid } from 'drizzle-orm/pg-core';
+import { drizzle } from 'drizzle-orm/pglite';
+import { type GraphQLObjectType, type GraphQLSchema, graphql } from 'graphql';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildSchema } from '@/index';
+
+// ── Schema covering every scalar-mapped column type ──────────────────────────
+const Docs = pgTable('docs', {
+  id: uuid('id').primaryKey(),
+  ownerId: uuid('owner_id'),
+  payload: jsonb('payload'),
+  counter: bigint('counter', { mode: 'bigint' }),
+  label: text('label'),
+});
+const relations = buildRelations({ Docs }, {});
+const schema = { Docs, relations };
+
+const DATA_DIR = `./tests/.temp/pgdata-scalars-${Date.now()}`;
+const UUID_A = '11111111-1111-4111-8111-111111111111';
+const UUID_B = '22222222-2222-4222-8222-222222222222';
+
+let pglite: PGlite;
+let db: any;
+let gqlSchema: GraphQLSchema;
+let entities: any;
+
+const run = (source: string, variableValues?: Record<string, any>) =>
+  graphql({ schema: gqlSchema, source, contextValue: {}, variableValues });
+
+const fieldTypeName = (typeName: string, fieldName: string) =>
+  String((entities.types[typeName] as GraphQLObjectType).getFields()[fieldName]!.type);
+
+beforeAll(async () => {
+  pglite = new PGlite(DATA_DIR);
+  await pglite.waitReady;
+  db = (drizzle as any)({ client: pglite, schema, relations, logger: !!process.env['LOG_SQL'] });
+
+  await db.execute(
+    sql`CREATE TABLE "docs" (
+      "id" uuid PRIMARY KEY NOT NULL,
+      "owner_id" uuid,
+      "payload" jsonb,
+      "counter" bigint,
+      "label" text
+    );`,
+  );
+
+  const built = buildSchema(db);
+  gqlSchema = built.schema;
+  entities = built.entities;
+});
+
+afterAll(async () => {
+  await pglite?.close().catch(() => {});
+});
+
+describe.sequential('scalar schema shape', () => {
+  it('maps uuid columns to the UUID scalar', () => {
+    expect(fieldTypeName('Docs', 'id')).toBe('UUID!');
+    expect(fieldTypeName('Docs', 'ownerId')).toBe('UUID');
+  });
+
+  it('maps jsonb columns to the JSON scalar', () => {
+    expect(fieldTypeName('Docs', 'payload')).toBe('JSON');
+  });
+
+  it('maps bigint columns to the BigInt scalar', () => {
+    expect(fieldTypeName('Docs', 'counter')).toBe('BigInt');
+  });
+
+  it('leaves plain text columns as String', () => {
+    expect(fieldTypeName('Docs', 'label')).toBe('String');
+  });
+
+  it('uses the same scalars on the insert input', () => {
+    const fields = entities.inputs['CreateDocsInput'].getFields();
+    expect(String(fields['id'].type)).toBe('UUID!');
+    expect(String(fields['payload'].type)).toBe('JSON');
+    expect(String(fields['counter'].type)).toBe('BigInt');
+  });
+
+  it('aggregates over a bigint column keep the BigInt scalar', () => {
+    const aggregate = (entities.types['DocsAggregate'] as GraphQLObjectType).getFields();
+    const min = (aggregate['min']!.type as any).getFields();
+    expect(String(min['counter'].type)).toBe('BigInt');
+  });
+});
+
+describe.sequential('JSON round-trips', () => {
+  it('stores and returns an object literal without stringifying it', async () => {
+    const insert = await run(`mutation {
+      createDocsSingle(values: { id: "${UUID_A}", payload: { field: "value", nested: { n: 1 } } }) {
+        id
+        payload
+      }
+    }`);
+    expect(insert.errors).toBeUndefined();
+    expect((insert.data as any).createDocsSingle).toEqual({
+      id: UUID_A,
+      payload: { field: 'value', nested: { n: 1 } },
+    });
+
+    const read = await run(`{ docsSingle(where: { id: { eq: "${UUID_A}" } }) { payload } }`);
+    expect(read.errors).toBeUndefined();
+    expect((read.data as any).docsSingle.payload).toEqual({ field: 'value', nested: { n: 1 } });
+  });
+
+  it('round-trips a JSON array', async () => {
+    const res = await run(`mutation {
+      createDocsSingle(values: { id: "${UUID_B}", payload: [1, "two", { three: true }] }) { payload }
+    }`);
+    expect(res.errors).toBeUndefined();
+    expect((res.data as any).createDocsSingle.payload).toEqual([1, 'two', { three: true }]);
+  });
+
+  it('round-trips a JSON value that is itself a string, without re-parsing it', async () => {
+    const id = '33333333-3333-4333-8333-333333333333';
+    const res = await run(`mutation {
+      createDocsSingle(values: { id: "${id}", payload: "just a string" }) { payload }
+    }`);
+    // Previously this threw, because the string was fed back through JSON.parse.
+    expect(res.errors).toBeUndefined();
+    expect((res.data as any).createDocsSingle.payload).toBe('just a string');
+  });
+
+  it('accepts a JSON value passed as a variable', async () => {
+    const id = '44444444-4444-4444-8444-444444444444';
+    const res = await run(`mutation ($v: CreateDocsInput!) { createDocsSingle(values: $v) { payload } }`, {
+      v: { id, payload: { from: 'variable' } },
+    });
+    expect(res.errors).toBeUndefined();
+    expect((res.data as any).createDocsSingle.payload).toEqual({ from: 'variable' });
+  });
+});
+
+describe.sequential('BigInt round-trips', () => {
+  it('accepts a decimal string and returns one', async () => {
+    const id = '55555555-5555-4555-8555-555555555555';
+    const res = await run(`mutation {
+      createDocsSingle(values: { id: "${id}", counter: "9007199254740993" }) { counter }
+    }`);
+    expect(res.errors).toBeUndefined();
+    // 9007199254740993 is not representable as a JS number — it must survive as a string.
+    expect((res.data as any).createDocsSingle.counter).toBe('9007199254740993');
+  });
+
+  it('accepts an integer literal', async () => {
+    const id = '66666666-6666-4666-8666-666666666666';
+    const res = await run(`mutation { createDocsSingle(values: { id: "${id}", counter: 42 }) { counter } }`);
+    expect(res.errors).toBeUndefined();
+    expect((res.data as any).createDocsSingle.counter).toBe('42');
+  });
+
+  it('rejects a non-integer string', async () => {
+    const id = '77777777-7777-4777-8777-777777777777';
+    const res = await run(`mutation { createDocsSingle(values: { id: "${id}", counter: "12.5" }) { counter } }`);
+    expect(res.errors?.[0]?.message).toMatch(/BigInt cannot represent non-integer value/);
+  });
+
+  it('rejects a float literal', async () => {
+    const id = '88888888-8888-4888-8888-888888888888';
+    const res = await run(`mutation { createDocsSingle(values: { id: "${id}", counter: 1.5 }) { counter } }`);
+    expect(res.errors?.[0]?.message).toMatch(/BigInt cannot represent a FloatValue/);
+  });
+});
+
+describe.sequential('UUID round-trips', () => {
+  it('returns the stored uuid unchanged', async () => {
+    const res = await run(`{ docsSingle(where: { id: { eq: "${UUID_A}" } }) { id } }`);
+    expect(res.errors).toBeUndefined();
+    expect((res.data as any).docsSingle.id).toBe(UUID_A);
+  });
+
+  it('rejects a malformed uuid on input', async () => {
+    const res = await run(`mutation { createDocsSingle(values: { id: "not-a-uuid" }) { id } }`);
+    expect(res.errors?.[0]?.message).toMatch(/UUID/);
+  });
+
+  it('rejects a malformed uuid in a filter', async () => {
+    const res = await run(`{ docsSingle(where: { id: { eq: "nope" } }) { id } }`);
+    expect(res.errors?.[0]?.message).toMatch(/UUID/);
+  });
+});

--- a/tests/pglite/transaction.test.ts
+++ b/tests/pglite/transaction.test.ts
@@ -1,0 +1,208 @@
+import { eq } from 'drizzle-orm';
+import { type GraphQLSchema, graphql } from 'graphql';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { buildSchema, drizzleExecutorKey } from '@/index';
+import {
+  createMinimalCtx,
+  type MinimalContext,
+  schema,
+  setupMinimal,
+  setupTables,
+  sql,
+  teardownMinimal,
+  teardownTables,
+} from './common';
+
+const DATA_DIR = `./tests/.temp/pgdata-transaction-${Date.now()}`;
+const ctx: MinimalContext = createMinimalCtx();
+
+// The same schema shape as ctx.schema, but with relations resolved lazily through the
+// request batch loader instead of an eager lateral join, so both paths get covered.
+let lazySchema: GraphQLSchema;
+
+const runOn = (gqlSchema: GraphQLSchema, source: string, executor?: unknown) =>
+  graphql({
+    schema: gqlSchema,
+    source,
+    contextValue: executor ? { [drizzleExecutorKey]: executor } : {},
+  });
+
+const run = (source: string, executor?: unknown) => runOn(ctx.schema, source, executor);
+
+/**
+ * Records every property read off the executor so we can prove a resolver went through the
+ * context executor rather than the build-time `db`. Methods are bound to the real target so
+ * drizzle's builders keep working.
+ */
+const recordingExecutor = <T extends object>(target: T, reads: string[]): T =>
+  new Proxy(target, {
+    get(t, prop) {
+      if (typeof prop === 'string') reads.push(prop);
+      const value = Reflect.get(t, prop, t);
+      return typeof value === 'function' ? value.bind(t) : value;
+    },
+  });
+
+beforeAll(async () => {
+  await setupMinimal(ctx, DATA_DIR);
+  await ctx.db.execute(
+    sql`DO $$ BEGIN CREATE TYPE "role" AS ENUM('admin','user'); EXCEPTION WHEN duplicate_object THEN null; END $$;`,
+  );
+  lazySchema = buildSchema(ctx.db, {
+    typeNameMapper: (name) =>
+      (
+        ({
+          Users: { singular: 'user', plural: 'users' },
+          Posts: { singular: 'post', plural: 'posts' },
+          Customers: { singular: 'customer', plural: 'customers' },
+          Tags: { singular: 'tag', plural: 'tags' },
+        }) as Record<string, { singular: string; plural: string }>
+      )[name],
+    prefixes: { insert: 'create', delete: 'delete' },
+    suffixes: { single: '', list: '' },
+    eagerLoadRelations: false,
+  }).schema;
+});
+afterAll(async () => {
+  await teardownMinimal(ctx, DATA_DIR);
+});
+beforeEach(async () => {
+  await setupTables(ctx);
+});
+afterEach(async () => {
+  await teardownTables(ctx);
+});
+
+describe.sequential('context executor routing', () => {
+  it('runs list queries on the context executor', async () => {
+    const reads: string[] = [];
+    const result = await run(`{ users { id name } }`, recordingExecutor(ctx.db, reads));
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.['users']).toHaveLength(3);
+    expect(reads).toContain('query');
+  });
+
+  it('runs single queries on the context executor', async () => {
+    const reads: string[] = [];
+    const result = await run(`{ user(where: { id: { eq: 1 } }) { id name } }`, recordingExecutor(ctx.db, reads));
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.['user']).toMatchObject({ id: 1, name: 'FirstUser' });
+    expect(reads).toContain('query');
+  });
+
+  it('runs lazy relation field resolvers on the context executor', async () => {
+    const reads: string[] = [];
+    // eagerLoadRelations: false, so `posts` goes through the request batch loader, which
+    // issues its own select and has to pick up the executor at resolve time.
+    const result = await runOn(lazySchema, `{ users { id posts { id content } } }`, recordingExecutor(ctx.db, reads));
+
+    expect(result.errors).toBeUndefined();
+    expect((result.data?.['users'] as any[])?.find((u) => u.id === 1)?.posts).toHaveLength(4);
+    expect(reads).toContain('select');
+  });
+
+  it('runs aggregate queries on the context executor', async () => {
+    const reads: string[] = [];
+    const result = await run(`{ usersAggregate { count } }`, recordingExecutor(ctx.db, reads));
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.['usersAggregate']).toMatchObject({ count: 3 });
+    expect(reads).toContain('select');
+  });
+
+  it('runs relation aggregates on the context executor', async () => {
+    const reads: string[] = [];
+    const result = await run(`{ users { id postsAggregate { count } } }`, recordingExecutor(ctx.db, reads));
+
+    expect(result.errors).toBeUndefined();
+    expect(reads).toContain('select');
+  });
+
+  it('runs insert, update and delete mutations on the context executor', async () => {
+    const inserts: string[] = [];
+    const insert = await run(
+      `mutation { createUser(values: { id: 100, name: "TxUser" }) { id name } }`,
+      recordingExecutor(ctx.db, inserts),
+    );
+    expect(insert.errors).toBeUndefined();
+    expect(inserts).toContain('insert');
+
+    const updates: string[] = [];
+    const update = await run(
+      `mutation { updateUser(set: { name: "Renamed" }, where: { id: { eq: 100 } }) { id name } }`,
+      recordingExecutor(ctx.db, updates),
+    );
+    expect(update.errors).toBeUndefined();
+    expect(updates).toContain('update');
+
+    const deletes: string[] = [];
+    const del = await run(
+      `mutation { deleteUser(where: { id: { eq: 100 } }) { id } }`,
+      recordingExecutor(ctx.db, deletes),
+    );
+    expect(del.errors).toBeUndefined();
+    expect(deletes).toContain('delete');
+  });
+
+  it('falls back to the build-time db when the context carries no executor', async () => {
+    const result = await run(`{ users { id name } }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.['users']).toHaveLength(3);
+  });
+});
+
+describe.sequential('transactions', () => {
+  it('rolls back mutations executed on a transaction', async () => {
+    await expect(
+      ctx.db.transaction(async (tx) => {
+        const insert = await run(`mutation { createUser(values: { id: 101, name: "RolledBack" }) { id name } }`, tx);
+        expect(insert.errors).toBeUndefined();
+
+        // The uncommitted row is visible to queries running on the same transaction.
+        const inside = await run(`{ user(where: { id: { eq: 101 } }) { id name } }`, tx);
+        expect(inside.data?.['user']).toMatchObject({ id: 101, name: 'RolledBack' });
+
+        throw new Error('rollback please');
+      }),
+    ).rejects.toThrow('rollback please');
+
+    const rows = await ctx.db.select().from(schema.Users).where(eq(schema.Users.id, 101));
+    expect(rows).toHaveLength(0);
+  });
+
+  it('commits several mutations as one unit', async () => {
+    await ctx.db.transaction(async (tx) => {
+      const first = await run(`mutation { createUser(values: { id: 102, name: "CommittedOne" }) { id } }`, tx);
+      const second = await run(`mutation { createUser(values: { id: 103, name: "CommittedTwo" }) { id } }`, tx);
+
+      expect(first.errors).toBeUndefined();
+      expect(second.errors).toBeUndefined();
+    });
+
+    const rows = await ctx.db.select().from(schema.Users).where(eq(schema.Users.id, 102));
+    expect(rows).toHaveLength(1);
+    const others = await ctx.db.select().from(schema.Users).where(eq(schema.Users.id, 103));
+    expect(others).toHaveLength(1);
+  });
+
+  it('rolls back every mutation in the batch when a later one fails', async () => {
+    await expect(
+      ctx.db.transaction(async (tx) => {
+        const ok = await run(`mutation { createUser(values: { id: 104, name: "First" }) { id } }`, tx);
+        expect(ok.errors).toBeUndefined();
+
+        // Duplicate primary key: the resolver surfaces the error, and re-throwing it aborts
+        // the transaction the way a caller batching mutations would.
+        const conflict = await run(`mutation { createUser(values: { id: 104, name: "Duplicate" }) { id } }`, tx);
+        expect(conflict.errors).toBeDefined();
+        throw new Error('aborting batch');
+      }),
+    ).rejects.toThrow();
+
+    const rows = await ctx.db.select().from(schema.Users).where(eq(schema.Users.id, 104));
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/tests/pglite/type.test.ts
+++ b/tests/pglite/type.test.ts
@@ -9,6 +9,7 @@ import type {
 } from 'graphql';
 import { afterAll, beforeAll, describe, expectTypeOf, it } from 'vitest';
 import {
+  type AggregateResolver,
   buildSchema,
   type DeleteResolver,
   type ExtractTables,
@@ -142,6 +143,35 @@ describe.sequential('Type tests', () => {
             ExtractTables<typeof schema>,
             typeof schema.usersRelations extends Relations<any, infer RelConf> ? RelConf : never
           >;
+        };
+      } & {
+        readonly customersAggregate: {
+          type: GraphQLNonNull<GraphQLObjectType>;
+          args: {
+            where: { type: GraphQLInputObjectType };
+          };
+          resolve: AggregateResolver<typeof schema.Customers>;
+        };
+        readonly postsAggregate: {
+          type: GraphQLNonNull<GraphQLObjectType>;
+          args: {
+            where: { type: GraphQLInputObjectType };
+          };
+          resolve: AggregateResolver<typeof schema.Posts>;
+        };
+        readonly tagsAggregate: {
+          type: GraphQLNonNull<GraphQLObjectType>;
+          args: {
+            where: { type: GraphQLInputObjectType };
+          };
+          resolve: AggregateResolver<typeof schema.Tags>;
+        };
+        readonly usersAggregate: {
+          type: GraphQLNonNull<GraphQLObjectType>;
+          args: {
+            where: { type: GraphQLInputObjectType };
+          };
+          resolve: AggregateResolver<typeof schema.Users>;
         };
       }
     >();
@@ -309,6 +339,11 @@ describe.sequential('Type tests', () => {
         readonly Posts: GraphQLObjectType;
         readonly Tags: GraphQLObjectType;
         readonly Users: GraphQLObjectType;
+      } & {
+        readonly CustomersAggregate: GraphQLObjectType;
+        readonly PostsAggregate: GraphQLObjectType;
+        readonly TagsAggregate: GraphQLObjectType;
+        readonly UsersAggregate: GraphQLObjectType;
       }
     >();
   });

--- a/tests/pglite/type.test.ts
+++ b/tests/pglite/type.test.ts
@@ -1,5 +1,6 @@
 import type { Relations } from 'drizzle-orm';
 import type {
+  GraphQLEnumType,
   GraphQLInputObjectType,
   GraphQLList,
   GraphQLNonNull,
@@ -50,6 +51,7 @@ describe.sequential('Type tests', () => {
             offset: { type: GraphQLScalarType<number, number> };
             limit: { type: GraphQLScalarType<number, number> };
             where: { type: GraphQLInputObjectType };
+            distinct: { type: GraphQLList<GraphQLNonNull<GraphQLEnumType>> };
           };
           resolve: SelectResolver<
             typeof schema.Customers,
@@ -64,6 +66,7 @@ describe.sequential('Type tests', () => {
             offset: { type: GraphQLScalarType<number, number> };
             limit: { type: GraphQLScalarType<number, number> };
             where: { type: GraphQLInputObjectType };
+            distinct: { type: GraphQLList<GraphQLNonNull<GraphQLEnumType>> };
           };
           resolve: SelectResolver<
             typeof schema.Posts,
@@ -78,6 +81,7 @@ describe.sequential('Type tests', () => {
             offset: { type: GraphQLScalarType<number, number> };
             limit: { type: GraphQLScalarType<number, number> };
             where: { type: GraphQLInputObjectType };
+            distinct: { type: GraphQLList<GraphQLNonNull<GraphQLEnumType>> };
           };
           resolve: SelectResolver<typeof schema.Tags, ExtractTables<typeof schema>, never>;
         };
@@ -88,6 +92,7 @@ describe.sequential('Type tests', () => {
             offset: { type: GraphQLScalarType<number, number> };
             limit: { type: GraphQLScalarType<number, number> };
             where: { type: GraphQLInputObjectType };
+            distinct: { type: GraphQLList<GraphQLNonNull<GraphQLEnumType>> };
           };
           resolve: SelectResolver<
             typeof schema.Users,

--- a/tests/pglite/unique-columns.test.ts
+++ b/tests/pglite/unique-columns.test.ts
@@ -1,0 +1,132 @@
+import { sql } from 'drizzle-orm';
+import { getTableConfig, integer, pgTable, primaryKey, text, unique, uniqueIndex } from 'drizzle-orm/pg-core';
+import { sqliteTable, getTableConfig as sqliteTableConfig, text as sqliteText } from 'drizzle-orm/sqlite-core';
+import { describe, expect, it } from 'vitest';
+import { generateColumnEnum, getUniqueColumnSets } from '@/util/builders/common';
+
+// getUniqueColumnSets takes the dialect's getTableConfig so one implementation serves all
+// three; these helpers stand in for what pg.ts / sqlite.ts pass.
+const pgUniqueSets = (table: any): string[][] => getUniqueColumnSets(table, getTableConfig as any);
+const sqliteUniqueSets = (table: any): string[][] => getUniqueColumnSets(table, sqliteTableConfig as any);
+
+describe('getUniqueColumnSets', () => {
+  it('reports an inline primary key', () => {
+    const t = pgTable('inline_pk', { id: integer('id').primaryKey(), name: text('name') });
+    expect(pgUniqueSets(t)).toEqual([['id']]);
+  });
+
+  it('reports a table-level composite primary key by property name', () => {
+    const t = pgTable(
+      'composite_pk',
+      { orgId: integer('org_id').notNull(), userId: integer('user_id').notNull() },
+      (cols) => [primaryKey({ columns: [cols.orgId, cols.userId] })],
+    );
+    expect(pgUniqueSets(t)).toEqual([['orgId', 'userId']]);
+  });
+
+  it('reports a table-level unique constraint alongside the primary key', () => {
+    const t = pgTable(
+      'unique_constraint',
+      { id: integer('id').primaryKey(), tenantId: integer('tenant_id').notNull(), email: text('email').notNull() },
+      (cols) => [unique('uq_tenant_email').on(cols.tenantId, cols.email)],
+    );
+    expect(pgUniqueSets(t)).toEqual([['id'], ['tenantId', 'email']]);
+  });
+
+  it('reports a unique index and ignores a non-unique one', () => {
+    const t = pgTable(
+      'unique_index',
+      { id: integer('id').primaryKey(), slug: text('slug').notNull(), name: text('name') },
+      (cols) => [uniqueIndex('uq_slug').on(cols.slug)],
+    );
+    expect(pgUniqueSets(t)).toEqual([['id'], ['slug']]);
+  });
+
+  it('reports an inline .unique() column', () => {
+    const t = pgTable('inline_unique', { id: integer('id').primaryKey(), email: text('email').unique() });
+    expect(pgUniqueSets(t)).toEqual([['id'], ['email']]);
+  });
+
+  it('deduplicates a column that is unique twice over', () => {
+    const t = pgTable(
+      'dedup',
+      { id: integer('id').primaryKey(), email: text('email').notNull().unique(), other: text('other').notNull() },
+      (cols) => [uniqueIndex('uq_email').on(cols.email), unique('uq_pair').on(cols.other, cols.email)],
+    );
+    // `email` appears via the unique index and the inline flag but is reported once; the
+    // (other, email) pair is a different set and survives. Constraints are listed before
+    // indexes, which are listed before inline unique columns.
+    expect(pgUniqueSets(t)).toEqual([['id'], ['other', 'email'], ['email']]);
+  });
+
+  it('skips an expression index, whose columns have no property to name', () => {
+    const t = pgTable('expr_index', { id: integer('id').primaryKey(), email: text('email').notNull() }, () => [
+      uniqueIndex('uq_lower_email').on(sql`lower(email)`),
+    ]);
+    expect(pgUniqueSets(t)).toEqual([['id']]);
+  });
+
+  it('returns nothing when the table declares no unique columns at all', () => {
+    const t = pgTable('no_keys', { name: text('name'), value: integer('value') });
+    expect(pgUniqueSets(t)).toEqual([]);
+  });
+
+  it('works the same way on a sqlite table', () => {
+    const t = sqliteTable('sqlite_keys', {
+      id: sqliteText('id').primaryKey(),
+      email: sqliteText('email').unique(),
+    });
+    expect(sqliteUniqueSets(t)).toEqual([['id'], ['email']]);
+  });
+});
+
+describe('generateColumnEnum', () => {
+  const table = pgTable('enum_source', {
+    id: integer('id').primaryKey(),
+    userName: text('user_name').notNull(),
+    email: text('email'),
+  });
+
+  it('builds an enum of every column property name by default', () => {
+    const gqlEnum = generateColumnEnum(table, 'EnumSourceAllColumns', 'All of them');
+
+    expect(gqlEnum?.name).toBe('EnumSourceAllColumns');
+    expect(gqlEnum?.description).toBe('All of them');
+    // Property names, not database column names.
+    expect(gqlEnum?.getValues().map((v) => v.name)).toEqual(['id', 'userName', 'email']);
+    expect(gqlEnum?.getValue('userName')?.value).toBe('userName');
+  });
+
+  it('filters columns with the predicate', () => {
+    const gqlEnum = generateColumnEnum(
+      table,
+      'EnumSourceNotNull',
+      'Only the required ones',
+      (column) => column.notNull,
+    );
+
+    expect(gqlEnum?.getValues().map((v) => v.name)).toEqual(['id', 'userName']);
+  });
+
+  it('returns undefined rather than an empty enum when nothing qualifies', () => {
+    expect(generateColumnEnum(table, 'EnumSourceNone', 'Nothing', () => false)).toBeUndefined();
+  });
+
+  it('caches per table and enum name', () => {
+    const first = generateColumnEnum(table, 'EnumSourceCached', 'Cached');
+    const second = generateColumnEnum(table, 'EnumSourceCached', 'Cached');
+    const other = generateColumnEnum(table, 'EnumSourceCachedOther', 'A different enum');
+
+    expect(second).toBe(first);
+    expect(other).not.toBe(first);
+  });
+
+  it('does not share a cache entry between two tables', () => {
+    const otherTable = pgTable('enum_source_two', { id: integer('id').primaryKey() });
+    const forFirst = generateColumnEnum(table, 'SharedName', 'x');
+    const forOther = generateColumnEnum(otherTable, 'SharedName', 'x');
+
+    expect(forOther).not.toBe(forFirst);
+    expect(forOther?.getValues().map((v) => v.name)).toEqual(['id']);
+  });
+});

--- a/tests/pglite/upsert.test.ts
+++ b/tests/pglite/upsert.test.ts
@@ -1,0 +1,239 @@
+import { PGlite } from '@electric-sql/pglite';
+import { buildRelations, sql } from 'drizzle-orm';
+import { integer, pgTable, text, unique } from 'drizzle-orm/pg-core';
+import { drizzle } from 'drizzle-orm/pglite';
+import { type GraphQLSchema, graphql } from 'graphql';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { buildSchema } from '@/index';
+
+// ── Schema with something to conflict on ──────────────────────────────────────
+const Items = pgTable(
+  'items',
+  {
+    id: integer('id').primaryKey(),
+    sku: text('sku').notNull(),
+    region: text('region').notNull(),
+    name: text('name'),
+    qty: integer('qty'),
+  },
+  (t) => [unique('items_sku_region').on(t.sku, t.region)],
+);
+// No primary key and no unique constraint: nothing to conflict on.
+const Logs = pgTable('logs', { body: text('body') });
+
+const relations = buildRelations({ Items, Logs }, { Items: {}, Logs: {} });
+const schema = { Items, Logs, relations };
+
+const DATA_DIR = `./tests/.temp/pgdata-upsert-${Date.now()}`;
+let pglite: PGlite;
+let db: any;
+let gqlSchema: GraphQLSchema;
+
+const run = (source: string, variableValues?: Record<string, any>) =>
+  graphql({ schema: gqlSchema, source, variableValues, contextValue: {} });
+
+const items = () => db.select().from(Items).orderBy(Items.id);
+
+beforeAll(async () => {
+  pglite = new PGlite(DATA_DIR);
+  await pglite.waitReady;
+  db = (drizzle as any)({ client: pglite, schema, relations, logger: !!process.env['LOG_SQL'] });
+
+  await db.execute(sql`CREATE TABLE "items" (
+		"id" integer PRIMARY KEY NOT NULL,
+		"sku" text NOT NULL,
+		"region" text NOT NULL,
+		"name" text,
+		"qty" integer,
+		CONSTRAINT "items_sku_region" UNIQUE("sku", "region")
+	);`);
+  await db.execute(sql`CREATE TABLE "logs" ("body" text);`);
+
+  gqlSchema = buildSchema(db, { features: { upsert: true } }).schema;
+});
+
+afterAll(async () => {
+  await pglite?.close().catch(console.error);
+  const { rm } = await import('node:fs/promises');
+  await rm(DATA_DIR, { recursive: true, force: true }).catch(console.error);
+});
+
+beforeEach(async () => {
+  await db.execute(sql`DELETE FROM "items"`);
+  await db.insert(Items).values({ id: 1, sku: 'A', region: 'eu', name: 'Original', qty: 5 });
+});
+
+describe.sequential('upsert: generated surface', () => {
+  it('generates nothing unless the feature is switched on', () => {
+    const defaults = buildSchema(db).schema;
+
+    expect(defaults.getMutationType()!.getFields()['upsertItems']).toBeUndefined();
+    expect(defaults.getMutationType()!.getFields()['upsertItemsSingle']).toBeUndefined();
+    expect(defaults.getType('ItemsOnConflict')).toBeUndefined();
+    expect(defaults.getType('ItemsConflictTarget')).toBeUndefined();
+  });
+
+  it('generates array and single upsert mutations when switched on', () => {
+    const mutations = gqlSchema.getMutationType()!.getFields();
+
+    expect(mutations['upsertItems']).toBeDefined();
+    expect(mutations['upsertItemsSingle']).toBeDefined();
+    expect(mutations['upsertItems']!.args.map((a) => a.name).sort()).toEqual(['onConflict', 'values']);
+    // The upsert reuses the insert input rather than emitting an identical copy.
+    expect(gqlSchema.getType('CreateItemsInput')).toBeDefined();
+  });
+
+  it('offers only unique column sets as conflict targets', () => {
+    const target = gqlSchema.getType('ItemsConflictTarget') as any;
+
+    expect(Object.keys(target.getValues ? target.toConfig().values : {}).sort()).toEqual(['id', 'region', 'sku']);
+    // Any column can be overwritten, unique or not.
+    expect(Object.keys((gqlSchema.getType('ItemsUpdateColumn') as any).toConfig().values).sort()).toEqual([
+      'id',
+      'name',
+      'qty',
+      'region',
+      'sku',
+    ]);
+  });
+
+  it('skips a table that has nothing to conflict on', () => {
+    const mutations = gqlSchema.getMutationType()!.getFields();
+
+    expect(mutations['upsertLogs']).toBeUndefined();
+    expect(gqlSchema.getType('LogsOnConflict')).toBeUndefined();
+    // Its ordinary mutations are untouched.
+    expect(mutations['createLogs']).toBeDefined();
+  });
+});
+
+describe.sequential('upsert: behaviour', () => {
+  it('inserts a row that does not conflict', async () => {
+    const result = await run(
+      `mutation { upsertItemsSingle(values: { id: 2, sku: "B", region: "eu", name: "New", qty: 1 }) { id name } }`,
+    );
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.['upsertItemsSingle']).toMatchObject({ id: 2, name: 'New' });
+    expect(await items()).toHaveLength(2);
+  });
+
+  it('overwrites the conflicting row on the primary key by default', async () => {
+    const result = await run(
+      `mutation { upsertItemsSingle(values: { id: 1, sku: "A", region: "eu", name: "Replaced", qty: 9 }) { id name qty } }`,
+    );
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.['upsertItemsSingle']).toMatchObject({ id: 1, name: 'Replaced', qty: 9 });
+    expect(await items()).toHaveLength(1);
+  });
+
+  it('updates each row of a batch with its own values', async () => {
+    await db.insert(Items).values({ id: 2, sku: 'B', region: 'eu', name: 'Second', qty: 2 });
+
+    const result = await run(`mutation {
+      upsertItems(values: [
+        { id: 1, sku: "A", region: "eu", name: "One", qty: 11 },
+        { id: 2, sku: "B", region: "eu", name: "Two", qty: 22 },
+        { id: 3, sku: "C", region: "eu", name: "Three", qty: 33 }
+      ]) { id name qty }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.['upsertItems']).toEqual([
+      { id: 1, name: 'One', qty: 11 },
+      { id: 2, name: 'Two', qty: 22 },
+      { id: 3, name: 'Three', qty: 33 },
+    ]);
+  });
+
+  it('leaves the existing row alone when the action is NOTHING', async () => {
+    const result = await run(`mutation {
+      upsertItemsSingle(
+        values: { id: 1, sku: "A", region: "eu", name: "Ignored", qty: 99 }
+        onConflict: { action: NOTHING }
+      ) { id name }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    // Nothing was inserted, so there is no row to return.
+    expect(result.data?.['upsertItemsSingle']).toBeNull();
+    expect((await items())[0]).toMatchObject({ name: 'Original', qty: 5 });
+  });
+
+  it('conflicts on an explicit unique constraint instead of the primary key', async () => {
+    const result = await run(`mutation {
+      upsertItemsSingle(
+        values: { id: 7, sku: "A", region: "eu", name: "BySku", qty: 3 }
+        onConflict: { target: [sku, region], update: [name, qty] }
+      ) { id name qty }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    // The row kept its original id — it was updated, not inserted.
+    expect(result.data?.['upsertItemsSingle']).toMatchObject({ id: 1, name: 'BySku', qty: 3 });
+    expect(await items()).toHaveLength(1);
+  });
+
+  it('rejects a conflict target that is not a unique constraint', async () => {
+    const result = await run(`mutation {
+      upsertItemsSingle(values: { id: 1, sku: "A", region: "eu" }, onConflict: { target: [sku] }) { id }
+    }`);
+
+    expect(result.errors?.[0]?.message).toContain('is not a unique constraint');
+    // The error names the targets that would have worked.
+    expect(result.errors?.[0]?.message).toContain('[id]');
+    expect(result.errors?.[0]?.message).toContain('[sku, region]');
+  });
+
+  it('overwrites only the listed columns', async () => {
+    const result = await run(`mutation {
+      upsertItemsSingle(
+        values: { id: 1, sku: "A", region: "eu", name: "Fresh", qty: 42 }
+        onConflict: { update: [qty] }
+      ) { id name qty }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.['upsertItemsSingle']).toMatchObject({ name: 'Original', qty: 42 });
+  });
+
+  it('rejects an update column the values do not supply', async () => {
+    const result = await run(`mutation {
+      upsertItemsSingle(values: { id: 1, sku: "A", region: "eu" }, onConflict: { update: [name] }) { id }
+    }`);
+
+    expect(result.errors?.[0]?.message).toContain('which the values do not supply');
+  });
+
+  it('only overwrites rows that match the where guard', async () => {
+    const blocked = await run(`mutation {
+      upsertItemsSingle(
+        values: { id: 1, sku: "A", region: "eu", name: "Blocked", qty: 1 }
+        onConflict: { where: { name: { eq: "Missing" } } }
+      ) { id name }
+    }`);
+
+    expect(blocked.errors).toBeUndefined();
+    expect(blocked.data?.['upsertItemsSingle']).toBeNull();
+    expect((await items())[0]).toMatchObject({ name: 'Original' });
+
+    const allowed = await run(`mutation {
+      upsertItemsSingle(
+        values: { id: 1, sku: "A", region: "eu", name: "Allowed", qty: 1 }
+        onConflict: { where: { name: { eq: "Original" } } }
+      ) { id name }
+    }`);
+
+    expect(allowed.errors).toBeUndefined();
+    expect(allowed.data?.['upsertItemsSingle']).toMatchObject({ name: 'Allowed' });
+  });
+
+  it('does nothing when the only supplied columns are the conflict target', async () => {
+    const result = await run(`mutation { upsertItemsSingle(values: { id: 1, sku: "A", region: "eu" }) { id } }`);
+
+    // sku/region are supplied too, so this really is an update of those columns.
+    expect(result.errors).toBeUndefined();
+    expect((await items())[0]).toMatchObject({ name: 'Original', qty: 5 });
+  });
+});

--- a/tests/sqlite-conflict.test.ts
+++ b/tests/sqlite-conflict.test.ts
@@ -1,0 +1,89 @@
+import { type Client, createClient } from '@libsql/client';
+import { sql } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/libsql';
+import type { BaseSQLiteDatabase } from 'drizzle-orm/sqlite-core';
+import { type GraphQLSchema, graphql } from 'graphql';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { buildSchema } from '@/index';
+import * as schema from './schema/sqlite';
+
+interface Ctx {
+  client: Client;
+  db: BaseSQLiteDatabase<'async', any, typeof schema>;
+  strict: GraphQLSchema;
+  lenient: GraphQLSchema;
+}
+
+const ctx: Ctx = {} as any;
+
+const insertDuplicate = (gqlSchema: GraphQLSchema) =>
+  graphql({
+    schema: gqlSchema,
+    source: `mutation { createUsersSingle(values: { id: 1, name: "Duplicate" }) { id name } }`,
+  });
+
+beforeAll(async () => {
+  ctx.client = createClient({ url: 'file::memory:?cache=shared' });
+  ctx.db = drizzle({ client: ctx.client, schema, relations: schema.relations });
+
+  ctx.strict = buildSchema(ctx.db).schema;
+  ctx.lenient = buildSchema(ctx.db, { conflictDoNothing: true }).schema;
+
+  await ctx.db.run(sql`CREATE TABLE IF NOT EXISTS \`users\` (
+		\`id\` integer PRIMARY KEY NOT NULL,
+		\`name\` text NOT NULL,
+		\`email\` text,
+		\`text_json\` text,
+		\`blob_bigint\` blob,
+		\`numeric\` numeric,
+		\`created_at\` integer,
+		\`created_at_ms\` integer,
+		\`real\` real,
+		\`text\` text(255),
+		\`role\` text DEFAULT 'user',
+		\`is_confirmed\` integer
+	);`);
+});
+
+afterAll(() => {
+  ctx.client.close();
+});
+
+beforeEach(async () => {
+  await ctx.db.run(sql`DELETE FROM \`users\``);
+  await ctx.db.insert(schema.Users).values({ id: 1, name: 'FirstUser' });
+});
+
+// SQLite used to append onConflictDoNothing() to every insert, which swallowed conflicts
+// with no way to opt out and did not match PostgreSQL's behaviour for the same config.
+describe.sequential('SQLite insert conflict behaviour', () => {
+  it('raises an error on a duplicate primary key by default', async () => {
+    const result = await insertDuplicate(ctx.strict);
+
+    expect(result.errors).toBeDefined();
+    const rows = await ctx.db.select().from(schema.Users);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.name).toBe('FirstUser');
+  });
+
+  it('silently ignores a duplicate primary key when conflictDoNothing is true', async () => {
+    const result = await insertDuplicate(ctx.lenient);
+
+    expect(result.errors).toBeUndefined();
+    // onConflictDoNothing inserts nothing, so there is no row to return.
+    expect(result.data?.['createUsersSingle']).toBeNull();
+    const rows = await ctx.db.select().from(schema.Users);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.name).toBe('FirstUser');
+  });
+
+  it('still inserts non-conflicting rows when conflictDoNothing is true', async () => {
+    const result = await graphql({
+      schema: ctx.lenient,
+      source: `mutation { createUsersSingle(values: { id: 2, name: "SecondUser" }) { id name } }`,
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.['createUsersSingle']).toMatchObject({ id: 2, name: 'SecondUser' });
+  });
+});

--- a/tests/sqlite-custom.test.ts
+++ b/tests/sqlite-custom.test.ts
@@ -257,7 +257,7 @@ describe.sequential('Query tests', async () => {
           id: 1,
           name: 'FirstUser',
           email: 'userOne@notmail.com',
-          textJson: '{"field":"value"}',
+          textJson: { field: 'value' },
           blobBigInt: '10',
           numeric: '250.2',
           createdAt: '2024-04-02T06:44:41.000Z',
@@ -309,7 +309,7 @@ describe.sequential('Query tests', async () => {
             id: 1,
             name: 'FirstUser',
             email: 'userOne@notmail.com',
-            textJson: '{"field":"value"}',
+            textJson: { field: 'value' },
             blobBigInt: '10',
             numeric: '250.2',
             createdAt: '2024-04-02T06:44:41.000Z',
@@ -434,7 +434,7 @@ describe.sequential('Query tests', async () => {
           id: 1,
           name: 'FirstUser',
           email: 'userOne@notmail.com',
-          textJson: '{"field":"value"}',
+          textJson: { field: 'value' },
           blobBigInt: '10',
           numeric: '250.2',
           createdAt: '2024-04-02T06:44:41.000Z',
@@ -475,7 +475,7 @@ describe.sequential('Query tests', async () => {
             id: 1,
             name: 'FirstUser',
             email: 'userOne@notmail.com',
-            textJson: '{"field":"value"}',
+            textJson: { field: 'value' },
             // RQB can't handle blobs in JSON, for now
             // blobBigInt: '10',
             numeric: '250.2',
@@ -542,7 +542,7 @@ describe.sequential('Query tests', async () => {
             id: 1,
             name: 'FirstUser',
             email: 'userOne@notmail.com',
-            textJson: '{"field":"value"}',
+            textJson: { field: 'value' },
             blobBigInt: '10',
             numeric: '250.2',
             createdAt: '2024-04-02T06:44:41.000Z',
@@ -625,7 +625,7 @@ describe.sequential('Query tests', async () => {
               id: 1,
               name: 'FirstUser',
               email: 'userOne@notmail.com',
-              textJson: '{"field":"value"}',
+              textJson: { field: 'value' },
               // RQB can't handle blobs in JSON, for now
               // blobBigInt: '10',
               numeric: '250.2',
@@ -645,7 +645,7 @@ describe.sequential('Query tests', async () => {
               id: 1,
               name: 'FirstUser',
               email: 'userOne@notmail.com',
-              textJson: '{"field":"value"}',
+              textJson: { field: 'value' },
               // RQB can't handle blobs in JSON, for now
               // blobBigInt: '10',
               numeric: '250.2',
@@ -665,7 +665,7 @@ describe.sequential('Query tests', async () => {
               id: 1,
               name: 'FirstUser',
               email: 'userOne@notmail.com',
-              textJson: '{"field":"value"}',
+              textJson: { field: 'value' },
               // RQB can't handle blobs in JSON, for now
               // blobBigInt: '10',
               numeric: '250.2',
@@ -725,7 +725,7 @@ describe.sequential('Query tests', async () => {
               id: 1,
               name: 'FirstUser',
               email: 'userOne@notmail.com',
-              textJson: '{"field":"value"}',
+              textJson: { field: 'value' },
               // RQB can't handle blobs in JSON, for now
               // blobBigInt: '10',
               numeric: '250.2',
@@ -782,7 +782,7 @@ describe.sequential('Query tests', async () => {
           id: 1,
           name: 'FirstUser',
           email: 'userOne@notmail.com',
-          textJson: '{"field":"value"}',
+          textJson: { field: 'value' },
           blobBigInt: '10',
           numeric: '250.2',
           createdAt: '2024-04-02T06:44:41.000Z',
@@ -842,7 +842,7 @@ describe.sequential('Query tests', async () => {
             id: 1,
             name: 'FirstUser',
             email: 'userOne@notmail.com',
-            textJson: '{"field":"value"}',
+            textJson: { field: 'value' },
             blobBigInt: '10',
             numeric: '250.2',
             createdAt: '2024-04-02T06:44:41.000Z',
@@ -975,7 +975,7 @@ describe.sequential('Query tests', async () => {
           id: 1,
           name: 'FirstUser',
           email: 'userOne@notmail.com',
-          textJson: '{"field":"value"}',
+          textJson: { field: 'value' },
           blobBigInt: '10',
           numeric: '250.2',
           createdAt: '2024-04-02T06:44:41.000Z',
@@ -1016,7 +1016,7 @@ describe.sequential('Query tests', async () => {
             id: 1,
             name: 'FirstUser',
             email: 'userOne@notmail.com',
-            textJson: '{"field":"value"}',
+            textJson: { field: 'value' },
             // RQB can't handle blobs in JSON, for now
             // blobBigInt: '10',
             numeric: '250.2',
@@ -1091,7 +1091,7 @@ describe.sequential('Query tests', async () => {
             id: 1,
             name: 'FirstUser',
             email: 'userOne@notmail.com',
-            textJson: '{"field":"value"}',
+            textJson: { field: 'value' },
             blobBigInt: '10',
             numeric: '250.2',
             createdAt: '2024-04-02T06:44:41.000Z',
@@ -1174,7 +1174,7 @@ describe.sequential('Query tests', async () => {
               id: 1,
               name: 'FirstUser',
               email: 'userOne@notmail.com',
-              textJson: '{"field":"value"}',
+              textJson: { field: 'value' },
               // RQB can't handle blobs in JSON, for now
               // blobBigInt: '10',
               numeric: '250.2',
@@ -1194,7 +1194,7 @@ describe.sequential('Query tests', async () => {
               id: 1,
               name: 'FirstUser',
               email: 'userOne@notmail.com',
-              textJson: '{"field":"value"}',
+              textJson: { field: 'value' },
               // RQB can't handle blobs in JSON, for now
               // blobBigInt: '10',
               numeric: '250.2',
@@ -1214,7 +1214,7 @@ describe.sequential('Query tests', async () => {
               id: 1,
               name: 'FirstUser',
               email: 'userOne@notmail.com',
-              textJson: '{"field":"value"}',
+              textJson: { field: 'value' },
               // RQB can't handle blobs in JSON, for now
               // blobBigInt: '10',
               numeric: '250.2',
@@ -1274,7 +1274,7 @@ describe.sequential('Query tests', async () => {
               id: 1,
               name: 'FirstUser',
               email: 'userOne@notmail.com',
-              textJson: '{"field":"value"}',
+              textJson: { field: 'value' },
               // RQB can't handle blobs in JSON, for now
               // blobBigInt: '10',
               numeric: '250.2',
@@ -1299,7 +1299,7 @@ describe.sequential('Query tests', async () => {
 						id: 3
 						name: "ThirdUser"
 						email: "userThree@notmail.com"
-						textJson: "{ \\"field\\": \\"value\\" }"
+						textJson: { field: "value" }
 						blobBigInt: "10"
 						numeric: "250.2"
 						createdAt: "2024-04-02T06:44:41.785Z"
@@ -1332,7 +1332,7 @@ describe.sequential('Query tests', async () => {
           id: 3,
           name: 'ThirdUser',
           email: 'userThree@notmail.com',
-          textJson: '{"field":"value"}',
+          textJson: { field: 'value' },
           blobBigInt: '10',
           numeric: '250.2',
           createdAt: '2024-04-02T06:44:41.000Z',
@@ -1355,7 +1355,7 @@ describe.sequential('Query tests', async () => {
 							id: 3
 							name: "ThirdUser"
 							email: "userThree@notmail.com"
-							textJson: "{ \\"field\\": \\"value\\" }"
+							textJson: { field: "value" }
 							blobBigInt: "10"
 							numeric: "250.2"
 							createdAt: "2024-04-02T06:44:41.785Z"
@@ -1369,7 +1369,7 @@ describe.sequential('Query tests', async () => {
 							id: 4
 							name: "FourthUser"
 							email: "userFour@notmail.com"
-							textJson: "{ \\"field\\": \\"value\\" }"
+							textJson: { field: "value" }
 							blobBigInt: "10"
 							numeric: "250.2"
 							createdAt: "2024-04-02T06:44:41.785Z"
@@ -1404,7 +1404,7 @@ describe.sequential('Query tests', async () => {
             id: 3,
             name: 'ThirdUser',
             email: 'userThree@notmail.com',
-            textJson: '{"field":"value"}',
+            textJson: { field: 'value' },
             blobBigInt: '10',
             numeric: '250.2',
             createdAt: '2024-04-02T06:44:41.000Z',
@@ -1418,7 +1418,7 @@ describe.sequential('Query tests', async () => {
             id: 4,
             name: 'FourthUser',
             email: 'userFour@notmail.com',
-            textJson: '{"field":"value"}',
+            textJson: { field: 'value' },
             blobBigInt: '10',
             numeric: '250.2',
             createdAt: '2024-04-02T06:44:41.000Z',

--- a/tests/sqlite-upsert.test.ts
+++ b/tests/sqlite-upsert.test.ts
@@ -1,0 +1,138 @@
+import { type Client, createClient } from '@libsql/client';
+import { buildRelations, sql } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/libsql';
+import { integer, sqliteTable, text, unique } from 'drizzle-orm/sqlite-core';
+import { type GraphQLSchema, graphql } from 'graphql';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { buildSchema } from '@/index';
+
+const Items = sqliteTable(
+  'items',
+  {
+    id: integer('id').primaryKey(),
+    sku: text('sku').notNull(),
+    region: text('region').notNull(),
+    name: text('name'),
+    qty: integer('qty'),
+  },
+  (t) => [unique('items_sku_region').on(t.sku, t.region)],
+);
+const relations = buildRelations({ Items }, { Items: {} });
+const schema = { Items, relations };
+
+let client: Client;
+let db: any;
+let gqlSchema: GraphQLSchema;
+
+const run = (source: string) => graphql({ schema: gqlSchema, source, contextValue: {} });
+const items = () => db.select().from(Items).orderBy(Items.id);
+
+beforeAll(async () => {
+  client = createClient({ url: ':memory:' });
+  db = (drizzle as any)({ client, schema, relations });
+
+  await db.run(sql`CREATE TABLE "items" (
+		"id" integer PRIMARY KEY NOT NULL,
+		"sku" text NOT NULL,
+		"region" text NOT NULL,
+		"name" text,
+		"qty" integer,
+		CONSTRAINT "items_sku_region" UNIQUE("sku", "region")
+	);`);
+
+  gqlSchema = buildSchema(db, { features: { upsert: true } }).schema;
+});
+
+afterAll(() => {
+  client.close();
+});
+
+beforeEach(async () => {
+  await db.run(sql`DELETE FROM "items"`);
+  await db.insert(Items).values({ id: 1, sku: 'A', region: 'eu', name: 'Original', qty: 5 });
+});
+
+describe.sequential('SQLite upsert', () => {
+  it('is opt-in', () => {
+    expect(buildSchema(db).schema.getMutationType()!.getFields()['upsertItems']).toBeUndefined();
+  });
+
+  it('inserts a row that does not conflict', async () => {
+    const result = await run(
+      `mutation { upsertItemsSingle(values: { id: 2, sku: "B", region: "eu", name: "New" }) { id name } }`,
+    );
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.['upsertItemsSingle']).toMatchObject({ id: 2, name: 'New' });
+  });
+
+  it('overwrites the conflicting row on the primary key by default', async () => {
+    const result = await run(
+      `mutation { upsertItemsSingle(values: { id: 1, sku: "A", region: "eu", name: "Replaced", qty: 9 }) { name qty } }`,
+    );
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.['upsertItemsSingle']).toMatchObject({ name: 'Replaced', qty: 9 });
+    expect(await items()).toHaveLength(1);
+  });
+
+  it('updates each row of a batch with its own values', async () => {
+    const result = await run(`mutation {
+      upsertItems(values: [
+        { id: 1, sku: "A", region: "eu", name: "One" },
+        { id: 2, sku: "B", region: "eu", name: "Two" }
+      ]) { id name }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.['upsertItems']).toEqual([
+      { id: 1, name: 'One' },
+      { id: 2, name: 'Two' },
+    ]);
+  });
+
+  it('leaves the existing row alone when the action is NOTHING', async () => {
+    const result = await run(`mutation {
+      upsertItemsSingle(
+        values: { id: 1, sku: "A", region: "eu", name: "Ignored" }
+        onConflict: { action: NOTHING }
+      ) { id }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.['upsertItemsSingle']).toBeNull();
+    expect((await items())[0]).toMatchObject({ name: 'Original' });
+  });
+
+  it('conflicts on an explicit unique constraint instead of the primary key', async () => {
+    const result = await run(`mutation {
+      upsertItemsSingle(
+        values: { id: 7, sku: "A", region: "eu", name: "BySku" }
+        onConflict: { target: [sku, region], update: [name] }
+      ) { id name }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.['upsertItemsSingle']).toMatchObject({ id: 1, name: 'BySku' });
+  });
+
+  it('rejects a conflict target that is not a unique constraint', async () => {
+    const result = await run(`mutation {
+      upsertItemsSingle(values: { id: 1, sku: "A", region: "eu" }, onConflict: { target: [sku] }) { id }
+    }`);
+
+    expect(result.errors?.[0]?.message).toContain('is not a unique constraint');
+  });
+
+  it('only overwrites rows that match the where guard', async () => {
+    const blocked = await run(`mutation {
+      upsertItemsSingle(
+        values: { id: 1, sku: "A", region: "eu", name: "Blocked" }
+        onConflict: { where: { name: { eq: "Missing" } } }
+      ) { id }
+    }`);
+
+    expect(blocked.errors).toBeUndefined();
+    expect((await items())[0]).toMatchObject({ name: 'Original' });
+  });
+});

--- a/tests/sqlite.test.ts
+++ b/tests/sqlite.test.ts
@@ -2105,6 +2105,146 @@ describe.sequential('Aggregate query tests', () => {
   });
 });
 
+describe.sequential('Relation filter tests', () => {
+  it(`Filter by a to-many relation`, async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				some: users(where: { posts: { some: { content: { eq: "3MESSAGE" } } } }) {
+					id
+				}
+
+				none: users(where: { posts: { none: {} } }) {
+					id
+				}
+
+				every: users(where: { posts: { every: { content: { eq: "1MESSAGE" } } } }) {
+					id
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        some: [{ id: 1 }],
+        none: [{ id: 2 }],
+        // Users 1 and 5 both own a non-matching post; user 2 owns none, so it matches vacuously.
+        every: [{ id: 2 }],
+      },
+    });
+  });
+
+  it(`Filter by a to-one relation`, async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				posts(where: { author: { name: { eq: "FifthUser" } } }, orderBy: { id: { direction: asc, priority: 1 } }) {
+					id
+				}
+
+				usersSingle(where: { customer: { address: { eq: "AdTwo" } } }) {
+					id
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        posts: [{ id: 4 }, { id: 5 }],
+        usersSingle: { id: 2 },
+      },
+    });
+  });
+
+  it(`Nested relation filters, combined with column filters`, async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				nested: users(where: { posts: { some: { author: { name: { eq: "FirstUser" } } } } }) {
+					id
+				}
+
+				withColumns: users(
+					where: { name: { like: "F%" }, posts: { some: { content: { eq: "2MESSAGE" } } } }
+					orderBy: { id: { direction: asc, priority: 1 } }
+				) {
+					id
+				}
+
+				withOr: users(
+					where: { OR: [{ name: { eq: "SecondUser" } }, { posts: { some: { content: { eq: "3MESSAGE" } } } }] }
+					orderBy: { id: { direction: asc, priority: 1 } }
+				) {
+					id
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        nested: [{ id: 1 }],
+        withColumns: [{ id: 1 }, { id: 5 }],
+        withOr: [{ id: 1 }, { id: 2 }],
+      },
+    });
+  });
+
+  it(`Relation filters on aggregates and relation fields`, async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				usersAggregate(where: { posts: { some: {} } }) {
+					count
+				}
+
+				usersSingle(where: { id: { eq: 1 } }) {
+					id
+					posts(where: { author: { name: { eq: "SecondUser" } } }) {
+						id
+					}
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        usersAggregate: { count: 2 },
+        usersSingle: { id: 1, posts: [] },
+      },
+    });
+  });
+
+  it(`Relation filters on mutations`, async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			mutation {
+				updatePosts(set: { content: "UPDATED" }, where: { author: { name: { eq: "FifthUser" } } }) {
+					id
+					content
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        updatePosts: [
+          { id: 4, content: 'UPDATED' },
+          { id: 5, content: 'UPDATED' },
+        ],
+      },
+    });
+
+    const deleted = await ctx.gql.queryGql(/* GraphQL */ `
+			mutation {
+				deletePosts(where: { author: { name: { eq: "FifthUser" } } }) {
+					id
+				}
+			}
+		`);
+
+    expect(deleted).toStrictEqual({
+      data: {
+        deletePosts: [{ id: 4 }, { id: 5 }],
+      },
+    });
+  });
+});
+
 describe.sequential('Returned data tests', () => {
   it('Schema', () => {
     expect(ctx.schema instanceof GraphQLSchema).toBe(true);

--- a/tests/sqlite.test.ts
+++ b/tests/sqlite.test.ts
@@ -5,8 +5,9 @@ import { sql } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/libsql';
 import type { BaseSQLiteDatabase } from 'drizzle-orm/sqlite-core';
 import {
+  type GraphQLEnumType,
   GraphQLInputObjectType,
-  type GraphQLList,
+  GraphQLList,
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLScalarType,
@@ -2265,6 +2266,66 @@ describe.sequential('Default pagination order tests', () => {
   });
 });
 
+describe.sequential('Distinct tests', () => {
+  it(`Keeps the first row of each distinct value`, async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				posts(distinct: [content]) {
+					id
+					content
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        posts: [
+          { id: 1, content: '1MESSAGE' },
+          { id: 2, content: '2MESSAGE' },
+          { id: 3, content: '3MESSAGE' },
+          { id: 6, content: '4MESSAGE' },
+        ],
+      },
+    });
+  });
+
+  it(`Picks the first row according to the requested order`, async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				posts(distinct: [content], orderBy: { id: { direction: desc, priority: 1 } }) {
+					id
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({ data: { posts: [{ id: 6 }, { id: 5 }, { id: 4 }, { id: 3 }] } });
+  });
+
+  it(`Applies limit and offset after the rows are made distinct`, async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				posts(distinct: [content], limit: 2, offset: 1) {
+					id
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({ data: { posts: [{ id: 2 }, { id: 3 }] } });
+  });
+
+  it(`Filters before making rows distinct`, async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				posts(where: { authorId: { eq: 5 } }, distinct: [content]) {
+					id
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({ data: { posts: [{ id: 4 }, { id: 5 }] } });
+  });
+});
+
 describe.sequential('Relation filter tests', () => {
   it(`Filter by a to-many relation`, async () => {
     const res = await ctx.gql.queryGql(/* GraphQL */ `
@@ -2440,6 +2501,11 @@ describe.sequential('Returned data tests', () => {
                         type: z.instanceof(GraphQLInputObjectType),
                       })
                       .strict(),
+                    distinct: z
+                      .object({
+                        type: z.instanceof(GraphQLList),
+                      })
+                      .strict(),
                   })
                   .strict(),
                 resolve: z.function(),
@@ -2495,6 +2561,11 @@ describe.sequential('Returned data tests', () => {
                         type: z.instanceof(GraphQLInputObjectType),
                       })
                       .strict(),
+                    distinct: z
+                      .object({
+                        type: z.instanceof(GraphQLList),
+                      })
+                      .strict(),
                   })
                   .strict(),
                 resolve: z.function(),
@@ -2548,6 +2619,11 @@ describe.sequential('Returned data tests', () => {
                     where: z
                       .object({
                         type: z.instanceof(GraphQLInputObjectType),
+                      })
+                      .strict(),
+                    distinct: z
+                      .object({
+                        type: z.instanceof(GraphQLList),
                       })
                       .strict(),
                   })
@@ -2882,6 +2958,7 @@ describe.sequential('Type tests', () => {
             offset: { type: GraphQLScalarType<number, number> };
             limit: { type: GraphQLScalarType<number, number> };
             where: { type: GraphQLInputObjectType };
+            distinct: { type: GraphQLList<GraphQLNonNull<GraphQLEnumType>> };
           };
           resolve: SelectResolver<
             typeof schema.Customers,
@@ -2896,6 +2973,7 @@ describe.sequential('Type tests', () => {
             offset: { type: GraphQLScalarType<number, number> };
             limit: { type: GraphQLScalarType<number, number> };
             where: { type: GraphQLInputObjectType };
+            distinct: { type: GraphQLList<GraphQLNonNull<GraphQLEnumType>> };
           };
           resolve: SelectResolver<
             typeof schema.Posts,
@@ -2910,6 +2988,7 @@ describe.sequential('Type tests', () => {
             offset: { type: GraphQLScalarType<number, number> };
             limit: { type: GraphQLScalarType<number, number> };
             where: { type: GraphQLInputObjectType };
+            distinct: { type: GraphQLList<GraphQLNonNull<GraphQLEnumType>> };
           };
           resolve: SelectResolver<
             typeof schema.Users,

--- a/tests/sqlite.test.ts
+++ b/tests/sqlite.test.ts
@@ -244,7 +244,7 @@ describe.sequential('Query tests', async () => {
           id: 1,
           name: 'FirstUser',
           email: 'userOne@notmail.com',
-          textJson: '{"field":"value"}',
+          textJson: { field: 'value' },
           blobBigInt: '10',
           numeric: '250.2',
           createdAt: '2024-04-02T06:44:41.000Z',
@@ -296,7 +296,7 @@ describe.sequential('Query tests', async () => {
             id: 1,
             name: 'FirstUser',
             email: 'userOne@notmail.com',
-            textJson: '{"field":"value"}',
+            textJson: { field: 'value' },
             blobBigInt: '10',
             numeric: '250.2',
             createdAt: '2024-04-02T06:44:41.000Z',
@@ -421,7 +421,7 @@ describe.sequential('Query tests', async () => {
           id: 1,
           name: 'FirstUser',
           email: 'userOne@notmail.com',
-          textJson: '{"field":"value"}',
+          textJson: { field: 'value' },
           blobBigInt: '10',
           numeric: '250.2',
           createdAt: '2024-04-02T06:44:41.000Z',
@@ -462,7 +462,7 @@ describe.sequential('Query tests', async () => {
             id: 1,
             name: 'FirstUser',
             email: 'userOne@notmail.com',
-            textJson: '{"field":"value"}',
+            textJson: { field: 'value' },
             // RQB can't handle blobs in JSON, for now
             // blobBigInt: '10',
             numeric: '250.2',
@@ -529,7 +529,7 @@ describe.sequential('Query tests', async () => {
             id: 1,
             name: 'FirstUser',
             email: 'userOne@notmail.com',
-            textJson: '{"field":"value"}',
+            textJson: { field: 'value' },
             blobBigInt: '10',
             numeric: '250.2',
             createdAt: '2024-04-02T06:44:41.000Z',
@@ -612,7 +612,7 @@ describe.sequential('Query tests', async () => {
               id: 1,
               name: 'FirstUser',
               email: 'userOne@notmail.com',
-              textJson: '{"field":"value"}',
+              textJson: { field: 'value' },
               // RQB can't handle blobs in JSON, for now
               // blobBigInt: '10',
               numeric: '250.2',
@@ -632,7 +632,7 @@ describe.sequential('Query tests', async () => {
               id: 1,
               name: 'FirstUser',
               email: 'userOne@notmail.com',
-              textJson: '{"field":"value"}',
+              textJson: { field: 'value' },
               // RQB can't handle blobs in JSON, for now
               // blobBigInt: '10',
               numeric: '250.2',
@@ -652,7 +652,7 @@ describe.sequential('Query tests', async () => {
               id: 1,
               name: 'FirstUser',
               email: 'userOne@notmail.com',
-              textJson: '{"field":"value"}',
+              textJson: { field: 'value' },
               // RQB can't handle blobs in JSON, for now
               // blobBigInt: '10',
               numeric: '250.2',
@@ -712,7 +712,7 @@ describe.sequential('Query tests', async () => {
               id: 1,
               name: 'FirstUser',
               email: 'userOne@notmail.com',
-              textJson: '{"field":"value"}',
+              textJson: { field: 'value' },
               // RQB can't handle blobs in JSON, for now
               // blobBigInt: '10',
               numeric: '250.2',
@@ -769,7 +769,7 @@ describe.sequential('Query tests', async () => {
           id: 1,
           name: 'FirstUser',
           email: 'userOne@notmail.com',
-          textJson: '{"field":"value"}',
+          textJson: { field: 'value' },
           blobBigInt: '10',
           numeric: '250.2',
           createdAt: '2024-04-02T06:44:41.000Z',
@@ -829,7 +829,7 @@ describe.sequential('Query tests', async () => {
             id: 1,
             name: 'FirstUser',
             email: 'userOne@notmail.com',
-            textJson: '{"field":"value"}',
+            textJson: { field: 'value' },
             blobBigInt: '10',
             numeric: '250.2',
             createdAt: '2024-04-02T06:44:41.000Z',
@@ -962,7 +962,7 @@ describe.sequential('Query tests', async () => {
           id: 1,
           name: 'FirstUser',
           email: 'userOne@notmail.com',
-          textJson: '{"field":"value"}',
+          textJson: { field: 'value' },
           blobBigInt: '10',
           numeric: '250.2',
           createdAt: '2024-04-02T06:44:41.000Z',
@@ -1003,7 +1003,7 @@ describe.sequential('Query tests', async () => {
             id: 1,
             name: 'FirstUser',
             email: 'userOne@notmail.com',
-            textJson: '{"field":"value"}',
+            textJson: { field: 'value' },
             // RQB can't handle blobs in JSON, for now
             // blobBigInt: '10',
             numeric: '250.2',
@@ -1078,7 +1078,7 @@ describe.sequential('Query tests', async () => {
             id: 1,
             name: 'FirstUser',
             email: 'userOne@notmail.com',
-            textJson: '{"field":"value"}',
+            textJson: { field: 'value' },
             blobBigInt: '10',
             numeric: '250.2',
             createdAt: '2024-04-02T06:44:41.000Z',
@@ -1161,7 +1161,7 @@ describe.sequential('Query tests', async () => {
               id: 1,
               name: 'FirstUser',
               email: 'userOne@notmail.com',
-              textJson: '{"field":"value"}',
+              textJson: { field: 'value' },
               // RQB can't handle blobs in JSON, for now
               // blobBigInt: '10',
               numeric: '250.2',
@@ -1181,7 +1181,7 @@ describe.sequential('Query tests', async () => {
               id: 1,
               name: 'FirstUser',
               email: 'userOne@notmail.com',
-              textJson: '{"field":"value"}',
+              textJson: { field: 'value' },
               // RQB can't handle blobs in JSON, for now
               // blobBigInt: '10',
               numeric: '250.2',
@@ -1201,7 +1201,7 @@ describe.sequential('Query tests', async () => {
               id: 1,
               name: 'FirstUser',
               email: 'userOne@notmail.com',
-              textJson: '{"field":"value"}',
+              textJson: { field: 'value' },
               // RQB can't handle blobs in JSON, for now
               // blobBigInt: '10',
               numeric: '250.2',
@@ -1261,7 +1261,7 @@ describe.sequential('Query tests', async () => {
               id: 1,
               name: 'FirstUser',
               email: 'userOne@notmail.com',
-              textJson: '{"field":"value"}',
+              textJson: { field: 'value' },
               // RQB can't handle blobs in JSON, for now
               // blobBigInt: '10',
               numeric: '250.2',
@@ -1286,7 +1286,7 @@ describe.sequential('Query tests', async () => {
 						id: 3
 						name: "ThirdUser"
 						email: "userThree@notmail.com"
-						textJson: "{ \\"field\\": \\"value\\" }"
+						textJson: { field: "value" }
 						blobBigInt: "10"
 						numeric: "250.2"
 						createdAt: "2024-04-02T06:44:41.785Z"
@@ -1319,7 +1319,7 @@ describe.sequential('Query tests', async () => {
           id: 3,
           name: 'ThirdUser',
           email: 'userThree@notmail.com',
-          textJson: '{"field":"value"}',
+          textJson: { field: 'value' },
           blobBigInt: '10',
           numeric: '250.2',
           createdAt: '2024-04-02T06:44:41.000Z',
@@ -1342,7 +1342,7 @@ describe.sequential('Query tests', async () => {
 							id: 3
 							name: "ThirdUser"
 							email: "userThree@notmail.com"
-							textJson: "{ \\"field\\": \\"value\\" }"
+							textJson: { field: "value" }
 							blobBigInt: "10"
 							numeric: "250.2"
 							createdAt: "2024-04-02T06:44:41.785Z"
@@ -1356,7 +1356,7 @@ describe.sequential('Query tests', async () => {
 							id: 4
 							name: "FourthUser"
 							email: "userFour@notmail.com"
-							textJson: "{ \\"field\\": \\"value\\" }"
+							textJson: { field: "value" }
 							blobBigInt: "10"
 							numeric: "250.2"
 							createdAt: "2024-04-02T06:44:41.785Z"
@@ -1391,7 +1391,7 @@ describe.sequential('Query tests', async () => {
             id: 3,
             name: 'ThirdUser',
             email: 'userThree@notmail.com',
-            textJson: '{"field":"value"}',
+            textJson: { field: 'value' },
             blobBigInt: '10',
             numeric: '250.2',
             createdAt: '2024-04-02T06:44:41.000Z',
@@ -1405,7 +1405,7 @@ describe.sequential('Query tests', async () => {
             id: 4,
             name: 'FourthUser',
             email: 'userFour@notmail.com',
-            textJson: '{"field":"value"}',
+            textJson: { field: 'value' },
             blobBigInt: '10',
             numeric: '250.2',
             createdAt: '2024-04-02T06:44:41.000Z',
@@ -3447,7 +3447,7 @@ describe.sequential('__typename only tests', () => {
 						id: 3
 						name: "ThirdUser"
 						email: "userThree@notmail.com"
-						textJson: "{ \\"field\\": \\"value\\" }"
+						textJson: { field: "value" }
 						blobBigInt: "10"
 						numeric: "250.2"
 						createdAt: "2024-04-02T06:44:41.785Z"
@@ -3481,7 +3481,7 @@ describe.sequential('__typename only tests', () => {
 							id: 3
 							name: "ThirdUser"
 							email: "userThree@notmail.com"
-							textJson: "{ \\"field\\": \\"value\\" }"
+							textJson: { field: "value" }
 							blobBigInt: "10"
 							numeric: "250.2"
 							createdAt: "2024-04-02T06:44:41.785Z"
@@ -3495,7 +3495,7 @@ describe.sequential('__typename only tests', () => {
 							id: 4
 							name: "FourthUser"
 							email: "userFour@notmail.com"
-							textJson: "{ \\"field\\": \\"value\\" }"
+							textJson: { field: "value" }
 							blobBigInt: "10"
 							numeric: "250.2"
 							createdAt: "2024-04-02T06:44:41.785Z"
@@ -3608,7 +3608,7 @@ describe.sequential('__typename with data tests', async () => {
           id: 1,
           name: 'FirstUser',
           email: 'userOne@notmail.com',
-          textJson: '{"field":"value"}',
+          textJson: { field: 'value' },
           blobBigInt: '10',
           numeric: '250.2',
           createdAt: '2024-04-02T06:44:41.000Z',
@@ -3664,7 +3664,7 @@ describe.sequential('__typename with data tests', async () => {
             id: 1,
             name: 'FirstUser',
             email: 'userOne@notmail.com',
-            textJson: '{"field":"value"}',
+            textJson: { field: 'value' },
             blobBigInt: '10',
             numeric: '250.2',
             createdAt: '2024-04-02T06:44:41.000Z',
@@ -3802,7 +3802,7 @@ describe.sequential('__typename with data tests', async () => {
           id: 1,
           name: 'FirstUser',
           email: 'userOne@notmail.com',
-          textJson: '{"field":"value"}',
+          textJson: { field: 'value' },
           blobBigInt: '10',
           numeric: '250.2',
           createdAt: '2024-04-02T06:44:41.000Z',
@@ -3849,7 +3849,7 @@ describe.sequential('__typename with data tests', async () => {
             id: 1,
             name: 'FirstUser',
             email: 'userOne@notmail.com',
-            textJson: '{"field":"value"}',
+            textJson: { field: 'value' },
             // RQB can't handle blobs in JSON, for now
             // blobBigInt: '10',
             numeric: '250.2',
@@ -3921,7 +3921,7 @@ describe.sequential('__typename with data tests', async () => {
             id: 1,
             name: 'FirstUser',
             email: 'userOne@notmail.com',
-            textJson: '{"field":"value"}',
+            textJson: { field: 'value' },
             blobBigInt: '10',
             numeric: '250.2',
             createdAt: '2024-04-02T06:44:41.000Z',
@@ -4014,7 +4014,7 @@ describe.sequential('__typename with data tests', async () => {
               id: 1,
               name: 'FirstUser',
               email: 'userOne@notmail.com',
-              textJson: '{"field":"value"}',
+              textJson: { field: 'value' },
               // RQB can't handle blobs in JSON, for now
               // blobBigInt: '10',
               numeric: '250.2',
@@ -4036,7 +4036,7 @@ describe.sequential('__typename with data tests', async () => {
               id: 1,
               name: 'FirstUser',
               email: 'userOne@notmail.com',
-              textJson: '{"field":"value"}',
+              textJson: { field: 'value' },
               // RQB can't handle blobs in JSON, for now
               // blobBigInt: '10',
               numeric: '250.2',
@@ -4058,7 +4058,7 @@ describe.sequential('__typename with data tests', async () => {
               id: 1,
               name: 'FirstUser',
               email: 'userOne@notmail.com',
-              textJson: '{"field":"value"}',
+              textJson: { field: 'value' },
               // RQB can't handle blobs in JSON, for now
               // blobBigInt: '10',
               numeric: '250.2',
@@ -4124,7 +4124,7 @@ describe.sequential('__typename with data tests', async () => {
               id: 1,
               name: 'FirstUser',
               email: 'userOne@notmail.com',
-              textJson: '{"field":"value"}',
+              textJson: { field: 'value' },
               // RQB can't handle blobs in JSON, for now
               // blobBigInt: '10',
               numeric: '250.2',
@@ -4150,7 +4150,7 @@ describe.sequential('__typename with data tests', async () => {
 						id: 3
 						name: "ThirdUser"
 						email: "userThree@notmail.com"
-						textJson: "{ \\"field\\": \\"value\\" }"
+						textJson: { field: "value" }
 						blobBigInt: "10"
 						numeric: "250.2"
 						createdAt: "2024-04-02T06:44:41.785Z"
@@ -4184,7 +4184,7 @@ describe.sequential('__typename with data tests', async () => {
           id: 3,
           name: 'ThirdUser',
           email: 'userThree@notmail.com',
-          textJson: '{"field":"value"}',
+          textJson: { field: 'value' },
           blobBigInt: '10',
           numeric: '250.2',
           createdAt: '2024-04-02T06:44:41.000Z',
@@ -4208,7 +4208,7 @@ describe.sequential('__typename with data tests', async () => {
 							id: 3
 							name: "ThirdUser"
 							email: "userThree@notmail.com"
-							textJson: "{ \\"field\\": \\"value\\" }"
+							textJson: { field: "value" }
 							blobBigInt: "10"
 							numeric: "250.2"
 							createdAt: "2024-04-02T06:44:41.785Z"
@@ -4222,7 +4222,7 @@ describe.sequential('__typename with data tests', async () => {
 							id: 4
 							name: "FourthUser"
 							email: "userFour@notmail.com"
-							textJson: "{ \\"field\\": \\"value\\" }"
+							textJson: { field: "value" }
 							blobBigInt: "10"
 							numeric: "250.2"
 							createdAt: "2024-04-02T06:44:41.785Z"
@@ -4258,7 +4258,7 @@ describe.sequential('__typename with data tests', async () => {
             id: 3,
             name: 'ThirdUser',
             email: 'userThree@notmail.com',
-            textJson: '{"field":"value"}',
+            textJson: { field: 'value' },
             blobBigInt: '10',
             numeric: '250.2',
             createdAt: '2024-04-02T06:44:41.000Z',
@@ -4273,7 +4273,7 @@ describe.sequential('__typename with data tests', async () => {
             id: 4,
             name: 'FourthUser',
             email: 'userFour@notmail.com',
-            textJson: '{"field":"value"}',
+            textJson: { field: 'value' },
             blobBigInt: '10',
             numeric: '250.2',
             createdAt: '2024-04-02T06:44:41.000Z',

--- a/tests/sqlite.test.ts
+++ b/tests/sqlite.test.ts
@@ -2202,6 +2202,44 @@ describe.sequential('Relation aggregate tests', () => {
   });
 });
 
+describe.sequential('Default pagination order tests', () => {
+  it(`Unordered paginated query falls back to primary key order`, async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				posts(limit: 3) {
+					id
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({ data: { posts: [{ id: 1 }, { id: 2 }, { id: 3 }] } });
+  });
+
+  it(`Unordered single query falls back to primary key order`, async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				postsSingle {
+					id
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({ data: { postsSingle: { id: 1 } } });
+  });
+
+  it(`Explicit orderBy wins over the primary key default`, async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				posts(limit: 3, orderBy: { id: { direction: desc, priority: 1 } }) {
+					id
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({ data: { posts: [{ id: 6 }, { id: 5 }, { id: 4 }] } });
+  });
+});
+
 describe.sequential('Relation filter tests', () => {
   it(`Filter by a to-many relation`, async () => {
     const res = await ctx.gql.queryGql(/* GraphQL */ `

--- a/tests/sqlite.test.ts
+++ b/tests/sqlite.test.ts
@@ -16,6 +16,7 @@ import { createYoga } from 'graphql-yoga';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, expectTypeOf, it } from 'vitest';
 import z from 'zod';
 import {
+  type AggregateResolver,
   buildSchema,
   type DeleteResolver,
   type ExtractTables,
@@ -1942,6 +1943,168 @@ describe.sequential('Arguments tests', async () => {
   });
 });
 
+describe.sequential('Aggregate query tests', () => {
+  it(`Count`, async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				usersAggregate {
+					count
+				}
+
+				postsAggregate {
+					count
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        usersAggregate: { count: 3 },
+        postsAggregate: { count: 6 },
+      },
+    });
+  });
+
+  it(`Numeric aggregates`, async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				postsAggregate {
+					count
+					avg {
+						id
+					}
+					sum {
+						id
+					}
+					min {
+						id
+					}
+					max {
+						id
+					}
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        postsAggregate: {
+          count: 6,
+          avg: { id: 3.5 },
+          sum: { id: 21 },
+          min: { id: 1 },
+          max: { id: 6 },
+        },
+      },
+    });
+  });
+
+  it(`Aggregates with where filter`, async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				postsAggregate(where: { authorId: { eq: 5 } }) {
+					count
+					sum {
+						id
+					}
+					min {
+						id
+					}
+					max {
+						id
+					}
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        postsAggregate: {
+          count: 2,
+          sum: { id: 9 },
+          min: { id: 4 },
+          max: { id: 5 },
+        },
+      },
+    });
+  });
+
+  it(`Min and max on text and timestamp columns`, async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				usersAggregate {
+					min {
+						name
+						createdAt
+						createdAtMs
+					}
+					max {
+						name
+					}
+				}
+
+				customersAggregate {
+					min {
+						registrationDate
+					}
+					max {
+						registrationDate
+					}
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        usersAggregate: {
+          min: {
+            name: 'FifthUser',
+            createdAt: '2024-04-02T06:44:41.000Z',
+            createdAtMs: '2024-04-02T06:44:41.785Z',
+          },
+          max: {
+            name: 'SecondUser',
+          },
+        },
+        customersAggregate: {
+          min: { registrationDate: '2024-03-27T03:54:45.235Z' },
+          max: { registrationDate: '2024-03-27T03:55:42.358Z' },
+        },
+      },
+    });
+  });
+
+  it(`Aggregates over an empty result set`, async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				usersAggregate(where: { name: { eq: "Nobody" } }) {
+					count
+					avg {
+						id
+					}
+					min {
+						name
+					}
+					max {
+						createdAt
+					}
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        usersAggregate: {
+          count: 0,
+          avg: { id: null },
+          min: { name: null },
+          max: { createdAt: null },
+        },
+      },
+    });
+  });
+});
+
 describe.sequential('Returned data tests', () => {
   it('Schema', () => {
     expect(ctx.schema instanceof GraphQLSchema).toBe(true);
@@ -2116,6 +2279,51 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 type: z.instanceof(GraphQLObjectType),
+              })
+              .strict(),
+            usersAggregate: z
+              .object({
+                args: z
+                  .object({
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
+            postsAggregate: z
+              .object({
+                args: z
+                  .object({
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
+            customersAggregate: z
+              .object({
+                args: z
+                  .object({
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
           })
@@ -2324,6 +2532,9 @@ describe.sequential('Returned data tests', () => {
             Users: z.instanceof(GraphQLObjectType),
             Posts: z.instanceof(GraphQLObjectType),
             Customers: z.instanceof(GraphQLObjectType),
+            UsersAggregate: z.instanceof(GraphQLObjectType),
+            PostsAggregate: z.instanceof(GraphQLObjectType),
+            CustomersAggregate: z.instanceof(GraphQLObjectType),
           })
           .strict(),
         inputs: z
@@ -2445,6 +2656,28 @@ describe.sequential('Type tests', () => {
             ExtractTables<typeof schema>,
             typeof schema.usersRelations extends Relations<any, infer RelConf> ? RelConf : never
           >;
+        };
+      } & {
+        readonly customersAggregate: {
+          type: GraphQLNonNull<GraphQLObjectType>;
+          args: {
+            where: { type: GraphQLInputObjectType };
+          };
+          resolve: AggregateResolver<typeof schema.Customers>;
+        };
+        readonly postsAggregate: {
+          type: GraphQLNonNull<GraphQLObjectType>;
+          args: {
+            where: { type: GraphQLInputObjectType };
+          };
+          resolve: AggregateResolver<typeof schema.Posts>;
+        };
+        readonly usersAggregate: {
+          type: GraphQLNonNull<GraphQLObjectType>;
+          args: {
+            where: { type: GraphQLInputObjectType };
+          };
+          resolve: AggregateResolver<typeof schema.Users>;
         };
       }
     >();
@@ -2575,6 +2808,10 @@ describe.sequential('Type tests', () => {
         readonly Customers: GraphQLObjectType;
         readonly Posts: GraphQLObjectType;
         readonly Users: GraphQLObjectType;
+      } & {
+        readonly CustomersAggregate: GraphQLObjectType;
+        readonly PostsAggregate: GraphQLObjectType;
+        readonly UsersAggregate: GraphQLObjectType;
       }
     >();
   });

--- a/tests/sqlite.test.ts
+++ b/tests/sqlite.test.ts
@@ -2105,6 +2105,103 @@ describe.sequential('Aggregate query tests', () => {
   });
 });
 
+describe.sequential('Relation aggregate tests', () => {
+  it(`Counts related rows per parent`, async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				users(orderBy: { id: { direction: asc, priority: 1 } }) {
+					id
+					postsAggregate {
+						count
+					}
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        users: [
+          { id: 1, postsAggregate: { count: 4 } },
+          { id: 2, postsAggregate: { count: 0 } },
+          { id: 5, postsAggregate: { count: 2 } },
+        ],
+      },
+    });
+  });
+
+  it(`Full aggregate set per parent, filtered and unfiltered`, async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				usersSingle(where: { id: { eq: 1 } }) {
+					all: postsAggregate {
+						count
+						avg {
+							id
+						}
+						sum {
+							id
+						}
+						min {
+							content
+						}
+						max {
+							content
+						}
+					}
+					filtered: postsAggregate(where: { content: { eq: "1MESSAGE" } }) {
+						count
+					}
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        usersSingle: {
+          all: {
+            count: 4,
+            avg: { id: 3 },
+            sum: { id: 12 },
+            min: { content: '1MESSAGE' },
+            max: { content: '4MESSAGE' },
+          },
+          filtered: { count: 1 },
+        },
+      },
+    });
+  });
+
+  it(`Empty relations aggregate to count 0 and nulls`, async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				usersSingle(where: { id: { eq: 2 } }) {
+					postsAggregate {
+						count
+						avg {
+							id
+						}
+						min {
+							content
+						}
+					}
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        usersSingle: {
+          postsAggregate: {
+            count: 0,
+            avg: { id: null },
+            min: { content: null },
+          },
+        },
+      },
+    });
+  });
+});
+
 describe.sequential('Relation filter tests', () => {
   it(`Filter by a to-many relation`, async () => {
     const res = await ctx.gql.queryGql(/* GraphQL */ `

--- a/tests/sqlite.test.ts
+++ b/tests/sqlite.test.ts
@@ -1965,6 +1965,31 @@ describe.sequential('Aggregate query tests', () => {
     });
   });
 
+  it(`Per-column counts`, async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				postsAggregate {
+					countNonNull {
+						content
+					}
+					countDistinct {
+						authorId
+						content
+					}
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        postsAggregate: {
+          countNonNull: { content: 6 },
+          countDistinct: { authorId: 2, content: 4 },
+        },
+      },
+    });
+  });
+
   it(`Numeric aggregates`, async () => {
     const res = await ctx.gql.queryGql(/* GraphQL */ `
 			{


### PR DESCRIPTION
Twelve commits that add most of the query- and mutation-side surface the generator was missing, plus two breaking changes. Every feature is exercised end-to-end against PGlite/Postgres, MySQL 8 and SQLite.

## Queries

- **Aggregates** — `<plural>Aggregate` root queries with `count`, per-column `avg` / `sum` / `min` / `max`, plus `countNonNull` and `countDistinct`. Only the requested aggregations are computed.
- **Relation aggregates** — `<relation>Aggregate` fields that count or summarize a relation without fetching its rows.
- **Relation filters** — filter rows by what they're related to: a to-one relation takes the target's filter input directly, a to-many takes a `some` / `none` / `every` wrapper.
- **`distinct`** — a column list on list queries, resolved with `row_number() over (partition by …)`.
- **Stable pagination** — a paginated query with no `orderBy` is ordered by primary key, so paging can't repeat or skip a row.

## Mutations

- **Upsert** (opt-in via `features.upsert`) — `upsert<Table>` / `upsert<Table>Single` with a per-request `onConflict` argument: `target` (validated against the table's real unique constraints), `action` (`UPDATE` / `NOTHING`), `update` (which columns to overwrite) and `where` (a guard on the update branch). A batch upsert writes each row with its own values. MySQL gets the reduced input its `ON DUPLICATE KEY UPDATE` can honour and returns `MutationReturn`; on PostgreSQL and SQLite a table with nothing unique to conflict on gets no upsert mutations rather than ones that always fail.

## Configuration and runtime

- **`features` map** — turn individual generated operations off; the types behind them leave the schema too. Everything defaults to on except `upsert`.
- **Context executor** — every resolver reads its executor from the GraphQL context (`drizzleExecutorKey`) at resolve time, so a caller can run a whole request on one transaction.
- **Error handling** — resolver errors are sanitized by default, with an `onError` hook for logging the original.

## Breaking changes

- `feat(scalars)!` — `json` / `jsonb`, `bigint` and `uuid` columns now map to real `JSON` / `BigInt` / `UUID` scalars instead of `String`. Reads return parsed values; `BigInt` is a decimal string in both directions.
- `feat!` — SQLite no longer appends `onConflictDoNothing()` to every insert. Conflicts now throw, matching PostgreSQL, unless `conflictDoNothing: true` is set.
- `conflictDoNothing` is deprecated in favour of `onConflict: { action: NOTHING }` and will go in the next major.

## Verification

- `tsc --noEmit` and `biome check src` clean, `npm run build` produces ESM + CJS + types.
- 372 fast tests (29 files) and all four Docker suites (160 tests) pass.

Remaining work is tracked in `TODO.md` and `docs/plans/upsert-and-nested-writes.md` — nested writes, automatic transaction wrapping, and `groupBy` / `having` on aggregates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)