### PR TITLE
fix(types)!: swap InsertResolver and InsertArrResolver shapes

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -186,19 +186,21 @@ export type SelectSingleResolver<
   | null
 >;
 
+/** Resolver for `create<Table>Single`: one row in, one row (or `undefined`) out. */
 export type InsertResolver<TTable extends Table, IsReturnless extends boolean> = (
-  source: any,
-  args: Partial<InsertArgs<TTable, false>>,
-  context: any,
-  info: GraphQLResolveInfo,
-) => Promise<IsReturnless extends false ? Array<GetRemappedTableDataType<TTable>> : MutationReturnlessResult>;
-
-export type InsertArrResolver<TTable extends Table, IsReturnless extends boolean> = (
   source: any,
   args: Partial<InsertArgs<TTable, true>>,
   context: any,
   info: GraphQLResolveInfo,
 ) => Promise<IsReturnless extends false ? GetRemappedTableDataType<TTable> | undefined : MutationReturnlessResult>;
+
+/** Resolver for `create<Table>`: an array of rows in, an array of rows out. */
+export type InsertArrResolver<TTable extends Table, IsReturnless extends boolean> = (
+  source: any,
+  args: Partial<InsertArgs<TTable, false>>,
+  context: any,
+  info: GraphQLResolveInfo,
+) => Promise<IsReturnless extends false ? Array<GetRemappedTableDataType<TTable>> : MutationReturnlessResult>;
 
 export type UpdateResolver<TTable extends Table, IsReturnless extends boolean> = (
   source: any,

--- a/tests/pglite/resolver-types.test.ts
+++ b/tests/pglite/resolver-types.test.ts
@@ -1,0 +1,53 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import type { InsertArrResolver, InsertResolver, UpsertArrResolver, UpsertResolver } from '@/index';
+import type * as schema from '../schema/pg';
+import type { MinimalContext } from './common';
+
+// Type-only: nothing here touches a database, so there is no setup/teardown.
+type Entities = MinimalContext['entities'];
+type Users = typeof schema.Users;
+
+type Returns<T extends (...args: any) => any> = Awaited<ReturnType<T>>;
+type Values<T extends (...args: any) => any> = NonNullable<NonNullable<Parameters<T>[1]>['values']>;
+
+describe('Mutation resolver types', () => {
+  // These two were named the wrong way round: InsertResolver described the array mutation and
+  // InsertArrResolver the single one, so anyone annotating a custom resolver with them got the
+  // opposite shape from what the name promised.
+  it('InsertResolver is the single-row resolver', () => {
+    expectTypeOf<Values<InsertResolver<Users, false>>>().not.toBeArray();
+    expectTypeOf<Returns<InsertResolver<Users, false>>>().not.toBeArray();
+  });
+
+  it('InsertArrResolver is the array resolver', () => {
+    expectTypeOf<Values<InsertArrResolver<Users, false>>>().toBeArray();
+    expectTypeOf<Returns<InsertArrResolver<Users, false>>>().toBeArray();
+  });
+
+  it('Upsert resolvers follow the same convention', () => {
+    expectTypeOf<Values<UpsertResolver<Users, false>>>().not.toBeArray();
+    expectTypeOf<Returns<UpsertResolver<Users, false>>>().not.toBeArray();
+    expectTypeOf<Values<UpsertArrResolver<Users, false>>>().toBeArray();
+    expectTypeOf<Returns<UpsertArrResolver<Users, false>>>().toBeArray();
+  });
+
+  it('Returnless dialects resolve to MutationReturn either way', () => {
+    expectTypeOf<Returns<InsertResolver<Users, true>>>().toEqualTypeOf<{ isSuccess: boolean }>();
+    expectTypeOf<Returns<InsertArrResolver<Users, true>>>().toEqualTypeOf<{ isSuccess: boolean }>();
+  });
+});
+
+describe('Generated entities wire the right resolver to each mutation', () => {
+  it('create<Table> returns an array and create<Table>Single returns one row', () => {
+    expectTypeOf<Returns<Entities['mutations']['createUsers']['resolve']>>().toBeArray();
+    expectTypeOf<Returns<Entities['mutations']['createUsersSingle']['resolve']>>().not.toBeArray();
+  });
+
+  it('upsert<Table> follows the same split', () => {
+    type UpsertArr = NonNullable<Entities['mutations']['upsertUsers']>;
+    type UpsertSingle = NonNullable<Entities['mutations']['upsertUsersSingle']>;
+
+    expectTypeOf<Returns<UpsertArr['resolve']>>().toBeArray();
+    expectTypeOf<Returns<UpsertSingle['resolve']>>().not.toBeArray();
+  });
+});


### PR DESCRIPTION
`InsertResolver` described the array mutation and `InsertArrResolver` the single one — the opposite of what `MutationsCore` wires them to. Runtime behaviour was always correct; only the exported types were wrong, so anyone annotating a custom resolver from them got the opposite shape.

After this change:

- `InsertResolver` — one row in, one row (or `undefined`) out → `create<Table>Single`
- `InsertArrResolver` — array in, array out → `create<Table>`

which also matches the `UpsertResolver` / `UpsertArrResolver` pair added with upsert.

Adds `tests/pglite/resolver-types.test.ts`: a type-only test that pins both the aliases and the generated entities' resolver shapes, so the two can't drift apart again. Verified the assertions actually bite (inverting one produces a tsc error).

BREAKING CHANGE: the two names have swapped meanings; code using either must swap them.

Closes #12