### PR TITLE
feat(query): add groupBy and having to aggregate queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ reach:
 const { schema } = buildSchema(db, {
     features: {
         aggregates: false,        // <plural>Aggregate root queries
+        groupBy: false,           // <plural>GroupBy root queries
         relationAggregates: false, // <relation>Aggregate fields on object types
         distinct: false,          // the `distinct` argument on list queries
         insert: false,            // create<Table> / create<Table>Single mutations
@@ -110,6 +111,8 @@ const { schema } = buildSchema(db, {
     changes nothing else
 -   `upsert` is the exception: it defaults to `false`, so the upsert mutations and their
     conflict input only exist if you ask for them
+-   `groupBy` needs `aggregates`: it reuses those output types, so turning `aggregates` off
+    turns the group-by queries off with it
 -   Turning off `insert` or `update` also drops the input type that only that mutation
     used (`Create<Type>Input` / `Update<Type>Input`)
 -   Turning off all three mutation features omits the `Mutation` type entirely, the same as
@@ -253,7 +256,72 @@ The optional `where` argument takes the same filter input as the table's list qu
 applied to every aggregate in the selection. All requested aggregates are computed in a
 single `SELECT`, and on an empty result set `count` is `0` while the other values are `null`.
 
-Grouping (`groupBy`) is not supported yet.
+Add `groupBy` to get the same numbers one row per group — see [Group by](#group-by).
+
+## Group by
+
+Every table with aggregates also gets a `<tableName>GroupBy` query (e.g. `postsGroupBy`): the
+same aggregates as `<tableName>Aggregate`, computed once per distinct combination of the
+columns you group by.
+
+```graphql
+{
+    postsGroupBy(
+        groupBy: [authorId, published]
+        where: { createdAt: { gte: "2024-01-01T00:00:00Z" } }
+        having: { count: { gte: 5 } }
+    ) {
+        group {
+            authorId
+            published
+        }
+        count
+        avg {
+            views
+        }
+        max {
+            createdAt
+        }
+    }
+}
+```
+
+-   `groupBy` is required and takes one or more values of the table's `<Type>GroupByColumn`
+    enum. It holds the orderable columns plus booleans — anything the database can group on.
+    An empty list is an error, and repeated columns are ignored
+-   `group` is a `<Type>GroupKeys!` object with one nullable field per groupable column, typed
+    like the table's own column. Columns the query did not group by come back as `null`, which
+    a column whose grouped value really is `NULL` is indistinguishable from
+-   Every other field is the same one `<tableName>Aggregate` returns — `count`, `avg`, `sum`,
+    `min`, `max`, `countNonNull`, `countDistinct` — with the identical types and rules
+-   `where` filters rows before grouping; `having` filters groups after aggregating
+-   The result is `[<Type>GroupBy!]!`, one row per group, in whatever order the database
+    returns them. Add your own ordering client-side if you need it
+
+`having` mirrors the aggregate selection, with an `AggregateNumberFilter` (`eq`, `ne`, `gt`,
+`gte`, `lt`, `lte`, all `Float`) in place of each value:
+
+```graphql
+{
+    postsGroupBy(groupBy: [authorId], having: { count: { gt: 3 }, avg: { views: { gte: 100 } } }) {
+        group {
+            authorId
+        }
+        count
+    }
+}
+```
+
+-   `having: { count: … }` filters on the row count; `avg` / `sum` / `min` / `max` /
+    `countNonNull` / `countDistinct` take one filter per column, over the same columns the
+    matching aggregate type exposes
+-   Every entry in a `having` is ANDed together
+-   A group filter does not need to be in the selection — `having: { count: { gt: 3 } }` works
+    whether or not you asked for `count`
+
+The whole thing is one `SELECT … GROUP BY … HAVING …`. Set `features: { groupBy: false }` to
+leave these queries (and their `<Type>GroupBy`, `<Type>GroupKeys`, `<Type>GroupByColumn` and
+`<Type>Having` types) out of the schema; turning off `aggregates` removes them too.
 
 ## Relation aggregates
 
@@ -408,7 +476,7 @@ fields it mentions:
 | Field | Cost |
 | --- | --- |
 | List query, to-many relation | `(limit ?? defaultListSize) * childComplexity` |
-| Aggregate query, `<relation>Aggregate` | `aggregateCost + childComplexity` |
+| Aggregate query, group-by query, `<relation>Aggregate` | `aggregateCost + childComplexity` |
 | Everything else | no hint — your estimator's default applies |
 
 So `users(limit: 20) { id posts(limit: 5) { id } }` costs `20 * (1 + 5 * 1)` = 120, while the

--- a/TODO.md
+++ b/TODO.md
@@ -17,13 +17,6 @@ Supabase's `pg_graphql`. Roughly ordered within each group; nothing here is comm
   resolve time. What is left is doing it automatically: wrapping a request that fires several
   mutations in a transaction the library opens itself, without the caller wiring up the
   context.
-- **`groupBy` / `having` on aggregates** — the aggregate queries compute one row over the
-  whole filtered set. Grouping is the obvious next step and the most-asked-for aggregate
-  feature after the ones already built.
-- **Query depth and complexity limits** — currently unbounded; a cyclic relation graph lets
-  a client ask for arbitrarily deep nesting. `graphql-depth-limit` and
-  `graphql-query-complexity` cover this from outside, but per-field complexity hints
-  (a relation with `limit: 1000` costs more than a scalar) can only come from the generator.
 - **Full-text search** — Postgres `tsvector` / `websearch_to_tsquery`, MySQL `MATCH … AGAINST`,
   SQLite FTS5. Would slot in as an operator on the filter input for qualifying columns.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,6 +103,7 @@ export const buildSchema = <TDbClient extends AnyDrizzleDB<any>>(
   // be asked for.
   const features = {
     aggregates: config?.features?.aggregates ?? true,
+    groupBy: config?.features?.groupBy ?? true,
     relationAggregates: config?.features?.relationAggregates ?? true,
     distinct: config?.features?.distinct ?? true,
     insert: config?.features?.insert ?? true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -520,6 +520,13 @@ export type GeneratedData<TDatabase extends AnyDrizzleDB<any>> = {
 export type SchemaFeatures = {
   /** `<plural>Aggregate` root queries and the aggregate output types. @default true */
   aggregates?: boolean;
+  /**
+   * `<plural>GroupBy` root queries — the same aggregates, one row per group. Requires
+   * `aggregates`, whose output types the grouped result reuses.
+   *
+   * @default true
+   */
+  groupBy?: boolean;
   /** `<relation>Aggregate` fields on object types, for to-many relations. @default true */
   relationAggregates?: boolean;
   /** The `distinct` argument on list queries. @default true */

--- a/src/util/builders/aggregates.ts
+++ b/src/util/builders/aggregates.ts
@@ -5,17 +5,25 @@ import {
   type Column,
   count,
   countDistinct,
+  eq,
   extractExtendedColumnType,
   getColumns,
+  gt,
+  gte,
   inArray,
+  lt,
+  lte,
   max,
   min,
+  ne,
   sum,
   type Table,
 } from 'drizzle-orm';
 import {
+  type GraphQLEnumType,
+  GraphQLError,
   GraphQLFloat,
-  type GraphQLInputObjectType,
+  GraphQLInputObjectType,
   GraphQLInt,
   GraphQLList,
   GraphQLNonNull,
@@ -31,6 +39,7 @@ import type { ConvertedColumn } from '../type-converter/types.ts';
 import {
   extractFilters,
   extractRelationJoinColumns,
+  generateColumnEnum,
   type RelationAggregateFactory,
   type RelationFilterBase,
   relationFilterCtx,
@@ -243,9 +252,13 @@ const aggregateTarget = (table: Table, tableName: string, typeName: string): Agg
  * into one drizzle select expression per (op, column) pair. An empty `selection` means the
  * client asked for nothing runnable (`__typename` only, or empty sub-selections).
  */
-const parseAggregateRequest = (info: any, target: AggregateTarget): AggregateRequest => {
+const parseAggregateRequest = (
+  info: any,
+  target: AggregateTarget,
+  rootTypeName = `${target.typeName}Aggregate`,
+): AggregateRequest => {
   const parsedInfo = parseResolveInfo(info, { deep: true }) as ResolveTree;
-  const selectionTree = parsedInfo.fieldsByTypeName[`${target.typeName}Aggregate`] ?? {};
+  const selectionTree = parsedInfo.fieldsByTypeName[rootTypeName] ?? {};
 
   const request: AggregateRequest = {
     count: false,
@@ -465,5 +478,278 @@ export const createRelationAggregateFactory = (
     };
 
     return { type, resolve };
+  };
+};
+
+// ── group by ──────────────────────────────────────────────────────────────────
+
+/** Alias prefix for grouped columns, kept clear of the `${op}__${column}` aggregate aliases. */
+const GROUP_COL = `group${SEP}`;
+
+/** Comparison operators a `having` clause can apply to an aggregated value. */
+const HAVING_OPS = { eq, ne, gt, gte, lt, lte } as const;
+
+/**
+ * Columns a query can group on. Grouping needs an equality operator, which is the same
+ * requirement min/max has, plus booleans — orderable excludes them because a min/max over
+ * true/false says nothing, but `GROUP BY isConfirmed` is perfectly ordinary.
+ */
+const groupableColumns = (
+  table: Table,
+  tableName: string,
+): Record<string, { column: Column; converted: ConvertedColumn }> => {
+  const { orderable } = classifyAggregateColumns(table, tableName);
+  const groupable: Record<string, { column: Column; converted: ConvertedColumn }> = { ...orderable };
+
+  for (const [columnName, column] of Object.entries(getColumns(table))) {
+    if (groupable[columnName]) {
+      continue;
+    }
+    const { type: dataType } = extractExtendedColumnType(column);
+    if (dataType !== 'boolean') {
+      continue;
+    }
+    groupable[columnName] = {
+      column,
+      converted: drizzleColumnToGraphQLType(column, columnName, tableName, true, false, false),
+    };
+  }
+
+  return groupable;
+};
+
+/** The `${typeName}GroupByColumn` enum listing what a group-by query can group on. */
+export const generateGroupByEnum = (table: Table, tableName: string, typeName: string): GraphQLEnumType | undefined => {
+  const groupable = groupableColumns(table, tableName);
+
+  return generateColumnEnum(
+    table,
+    `${typeName}GroupByColumn`,
+    `Columns of ${typeName} that a query can group by`,
+    (_column, columnName) => Boolean(groupable[columnName]),
+  );
+};
+
+/** Shared by every `having` clause, so it is created once rather than per table. */
+export const aggregateNumberFilter = new GraphQLInputObjectType({
+  name: 'AggregateNumberFilter',
+  description: 'Compares an aggregated value. Several operators in one filter are ANDed together.',
+  fields: Object.fromEntries(Object.keys(HAVING_OPS).map((op) => [op, { type: GraphQLFloat }])),
+});
+
+/**
+ * The `${typeName}Having` input: one entry per aggregate the group-by query can filter on.
+ * Several entries are ANDed together, as are several operators within one entry.
+ *
+ * `min`/`max` are limited to numeric columns here even though the output type computes them
+ * for every orderable column — the comparison is numeric, so a min over a text column has
+ * nothing to compare against.
+ */
+export const generateHavingInput = (table: Table, tableName: string, typeName: string): GraphQLInputObjectType => {
+  const { numeric, orderable, all } = classifyAggregateColumns(table, tableName);
+
+  const fields: Record<string, { type: any; description?: string }> = {
+    count: { type: aggregateNumberFilter, description: 'Filters groups by how many rows they contain' },
+  };
+
+  const opColumns: Record<string, Record<string, unknown>> = {
+    avg: numeric,
+    sum: numeric,
+    min: numeric,
+    max: numeric,
+    countNonNull: all,
+    countDistinct: orderable,
+  };
+
+  for (const [op, columns] of Object.entries(opColumns)) {
+    const columnNames = Object.keys(columns);
+    if (!columnNames.length) {
+      continue;
+    }
+    fields[op] = {
+      type: new GraphQLInputObjectType({
+        name: `${typeName}${capitalize(op)}Having`,
+        fields: Object.fromEntries(columnNames.map((columnName) => [columnName, { type: aggregateNumberFilter }])),
+      }),
+    };
+  }
+
+  return new GraphQLInputObjectType({
+    name: `${typeName}Having`,
+    description: `Filters ${typeName} groups by their aggregated values`,
+    fields,
+  });
+};
+
+/**
+ * The `${typeName}GroupBy` output type: the grouped columns under `group`, alongside the same
+ * aggregate fields the `${typeName}Aggregate` type carries — the wrapper types are the very
+ * same instances, so the schema holds one `${typeName}AvgAggregate` however it is reached.
+ *
+ * The keys are nested rather than spread across the top level so a column called `count`,
+ * `avg` or `min` cannot collide with the aggregate it sits next to.
+ */
+export const generateGroupByType = (
+  table: Table,
+  tableName: string,
+  typeName: string,
+  cacheCtx?: TypeCacheCtx,
+): GraphQLObjectType | undefined => {
+  const groupable = groupableColumns(table, tableName);
+  if (!Object.keys(groupable).length) {
+    return undefined;
+  }
+
+  const keysType = new GraphQLObjectType({
+    name: `${typeName}GroupKeys`,
+    description: `The grouped column values of one ${typeName} group. A column the query did not group by is null.`,
+    fields: Object.fromEntries(
+      Object.entries(groupable).map(([columnName, { converted }]) => [
+        columnName,
+        { type: converted.type, description: converted.description },
+      ]),
+    ),
+  });
+
+  const aggregateType = generateAggregateTypes(table, tableName, typeName, cacheCtx);
+  const aggregateFields = Object.fromEntries(
+    Object.values(aggregateType.getFields()).map((field) => [
+      field.name,
+      { type: field.type, description: field.description ?? undefined },
+    ]),
+  );
+
+  return new GraphQLObjectType({
+    name: `${typeName}GroupBy`,
+    fields: { group: { type: new GraphQLNonNull(keysType) }, ...aggregateFields },
+  });
+};
+
+/** Turns one `${typeName}Having` entry into SQL conditions over the matching aggregate expression. */
+const havingComparisons = (expression: any, filter: Record<string, any>): any[] =>
+  Object.entries(filter)
+    .filter(([op, value]) => value != null && op in HAVING_OPS)
+    .map(([op, value]) => HAVING_OPS[op as keyof typeof HAVING_OPS](expression, value));
+
+const buildHavingCondition = (having: Record<string, any> | undefined, columns: Record<string, Column>) => {
+  if (!having) {
+    return undefined;
+  }
+
+  const conditions: any[] = [];
+
+  for (const [key, value] of Object.entries(having)) {
+    if (value == null) {
+      continue;
+    }
+    if (key === 'count') {
+      conditions.push(...havingComparisons(count(), value));
+      continue;
+    }
+    if (!AGGREGATE_OPS.includes(key as AggregateOp)) {
+      continue;
+    }
+    for (const [columnName, filter] of Object.entries(value as Record<string, any>)) {
+      const column = columns[columnName];
+      if (!column || filter == null) {
+        continue;
+      }
+      conditions.push(...havingComparisons(OP_FNS[key as AggregateOp](column), filter));
+    }
+  }
+
+  return conditions.length ? and(...conditions) : undefined;
+};
+
+/**
+ * Creates the resolver for a table's `<plural>GroupBy` query: the same aggregates the
+ * `<plural>Aggregate` query computes, but one row per distinct combination of the requested
+ * columns, optionally filtered on the aggregated values with `having`.
+ *
+ * Shared by all three dialects — `SELECT <keys>, <aggregates> FROM t WHERE … GROUP BY <keys>
+ * HAVING …` is the same everywhere.
+ */
+export const generateGroupBy = (
+  db: any,
+  tableName: string,
+  table: Table,
+  typeName: string,
+  fieldName: string,
+  filterArgs: GraphQLInputObjectType,
+  groupByEnum: GraphQLEnumType,
+  havingInput: GraphQLInputObjectType,
+  filterCtx?: RelationFilterBase,
+): CreatedResolver => {
+  const target = aggregateTarget(table, tableName, typeName);
+  const groupable = groupableColumns(table, tableName);
+  const columns = getColumns(table);
+  const rootTypeName = `${typeName}GroupBy`;
+
+  const queryArgs = {
+    groupBy: {
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(groupByEnum))),
+      description: 'Columns to group by. One result row per distinct combination of their values.',
+    },
+    where: { type: filterArgs, description: 'Filters the rows before they are grouped.' },
+    having: { type: havingInput, description: 'Filters the groups after they are aggregated.' },
+  };
+
+  return {
+    name: fieldName,
+    resolver: async (
+      _source,
+      args: { groupBy?: string[]; where?: Filters<Table>; having?: Record<string, any> },
+      context,
+      info,
+    ) => {
+      try {
+        const requestedKeys = [...new Set(args.groupBy ?? [])];
+        if (!requestedKeys.length) {
+          throw new GraphQLError('At least one column to group by is required!');
+        }
+
+        const keyColumns = requestedKeys.map((columnName) => {
+          const groupableColumn = groupable[columnName];
+          if (!groupableColumn) {
+            throw new GraphQLError(`Cannot group ${typeName} by ${columnName}!`);
+          }
+          return [columnName, groupableColumn.column] as const;
+        });
+
+        const request = parseAggregateRequest(info, target, rootTypeName);
+        const selection = {
+          ...Object.fromEntries(keyColumns.map(([columnName, column]) => [`${GROUP_COL}${columnName}`, column])),
+          ...request.selection,
+        };
+
+        let query = resolveExecutor(db, context).select(selection).from(table);
+        if (args.where) {
+          query = query.where(extractFilters(table, tableName, args.where, relationFilterCtx(filterCtx, tableName)));
+        }
+        query = query.groupBy(...keyColumns.map(([, column]) => column));
+
+        const havingCondition = buildHavingCondition(args.having, columns);
+        if (havingCondition) {
+          query = query.having(havingCondition);
+        }
+
+        const rows: any[] = await query;
+
+        return rows.map((row) => {
+          const group: Record<string, any> = {};
+          for (const [columnName, column] of keyColumns) {
+            const value = row[`${GROUP_COL}${columnName}`];
+            const decoded =
+              typeof value === 'string' && target.dateTimeColumns.has(columnName) ? parseDriverDateTime(value) : value;
+            group[columnName] = value == null ? null : remapToGraphQLCore(columnName, decoded, tableName, column);
+          }
+
+          return { group, ...assembleAggregateRow(row, request, target) };
+        });
+      } catch (e) {
+        throw toGraphQLError(e);
+      }
+    },
+    args: queryArgs,
   };
 };

--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -2443,6 +2443,7 @@ export const computeResolverFieldNames = (
   listFieldName: string;
   singleFieldName: string;
   aggregateFieldName: string;
+  groupByFieldName: string;
   createArrayFieldName: string;
   createSingleFieldName: string;
   upsertArrayFieldName: string;
@@ -2455,6 +2456,7 @@ export const computeResolverFieldNames = (
   const listFieldName = (mapped?.plural ?? uncapitalize(tableName)) + suffixes.list;
   const singleFieldName = mapped?.singular ?? uncapitalize(tableName) + suffixes.single;
   const aggregateFieldName = `${mapped?.plural ?? uncapitalize(tableName)}Aggregate`;
+  const groupByFieldName = `${mapped?.plural ?? uncapitalize(tableName)}GroupBy`;
   const createArrayFieldName = `${prefixes.insert}${mapped ? capitalize(mapped.plural) : capitalize(tableName)}`;
   const createSingleFieldName = mapped
     ? `${prefixes.insert}${capitalize(mapped.singular)}`
@@ -2471,6 +2473,7 @@ export const computeResolverFieldNames = (
     listFieldName,
     singleFieldName,
     aggregateFieldName,
+    groupByFieldName,
     createArrayFieldName,
     createSingleFieldName,
     upsertArrayFieldName,

--- a/src/util/builders/mysql.ts
+++ b/src/util/builders/mysql.ts
@@ -46,7 +46,15 @@ import {
   toGraphQLError,
 } from '../builders/common.ts';
 import { remapFromGraphQLArrayInput, remapFromGraphQLSingleInput } from '../data-mappers/index.ts';
-import { createRelationAggregateFactory, generateAggregate, generateAggregateTypes } from './aggregates.ts';
+import {
+  createRelationAggregateFactory,
+  generateAggregate,
+  generateAggregateTypes,
+  generateGroupBy,
+  generateGroupByEnum,
+  generateGroupByType,
+  generateHavingInput,
+} from './aggregates.ts';
 import type {
   CreatedResolver,
   Filters,
@@ -489,6 +497,7 @@ export const generateSchemaData = <
       listFieldName,
       singleFieldName,
       aggregateFieldName,
+      groupByFieldName,
       createArrayFieldName,
       createSingleFieldName,
       upsertArrayFieldName,
@@ -574,6 +583,32 @@ export const generateSchemaData = <
         )
       : undefined;
 
+    // The grouped result reuses the aggregate output types, so it only exists alongside them.
+    const groupByType =
+      features.aggregates && features.groupBy
+        ? generateGroupByType(schema[tableName] as MySqlTable, tableName, typeName, cacheCtx)
+        : undefined;
+    const groupByEnum = groupByType
+      ? generateGroupByEnum(schema[tableName] as MySqlTable, tableName, typeName)
+      : undefined;
+    const havingInput = groupByEnum
+      ? generateHavingInput(schema[tableName] as MySqlTable, tableName, typeName)
+      : undefined;
+    const groupByGenerated =
+      groupByType && groupByEnum && havingInput
+        ? generateGroupBy(
+            db,
+            tableName,
+            schema[tableName] as MySqlTable,
+            typeName,
+            groupByFieldName,
+            tableFilters,
+            groupByEnum,
+            havingInput,
+            filterCtx,
+          )
+        : undefined;
+
     queries[selectArrGenerated.name] = {
       type: selectArrOutput,
       args: selectArrGenerated.args,
@@ -590,6 +625,14 @@ export const generateSchemaData = <
         type: new GraphQLNonNull(aggregateType),
         args: aggregateGenerated.args,
         resolve: aggregateGenerated.resolver,
+        ...(complexity ? { extensions: { complexity: aggregateFieldComplexity(complexity) } } : {}),
+      };
+    }
+    if (groupByGenerated && groupByType) {
+      queries[groupByGenerated.name] = {
+        type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(groupByType))),
+        args: groupByGenerated.args,
+        resolve: groupByGenerated.resolver,
         ...(complexity ? { extensions: { complexity: aggregateFieldComplexity(complexity) } } : {}),
       };
     }
@@ -625,6 +668,10 @@ export const generateSchemaData = <
     outputs[selectSingleOutput.name] = selectSingleOutput;
     if (aggregateType) {
       outputs[aggregateType.name] = aggregateType;
+    }
+    if (groupByType && havingInput) {
+      outputs[groupByType.name] = groupByType;
+      inputs[havingInput.name] = havingInput;
     }
   }
 

--- a/src/util/builders/pg.ts
+++ b/src/util/builders/pg.ts
@@ -58,7 +58,15 @@ import {
   remapToGraphQLArrayOutput,
   remapToGraphQLSingleOutput,
 } from '../data-mappers/index.ts';
-import { createRelationAggregateFactory, generateAggregate, generateAggregateTypes } from './aggregates.ts';
+import {
+  createRelationAggregateFactory,
+  generateAggregate,
+  generateAggregateTypes,
+  generateGroupBy,
+  generateGroupByEnum,
+  generateGroupByType,
+  generateHavingInput,
+} from './aggregates.ts';
 import type {
   CreatedResolver,
   Filters,
@@ -727,6 +735,7 @@ export function generateSchemaData<
       listFieldName,
       singleFieldName,
       aggregateFieldName,
+      groupByFieldName,
       createArrayFieldName,
       createSingleFieldName,
       upsertArrayFieldName,
@@ -876,6 +885,32 @@ export function generateSchemaData<
         )
       : undefined;
 
+    // The grouped result reuses the aggregate output types, so it only exists alongside them.
+    const groupByType =
+      features.aggregates && features.groupBy
+        ? generateGroupByType(schema[tableName] as PgTable, tableName, typeName, cacheCtx)
+        : undefined;
+    const groupByEnum = groupByType
+      ? generateGroupByEnum(schema[tableName] as PgTable, tableName, typeName)
+      : undefined;
+    const havingInput = groupByEnum
+      ? generateHavingInput(schema[tableName] as PgTable, tableName, typeName)
+      : undefined;
+    const groupByGenerated =
+      groupByType && groupByEnum && havingInput
+        ? generateGroupBy(
+            db,
+            tableName,
+            schema[tableName] as PgTable,
+            typeName,
+            groupByFieldName,
+            tableFilters,
+            groupByEnum,
+            havingInput,
+            filterCtx,
+          )
+        : undefined;
+
     queries[selectArrGenerated.name] = {
       type: selectArrOutput,
       args: selectArrGenerated.args,
@@ -892,6 +927,14 @@ export function generateSchemaData<
         type: new GraphQLNonNull(aggregateType),
         args: aggregateGenerated.args,
         resolve: aggregateGenerated.resolver,
+        ...(complexity ? { extensions: { complexity: aggregateFieldComplexity(complexity) } } : {}),
+      };
+    }
+    if (groupByGenerated && groupByType) {
+      queries[groupByGenerated.name] = {
+        type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(groupByType))),
+        args: groupByGenerated.args,
+        resolve: groupByGenerated.resolver,
         ...(complexity ? { extensions: { complexity: aggregateFieldComplexity(complexity) } } : {}),
       };
     }
@@ -954,6 +997,10 @@ export function generateSchemaData<
     outputs[singleTableItemOutput.name] = singleTableItemOutput;
     if (aggregateType) {
       outputs[aggregateType.name] = aggregateType;
+    }
+    if (groupByType && havingInput) {
+      outputs[groupByType.name] = groupByType;
+      inputs[havingInput.name] = havingInput;
     }
   }
 

--- a/src/util/builders/sqlite.ts
+++ b/src/util/builders/sqlite.ts
@@ -55,7 +55,15 @@ import {
   remapToGraphQLArrayOutput,
   remapToGraphQLSingleOutput,
 } from '../data-mappers/index.ts';
-import { createRelationAggregateFactory, generateAggregate, generateAggregateTypes } from './aggregates.ts';
+import {
+  createRelationAggregateFactory,
+  generateAggregate,
+  generateAggregateTypes,
+  generateGroupBy,
+  generateGroupByEnum,
+  generateGroupByType,
+  generateHavingInput,
+} from './aggregates.ts';
 import type {
   CreatedResolver,
   Filters,
@@ -639,6 +647,7 @@ export const generateSchemaData = <
       listFieldName,
       singleFieldName,
       aggregateFieldName,
+      groupByFieldName,
       createArrayFieldName,
       createSingleFieldName,
       upsertArrayFieldName,
@@ -788,6 +797,32 @@ export const generateSchemaData = <
         )
       : undefined;
 
+    // The grouped result reuses the aggregate output types, so it only exists alongside them.
+    const groupByType =
+      features.aggregates && features.groupBy
+        ? generateGroupByType(schema[tableName] as SQLiteTable, tableName, typeName, cacheCtx)
+        : undefined;
+    const groupByEnum = groupByType
+      ? generateGroupByEnum(schema[tableName] as SQLiteTable, tableName, typeName)
+      : undefined;
+    const havingInput = groupByEnum
+      ? generateHavingInput(schema[tableName] as SQLiteTable, tableName, typeName)
+      : undefined;
+    const groupByGenerated =
+      groupByType && groupByEnum && havingInput
+        ? generateGroupBy(
+            db,
+            tableName,
+            schema[tableName] as SQLiteTable,
+            typeName,
+            groupByFieldName,
+            tableFilters,
+            groupByEnum,
+            havingInput,
+            filterCtx,
+          )
+        : undefined;
+
     queries[selectArrGenerated.name] = {
       type: selectArrOutput,
       args: selectArrGenerated.args,
@@ -804,6 +839,14 @@ export const generateSchemaData = <
         type: new GraphQLNonNull(aggregateType),
         args: aggregateGenerated.args,
         resolve: aggregateGenerated.resolver,
+        ...(complexity ? { extensions: { complexity: aggregateFieldComplexity(complexity) } } : {}),
+      };
+    }
+    if (groupByGenerated && groupByType) {
+      queries[groupByGenerated.name] = {
+        type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(groupByType))),
+        args: groupByGenerated.args,
+        resolve: groupByGenerated.resolver,
         ...(complexity ? { extensions: { complexity: aggregateFieldComplexity(complexity) } } : {}),
       };
     }
@@ -866,6 +909,10 @@ export const generateSchemaData = <
     outputs[singleTableItemOutput.name] = singleTableItemOutput;
     if (aggregateType) {
       outputs[aggregateType.name] = aggregateType;
+    }
+    if (groupByType && havingInput) {
+      outputs[groupByType.name] = groupByType;
+      inputs[havingInput.name] = havingInput;
     }
   }
 

--- a/src/util/builders/types.ts
+++ b/src/util/builders/types.ts
@@ -22,6 +22,7 @@ import type { ResolvedComplexityOptions } from './common.ts';
  */
 export type GeneratorFeatures = {
   aggregates: boolean;
+  groupBy: boolean;
   relationAggregates: boolean;
   distinct: boolean;
   insert: boolean;

--- a/tests/mysql.test.ts
+++ b/tests/mysql.test.ts
@@ -2955,6 +2955,36 @@ describe.sequential('Returned data tests', () => {
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
+            usersGroupBy: z
+              .object({
+                args: z
+                  .object({
+                    groupBy: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                        description: z.string(),
+                      })
+                      .strict(),
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                        description: z.string(),
+                      })
+                      .strict(),
+                    having: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                        description: z.string(),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
             customersAggregate: z
               .object({
                 args: z
@@ -2972,6 +3002,36 @@ describe.sequential('Returned data tests', () => {
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
+            customersGroupBy: z
+              .object({
+                args: z
+                  .object({
+                    groupBy: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                        description: z.string(),
+                      })
+                      .strict(),
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                        description: z.string(),
+                      })
+                      .strict(),
+                    having: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                        description: z.string(),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
             postsAggregate: z
               .object({
                 args: z
@@ -2979,6 +3039,36 @@ describe.sequential('Returned data tests', () => {
                     where: z
                       .object({
                         type: z.instanceof(GraphQLInputObjectType),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
+            postsGroupBy: z
+              .object({
+                args: z
+                  .object({
+                    groupBy: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                        description: z.string(),
+                      })
+                      .strict(),
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                        description: z.string(),
+                      })
+                      .strict(),
+                    having: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                        description: z.string(),
                       })
                       .strict(),
                   })
@@ -3221,21 +3311,27 @@ describe.sequential('Returned data tests', () => {
             Customers: z.instanceof(GraphQLObjectType),
             MutationReturn: z.instanceof(GraphQLObjectType),
             UsersAggregate: z.instanceof(GraphQLObjectType),
+            UsersGroupBy: z.instanceof(GraphQLObjectType),
             CustomersAggregate: z.instanceof(GraphQLObjectType),
+            CustomersGroupBy: z.instanceof(GraphQLObjectType),
             PostsAggregate: z.instanceof(GraphQLObjectType),
+            PostsGroupBy: z.instanceof(GraphQLObjectType),
           })
           .strict(),
         inputs: z
           .object({
             UsersFilters: z.instanceof(GraphQLInputObjectType),
+            UsersHaving: z.instanceof(GraphQLInputObjectType),
             UsersOrderBy: z.instanceof(GraphQLInputObjectType),
             CreateUsersInput: z.instanceof(GraphQLInputObjectType),
             UpdateUsersInput: z.instanceof(GraphQLInputObjectType),
             PostsFilters: z.instanceof(GraphQLInputObjectType),
+            PostsHaving: z.instanceof(GraphQLInputObjectType),
             PostsOrderBy: z.instanceof(GraphQLInputObjectType),
             CreatePostsInput: z.instanceof(GraphQLInputObjectType),
             UpdatePostsInput: z.instanceof(GraphQLInputObjectType),
             CustomersFilters: z.instanceof(GraphQLInputObjectType),
+            CustomersHaving: z.instanceof(GraphQLInputObjectType),
             CustomersOrderBy: z.instanceof(GraphQLInputObjectType),
             CreateCustomersInput: z.instanceof(GraphQLInputObjectType),
             UpdateCustomersInput: z.instanceof(GraphQLInputObjectType),
@@ -4782,5 +4878,51 @@ describe.sequential('Upsert tests', () => {
     }`);
 
     expect(result.errors?.[0]?.message).toContain('which the values do not supply');
+  });
+});
+
+describe.sequential('Group by tests', () => {
+  // Seeded posts: author 1 has ids 1, 2, 3, 6 — author 5 has ids 4, 5.
+  const byAuthor = (rows: any[]) => [...rows].sort((a, b) => a.group.authorId - b.group.authorId);
+
+  it('Group by with aggregates', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+      {
+        postsGroupBy(groupBy: [authorId]) {
+          group {
+            authorId
+          }
+          count
+          sum {
+            id
+          }
+          min {
+            id
+          }
+        }
+      }
+    `);
+
+    expect(res.errors).toBeUndefined();
+    expect(byAuthor(res.data!['postsGroupBy'])).toStrictEqual([
+      { group: { authorId: 1 }, count: 4, sum: { id: 12 }, min: { id: 1 } },
+      { group: { authorId: 5 }, count: 2, sum: { id: 9 }, min: { id: 4 } },
+    ]);
+  });
+
+  it('Group by with where and having', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+      {
+        postsGroupBy(groupBy: [authorId], where: { id: { lt: 6 } }, having: { count: { gte: 3 } }) {
+          group {
+            authorId
+          }
+          count
+        }
+      }
+    `);
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data!['postsGroupBy']).toStrictEqual([{ group: { authorId: 1 }, count: 3 }]);
   });
 });

--- a/tests/pg.test.ts
+++ b/tests/pg.test.ts
@@ -2588,6 +2588,36 @@ describe.sequential('Returned data tests', () => {
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
+            usersGroupBy: z
+              .object({
+                args: z
+                  .object({
+                    groupBy: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                        description: z.string(),
+                      })
+                      .strict(),
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                        description: z.string(),
+                      })
+                      .strict(),
+                    having: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                        description: z.string(),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
             customersAggregate: z
               .object({
                 args: z
@@ -2595,6 +2625,36 @@ describe.sequential('Returned data tests', () => {
                     where: z
                       .object({
                         type: z.instanceof(GraphQLInputObjectType),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
+            customersGroupBy: z
+              .object({
+                args: z
+                  .object({
+                    groupBy: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                        description: z.string(),
+                      })
+                      .strict(),
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                        description: z.string(),
+                      })
+                      .strict(),
+                    having: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                        description: z.string(),
                       })
                       .strict(),
                   })
@@ -2622,6 +2682,36 @@ describe.sequential('Returned data tests', () => {
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
+            postsGroupBy: z
+              .object({
+                args: z
+                  .object({
+                    groupBy: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                        description: z.string(),
+                      })
+                      .strict(),
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                        description: z.string(),
+                      })
+                      .strict(),
+                    having: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                        description: z.string(),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
             tagsAggregate: z
               .object({
                 args: z
@@ -2629,6 +2719,36 @@ describe.sequential('Returned data tests', () => {
                     where: z
                       .object({
                         type: z.instanceof(GraphQLInputObjectType),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
+            tagsGroupBy: z
+              .object({
+                args: z
+                  .object({
+                    groupBy: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                        description: z.string(),
+                      })
+                      .strict(),
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                        description: z.string(),
+                      })
+                      .strict(),
+                    having: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                        description: z.string(),
                       })
                       .strict(),
                   })
@@ -2944,26 +3064,34 @@ describe.sequential('Returned data tests', () => {
             Customers: z.instanceof(GraphQLObjectType),
             Tags: z.instanceof(GraphQLObjectType),
             UsersAggregate: z.instanceof(GraphQLObjectType),
+            UsersGroupBy: z.instanceof(GraphQLObjectType),
             CustomersAggregate: z.instanceof(GraphQLObjectType),
+            CustomersGroupBy: z.instanceof(GraphQLObjectType),
             PostsAggregate: z.instanceof(GraphQLObjectType),
+            PostsGroupBy: z.instanceof(GraphQLObjectType),
             TagsAggregate: z.instanceof(GraphQLObjectType),
+            TagsGroupBy: z.instanceof(GraphQLObjectType),
           })
           .strict(),
         inputs: z
           .object({
             UsersFilters: z.instanceof(GraphQLInputObjectType),
+            UsersHaving: z.instanceof(GraphQLInputObjectType),
             UsersOrderBy: z.instanceof(GraphQLInputObjectType),
             CreateUsersInput: z.instanceof(GraphQLInputObjectType),
             UpdateUsersInput: z.instanceof(GraphQLInputObjectType),
             PostsFilters: z.instanceof(GraphQLInputObjectType),
+            PostsHaving: z.instanceof(GraphQLInputObjectType),
             PostsOrderBy: z.instanceof(GraphQLInputObjectType),
             CreatePostsInput: z.instanceof(GraphQLInputObjectType),
             UpdatePostsInput: z.instanceof(GraphQLInputObjectType),
             CustomersFilters: z.instanceof(GraphQLInputObjectType),
+            CustomersHaving: z.instanceof(GraphQLInputObjectType),
             CustomersOrderBy: z.instanceof(GraphQLInputObjectType),
             CreateCustomersInput: z.instanceof(GraphQLInputObjectType),
             UpdateCustomersInput: z.instanceof(GraphQLInputObjectType),
             TagsFilters: z.instanceof(GraphQLInputObjectType),
+            TagsHaving: z.instanceof(GraphQLInputObjectType),
             TagsOrderBy: z.instanceof(GraphQLInputObjectType),
             CreateTagsInput: z.instanceof(GraphQLInputObjectType),
             UpdateTagsInput: z.instanceof(GraphQLInputObjectType),

--- a/tests/pglite/features.test.ts
+++ b/tests/pglite/features.test.ts
@@ -1,6 +1,6 @@
 import { PGlite } from '@electric-sql/pglite';
 import { drizzle, type PgliteDatabase } from 'drizzle-orm/pglite';
-import type { GraphQLObjectType, GraphQLSchema } from 'graphql';
+import type { GraphQLEnumType, GraphQLInputObjectType, GraphQLObjectType, GraphQLSchema } from 'graphql';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { buildSchema, type SchemaFeatures } from '@/index';
 import * as schema from '../schema/pg';
@@ -38,6 +38,7 @@ describe('features: defaults', () => {
     expect(mutations['deleteUsers']).toBeDefined();
     // Upsert is the one flag that is off unless asked for.
     expect(mutations['upsertUsers']).toBeUndefined();
+    expect(queryFields(gqlSchema)['usersGroupBy']).toBeDefined();
   });
 
   it('treats an empty features block the same as no features block', () => {
@@ -63,6 +64,73 @@ describe('features: aggregates', () => {
 
   it('keeps relation aggregates, which are a separate switch', () => {
     expect(userFields(build({ aggregates: false }).schema)['postsAggregate']).toBeDefined();
+  });
+});
+
+describe('features: groupBy', () => {
+  it('generates the group-by query and its types by default', () => {
+    const gqlSchema = build().schema;
+    const groupBy = queryFields(gqlSchema)['postsGroupBy'];
+
+    expect(groupBy).toBeDefined();
+    expect(groupBy!.args.map((a) => a.name).sort()).toEqual(['groupBy', 'having', 'where']);
+    expect(gqlSchema.getType('PostsGroupBy')).toBeDefined();
+    expect(gqlSchema.getType('PostsGroupKeys')).toBeDefined();
+    expect(gqlSchema.getType('PostsGroupByColumn')).toBeDefined();
+    expect(gqlSchema.getType('PostsHaving')).toBeDefined();
+    expect(gqlSchema.getType('AggregateNumberFilter')).toBeDefined();
+  });
+
+  it('reuses the aggregate output types for the grouped result', () => {
+    const gqlSchema = build().schema;
+    const groupByFields = (gqlSchema.getType('PostsGroupBy') as GraphQLObjectType).getFields();
+    const aggregateFields = (gqlSchema.getType('PostsAggregate') as GraphQLObjectType).getFields();
+
+    expect(Object.keys(groupByFields)).toEqual(['group', ...Object.keys(aggregateFields)]);
+    // The very same wrapper instances, so the schema holds one PostsAvgAggregate.
+    expect(groupByFields['avg']!.type).toBe(aggregateFields['avg']!.type);
+  });
+
+  it('offers only groupable columns as keys', () => {
+    const gqlSchema = build().schema;
+    const columns = (gqlSchema.getType('UsersGroupByColumn') as GraphQLEnumType).getValues().map((v) => v.name);
+
+    expect(columns).toContain('name');
+    expect(columns).toContain('isConfirmed');
+    expect(columns).toContain('birthdayDate');
+    // Arrays and geometry have no equality to group on.
+    expect(columns).not.toContain('a');
+    expect(columns).not.toContain('geoXy');
+    expect(columns).not.toContain('vector');
+  });
+
+  it('offers having filters on the aggregates that compare numerically', () => {
+    const gqlSchema = build().schema;
+    const having = (gqlSchema.getType('PostsHaving') as GraphQLInputObjectType).getFields();
+
+    expect(Object.keys(having).sort()).toEqual(['avg', 'count', 'countDistinct', 'countNonNull', 'max', 'min', 'sum']);
+    // min/max are limited to numeric columns, unlike the output type which covers text too.
+    const min = (having['min']!.type as GraphQLInputObjectType).getFields();
+    expect(Object.keys(min)).toEqual(['id', 'authorId']);
+    expect(Object.keys((having['countNonNull']!.type as GraphQLInputObjectType).getFields())).toContain('content');
+  });
+
+  it('omits the group-by query and its types when off', () => {
+    const { schema: gqlSchema, entities } = build({ groupBy: false });
+
+    expect(queryFields(gqlSchema)['postsGroupBy']).toBeUndefined();
+    expect(gqlSchema.getType('PostsGroupBy')).toBeUndefined();
+    expect(gqlSchema.getType('PostsHaving')).toBeUndefined();
+    expect(Object.keys(entities.queries).some((name) => name.endsWith('GroupBy'))).toBe(false);
+    // The aggregate query is a separate switch.
+    expect(queryFields(gqlSchema)['postsAggregate']).toBeDefined();
+  });
+
+  it('goes away with aggregates, whose types it reuses', () => {
+    const gqlSchema = build({ aggregates: false }).schema;
+
+    expect(queryFields(gqlSchema)['postsGroupBy']).toBeUndefined();
+    expect(gqlSchema.getType('PostsGroupBy')).toBeUndefined();
   });
 });
 

--- a/tests/pglite/groupby.test.ts
+++ b/tests/pglite/groupby.test.ts
@@ -1,0 +1,189 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { type Context, createCtx, setupServer, setupTables, teardownServer, teardownTables } from './common';
+
+const DATA_DIR = `./tests/.temp/pgdata-groupby-${Date.now()}`;
+const ctx: Context = createCtx();
+
+// Seeded posts: author 1 has ids 1, 2, 3, 6 — author 5 has ids 4, 5.
+const byAuthor = (rows: any[]) => [...rows].sort((a, b) => a.group.authorId - b.group.authorId);
+
+beforeAll(async () => {
+  await setupServer(ctx, 4023, DATA_DIR);
+});
+afterAll(async () => {
+  await teardownServer(ctx, DATA_DIR);
+});
+beforeEach(async () => {
+  await setupTables(ctx);
+});
+afterEach(async () => {
+  await teardownTables(ctx);
+});
+
+describe.sequential('group by queries', () => {
+  it('counts rows per group', async () => {
+    const result = await ctx.gql.queryGql(`{
+      postsGroupBy(groupBy: [authorId]) { group { authorId } count }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(byAuthor(result.data?.postsGroupBy)).toEqual([
+      { group: { authorId: 1 }, count: 4 },
+      { group: { authorId: 5 }, count: 2 },
+    ]);
+  });
+
+  it('computes the same aggregates the aggregate query does, per group', async () => {
+    const result = await ctx.gql.queryGql(`{
+      postsGroupBy(groupBy: [authorId]) {
+        group { authorId }
+        count
+        avg { id }
+        sum { id }
+        min { id }
+        max { id }
+        countNonNull { content }
+        countDistinct { content }
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(byAuthor(result.data?.postsGroupBy)).toEqual([
+      {
+        group: { authorId: 1 },
+        count: 4,
+        avg: { id: 3 },
+        sum: { id: 12 },
+        min: { id: 1 },
+        max: { id: 6 },
+        countNonNull: { content: 4 },
+        countDistinct: { content: 4 },
+      },
+      {
+        group: { authorId: 5 },
+        count: 2,
+        avg: { id: 4.5 },
+        sum: { id: 9 },
+        min: { id: 4 },
+        max: { id: 5 },
+        countNonNull: { content: 2 },
+        countDistinct: { content: 2 },
+      },
+    ]);
+  });
+
+  it('groups by more than one column', async () => {
+    const result = await ctx.gql.queryGql(`{
+      postsGroupBy(groupBy: [authorId, content]) { group { authorId content } count }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    // Every (author, content) pair in the seed is unique, so each group holds one row.
+    expect(result.data?.postsGroupBy).toHaveLength(6);
+    expect(result.data?.postsGroupBy.every((row: any) => row.count === 1)).toBe(true);
+  });
+
+  it('leaves a key the query did not group by null', async () => {
+    const result = await ctx.gql.queryGql(`{
+      postsGroupBy(groupBy: [authorId]) { group { authorId content } }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(byAuthor(result.data?.postsGroupBy)).toEqual([
+      { group: { authorId: 1, content: null } },
+      { group: { authorId: 5, content: null } },
+    ]);
+  });
+
+  it('filters rows before grouping with where', async () => {
+    const result = await ctx.gql.queryGql(`{
+      postsGroupBy(groupBy: [authorId], where: { authorId: { eq: 1 } }) { group { authorId } count }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.postsGroupBy).toEqual([{ group: { authorId: 1 }, count: 4 }]);
+  });
+
+  it('filters groups by their row count with having', async () => {
+    const result = await ctx.gql.queryGql(`{
+      postsGroupBy(groupBy: [authorId], having: { count: { gt: 3 } }) { group { authorId } count }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.postsGroupBy).toEqual([{ group: { authorId: 1 }, count: 4 }]);
+  });
+
+  it('filters groups by an aggregated column value', async () => {
+    const result = await ctx.gql.queryGql(`{
+      postsGroupBy(groupBy: [authorId], having: { min: { id: { gte: 4 } } }) { group { authorId } min { id } }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.postsGroupBy).toEqual([{ group: { authorId: 5 }, min: { id: 4 } }]);
+  });
+
+  it('ands several having entries together', async () => {
+    const both = await ctx.gql.queryGql(`{
+      postsGroupBy(groupBy: [authorId], having: { count: { gte: 2 }, sum: { id: { lt: 10 } } }) {
+        group { authorId }
+      }
+    }`);
+
+    expect(both.errors).toBeUndefined();
+    // Author 1 passes the count but its ids sum to 12, so only author 5 satisfies both.
+    expect(both.data?.postsGroupBy).toEqual([{ group: { authorId: 5 } }]);
+
+    const contradictory = await ctx.gql.queryGql(`{
+      postsGroupBy(groupBy: [authorId], having: { count: { gt: 3 }, count2: { lt: 1 } }) { count }
+    }`);
+
+    // `count2` is not a field of the having input — a validation error, not a silent pass.
+    expect(contradictory.errors).toBeDefined();
+  });
+
+  it('combines where and having', async () => {
+    const result = await ctx.gql.queryGql(`{
+      postsGroupBy(
+        groupBy: [authorId]
+        where: { id: { lt: 4 } }
+        having: { count: { gte: 3 } }
+      ) { group { authorId } count }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    // Rows 1-3 all belong to author 1, so it is the only group and it survives having.
+    expect(result.data?.postsGroupBy).toEqual([{ group: { authorId: 1 }, count: 3 }]);
+  });
+
+  it('groups by a boolean column, nulls included', async () => {
+    const result = await ctx.gql.queryGql(`{
+      usersGroupBy(groupBy: [isConfirmed]) { group { isConfirmed } count }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    const rows = [...(result.data?.usersGroupBy ?? [])].sort((a: any, b: any) =>
+      String(a.group.isConfirmed).localeCompare(String(b.group.isConfirmed)),
+    );
+    // Two seeded users have no value there, and SQL collects them into one NULL group — which
+    // reads the same as a key the query did not group by.
+    expect(rows).toEqual([
+      { group: { isConfirmed: null }, count: 2 },
+      { group: { isConfirmed: true }, count: 1 },
+    ]);
+  });
+
+  it('rejects an empty groupBy', async () => {
+    const result = await ctx.gql.queryGql(`{ postsGroupBy(groupBy: []) { count } }`);
+
+    expect(result.errors?.[0]?.message).toStrictEqual('At least one column to group by is required!');
+  });
+
+  it('returns nothing when no row survives the filter', async () => {
+    const result = await ctx.gql.queryGql(`{
+      postsGroupBy(groupBy: [authorId], where: { authorId: { eq: 9999 } }) { group { authorId } count }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.postsGroupBy).toEqual([]);
+  });
+});

--- a/tests/pglite/returned-data.test.ts
+++ b/tests/pglite/returned-data.test.ts
@@ -306,6 +306,36 @@ describe.sequential('Returned data tests', () => {
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
+            usersGroupBy: z
+              .object({
+                args: z
+                  .object({
+                    groupBy: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                        description: z.string(),
+                      })
+                      .strict(),
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                        description: z.string(),
+                      })
+                      .strict(),
+                    having: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                        description: z.string(),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
             postsAggregate: z
               .object({
                 args: z
@@ -313,6 +343,36 @@ describe.sequential('Returned data tests', () => {
                     where: z
                       .object({
                         type: z.instanceof(GraphQLInputObjectType),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
+            postsGroupBy: z
+              .object({
+                args: z
+                  .object({
+                    groupBy: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                        description: z.string(),
+                      })
+                      .strict(),
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                        description: z.string(),
+                      })
+                      .strict(),
+                    having: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                        description: z.string(),
                       })
                       .strict(),
                   })
@@ -340,6 +400,36 @@ describe.sequential('Returned data tests', () => {
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
+            customersGroupBy: z
+              .object({
+                args: z
+                  .object({
+                    groupBy: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                        description: z.string(),
+                      })
+                      .strict(),
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                        description: z.string(),
+                      })
+                      .strict(),
+                    having: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                        description: z.string(),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
             tagsAggregate: z
               .object({
                 args: z
@@ -347,6 +437,36 @@ describe.sequential('Returned data tests', () => {
                     where: z
                       .object({
                         type: z.instanceof(GraphQLInputObjectType),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
+            tagsGroupBy: z
+              .object({
+                args: z
+                  .object({
+                    groupBy: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                        description: z.string(),
+                      })
+                      .strict(),
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                        description: z.string(),
+                      })
+                      .strict(),
+                    having: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                        description: z.string(),
                       })
                       .strict(),
                   })
@@ -666,26 +786,34 @@ describe.sequential('Returned data tests', () => {
             Tag: z.instanceof(GraphQLObjectType),
             Tag: z.instanceof(GraphQLObjectType),
             UserAggregate: z.instanceof(GraphQLObjectType),
+            UserGroupBy: z.instanceof(GraphQLObjectType),
             PostAggregate: z.instanceof(GraphQLObjectType),
+            PostGroupBy: z.instanceof(GraphQLObjectType),
             CustomerAggregate: z.instanceof(GraphQLObjectType),
+            CustomerGroupBy: z.instanceof(GraphQLObjectType),
             TagAggregate: z.instanceof(GraphQLObjectType),
+            TagGroupBy: z.instanceof(GraphQLObjectType),
           })
           .strict(),
         inputs: z
           .object({
             UserFilters: z.instanceof(GraphQLInputObjectType),
+            UserHaving: z.instanceof(GraphQLInputObjectType),
             UserOrderBy: z.instanceof(GraphQLInputObjectType),
             CreateUserInput: z.instanceof(GraphQLInputObjectType),
             UpdateUserInput: z.instanceof(GraphQLInputObjectType),
             PostFilters: z.instanceof(GraphQLInputObjectType),
+            PostHaving: z.instanceof(GraphQLInputObjectType),
             PostOrderBy: z.instanceof(GraphQLInputObjectType),
             CreatePostInput: z.instanceof(GraphQLInputObjectType),
             UpdatePostInput: z.instanceof(GraphQLInputObjectType),
             CustomerFilters: z.instanceof(GraphQLInputObjectType),
+            CustomerHaving: z.instanceof(GraphQLInputObjectType),
             CustomerOrderBy: z.instanceof(GraphQLInputObjectType),
             CreateCustomerInput: z.instanceof(GraphQLInputObjectType),
             UpdateCustomerInput: z.instanceof(GraphQLInputObjectType),
             TagFilters: z.instanceof(GraphQLInputObjectType),
+            TagHaving: z.instanceof(GraphQLInputObjectType),
             TagOrderBy: z.instanceof(GraphQLInputObjectType),
             CreateTagInput: z.instanceof(GraphQLInputObjectType),
             UpdateTagInput: z.instanceof(GraphQLInputObjectType),

--- a/tests/sqlite-groupby.test.ts
+++ b/tests/sqlite-groupby.test.ts
@@ -1,0 +1,144 @@
+import { type Client, createClient } from '@libsql/client';
+import { buildRelations, sql } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/libsql';
+import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { type GraphQLEnumType, type GraphQLObjectType, type GraphQLSchema, graphql } from 'graphql';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildSchema } from '@/index';
+
+const Sales = sqliteTable('sales', {
+  id: integer('id').primaryKey(),
+  region: text('region').notNull(),
+  channel: text('channel'),
+  amount: integer('amount'),
+});
+const relations = buildRelations({ Sales }, { Sales: {} });
+const schema = { Sales, relations };
+
+let client: Client;
+let db: any;
+let gqlSchema: GraphQLSchema;
+
+const run = (source: string) => graphql({ schema: gqlSchema, source, contextValue: {} });
+const byRegion = (rows: any[]) => [...rows].sort((a, b) => a.group.region.localeCompare(b.group.region));
+
+beforeAll(async () => {
+  client = createClient({ url: ':memory:' });
+  db = (drizzle as any)({ client, schema, relations });
+
+  await db.run(sql`CREATE TABLE "sales" (
+		"id" integer PRIMARY KEY NOT NULL,
+		"region" text NOT NULL,
+		"channel" text,
+		"amount" integer
+	);`);
+
+  await db.insert(Sales).values([
+    { id: 1, region: 'eu', channel: 'web', amount: 10 },
+    { id: 2, region: 'eu', channel: 'web', amount: 30 },
+    { id: 3, region: 'eu', channel: 'store', amount: 20 },
+    { id: 4, region: 'us', channel: 'web', amount: 100 },
+    { id: 5, region: 'us', channel: null, amount: null },
+  ]);
+
+  gqlSchema = buildSchema(db).schema;
+});
+
+afterAll(() => {
+  client.close();
+});
+
+describe.sequential('SQLite group by', () => {
+  it('returns one row per group with its aggregates', async () => {
+    const result = await run(`{
+      salesGroupBy(groupBy: [region]) {
+        group { region }
+        count
+        sum { amount }
+        avg { amount }
+        max { amount }
+        countNonNull { amount }
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(byRegion(result.data?.['salesGroupBy'] as any[])).toEqual([
+      {
+        group: { region: 'eu' },
+        count: 3,
+        sum: { amount: 60 },
+        avg: { amount: 20 },
+        max: { amount: 30 },
+        countNonNull: { amount: 3 },
+      },
+      {
+        group: { region: 'us' },
+        count: 2,
+        sum: { amount: 100 },
+        avg: { amount: 100 },
+        max: { amount: 100 },
+        countNonNull: { amount: 1 },
+      },
+    ]);
+  });
+
+  it('groups by several columns at once, keeping null keys', async () => {
+    const result = await run(`{
+      salesGroupBy(groupBy: [region, channel]) { group { region channel } count }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.['salesGroupBy']).toEqual(
+      expect.arrayContaining([
+        { group: { region: 'eu', channel: 'web' }, count: 2 },
+        { group: { region: 'eu', channel: 'store' }, count: 1 },
+        { group: { region: 'us', channel: 'web' }, count: 1 },
+        { group: { region: 'us', channel: null }, count: 1 },
+      ]),
+    );
+    expect(result.data?.['salesGroupBy']).toHaveLength(4);
+  });
+
+  it('filters rows with where and groups with having', async () => {
+    // `where` drops the first two eu sales, so eu sums to 20 and only us survives the `having`.
+    const result = await run(`{
+      salesGroupBy(groupBy: [region], where: { id: { gte: 3 } }, having: { sum: { amount: { gt: 45 } } }) {
+        group { region }
+        sum { amount }
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.['salesGroupBy']).toEqual([{ group: { region: 'us' }, sum: { amount: 100 } }]);
+  });
+
+  it('rejects an empty groupBy list', async () => {
+    const result = await run(`{ salesGroupBy(groupBy: []) { count } }`);
+
+    expect(result.errors?.[0]?.message).toBe('At least one column to group by is required!');
+  });
+
+  it('exposes only groupable columns on the enum and prices the query', () => {
+    const queries = gqlSchema.getQueryType()!.getFields();
+    const columns = gqlSchema.getType('SalesGroupByColumn') as GraphQLEnumType;
+
+    expect(columns.getValues().map((v) => v.name)).toEqual(['id', 'region', 'channel', 'amount']);
+    expect(queries['salesGroupBy']!.extensions['complexity']).toBeTypeOf('function');
+
+    // The group keys reuse the table's own column types; the aggregates reuse the aggregate ones.
+    const groupBy = gqlSchema.getType('SalesGroupBy') as GraphQLObjectType;
+    expect(groupBy.getFields()['group']!.type.toString()).toBe('SalesGroupKeys!');
+    expect(groupBy.getFields()['sum']!.type).toBe(
+      (gqlSchema.getType('SalesAggregate') as GraphQLObjectType).getFields()['sum']!.type,
+    );
+  });
+
+  it('is removed with features.groupBy', () => {
+    const withoutGroupBy = buildSchema(db, { features: { groupBy: false } }).schema;
+
+    expect(withoutGroupBy.getQueryType()!.getFields()['salesGroupBy']).toBeUndefined();
+    expect(withoutGroupBy.getQueryType()!.getFields()['salesAggregate']).toBeDefined();
+    expect(withoutGroupBy.getType('SalesGroupBy')).toBeUndefined();
+    expect(withoutGroupBy.getType('SalesHaving')).toBeUndefined();
+  });
+});

--- a/tests/sqlite.test.ts
+++ b/tests/sqlite.test.ts
@@ -2686,6 +2686,36 @@ describe.sequential('Returned data tests', () => {
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
+            usersGroupBy: z
+              .object({
+                args: z
+                  .object({
+                    groupBy: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                        description: z.string(),
+                      })
+                      .strict(),
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                        description: z.string(),
+                      })
+                      .strict(),
+                    having: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                        description: z.string(),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
             postsAggregate: z
               .object({
                 args: z
@@ -2703,6 +2733,36 @@ describe.sequential('Returned data tests', () => {
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
+            postsGroupBy: z
+              .object({
+                args: z
+                  .object({
+                    groupBy: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                        description: z.string(),
+                      })
+                      .strict(),
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                        description: z.string(),
+                      })
+                      .strict(),
+                    having: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                        description: z.string(),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
             customersAggregate: z
               .object({
                 args: z
@@ -2710,6 +2770,36 @@ describe.sequential('Returned data tests', () => {
                     where: z
                       .object({
                         type: z.instanceof(GraphQLInputObjectType),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
+            customersGroupBy: z
+              .object({
+                args: z
+                  .object({
+                    groupBy: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                        description: z.string(),
+                      })
+                      .strict(),
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                        description: z.string(),
+                      })
+                      .strict(),
+                    having: z
+                      .object({
+                        type: z.instanceof(GraphQLInputObjectType),
+                        description: z.string(),
                       })
                       .strict(),
                   })
@@ -2951,21 +3041,27 @@ describe.sequential('Returned data tests', () => {
             Posts: z.instanceof(GraphQLObjectType),
             Customers: z.instanceof(GraphQLObjectType),
             UsersAggregate: z.instanceof(GraphQLObjectType),
+            UsersGroupBy: z.instanceof(GraphQLObjectType),
             PostsAggregate: z.instanceof(GraphQLObjectType),
+            PostsGroupBy: z.instanceof(GraphQLObjectType),
             CustomersAggregate: z.instanceof(GraphQLObjectType),
+            CustomersGroupBy: z.instanceof(GraphQLObjectType),
           })
           .strict(),
         inputs: z
           .object({
             UsersFilters: z.instanceof(GraphQLInputObjectType),
+            UsersHaving: z.instanceof(GraphQLInputObjectType),
             UsersOrderBy: z.instanceof(GraphQLInputObjectType),
             CreateUsersInput: z.instanceof(GraphQLInputObjectType),
             UpdateUsersInput: z.instanceof(GraphQLInputObjectType),
             PostsFilters: z.instanceof(GraphQLInputObjectType),
+            PostsHaving: z.instanceof(GraphQLInputObjectType),
             PostsOrderBy: z.instanceof(GraphQLInputObjectType),
             CreatePostsInput: z.instanceof(GraphQLInputObjectType),
             UpdatePostsInput: z.instanceof(GraphQLInputObjectType),
             CustomersFilters: z.instanceof(GraphQLInputObjectType),
+            CustomersHaving: z.instanceof(GraphQLInputObjectType),
             CustomersOrderBy: z.instanceof(GraphQLInputObjectType),
             CreateCustomersInput: z.instanceof(GraphQLInputObjectType),
             UpdateCustomersInput: z.instanceof(GraphQLInputObjectType),


### PR DESCRIPTION
Closes #10.

Adds a `<plural>GroupBy` root query alongside each `<plural>Aggregate` one: the same aggregates, computed once per distinct combination of the columns you group by, in a single `SELECT … GROUP BY … HAVING …`.

```graphql
{
  postsGroupBy(groupBy: [authorId, published], where: { createdAt: { gte: "2024-01-01T00:00:00Z" } }, having: { count: { gte: 5 } }) {
    group { authorId published }
    count
    avg { views }
  }
}
```

## What it generates

- `<Type>GroupByColumn` — enum of groupable columns: the orderable ones plus booleans. `groupBy` is required; an empty list or a repeated/unknown column is handled at resolve time (`At least one column to group by is required!` / `Cannot group X by y!`).
- `<Type>GroupKeys` — one nullable field per groupable column, typed like the table's own column. Columns the query did not group by come back `null`.
- `<Type>GroupBy` — `group: <Type>GroupKeys!` plus the *same field instances* the existing `<Type>Aggregate` type exposes, so `count` / `avg` / `sum` / `min` / `max` / `countNonNull` / `countDistinct` behave identically and no output types are duplicated.
- `<Type>Having` — mirrors the aggregate selection with a shared `AggregateNumberFilter` (`eq`/`ne`/`gt`/`gte`/`lt`/`lte`, all `Float`) in place of each value. Entries are ANDed. A filtered aggregate does not have to be in the selection.
- `features: { groupBy: false }` removes the queries and every type above. The flag defaults to `true` but implies `aggregates` — turning aggregates off turns group-by off with it.
- The queries carry the same `aggregateCost + childComplexity` complexity hint as the aggregate queries.

## Deviations from the issue

- **Nested `group { … }` keys rather than flattening the grouped columns onto the result row** — a column named `count` or `avg` would otherwise collide with an aggregate field.
- **A dedicated `<Type>GroupByColumn` enum instead of reusing the `distinct` enum** — group-by should not change shape (or disappear) when `features.distinct` is toggled.
- **One shared `AggregateNumberFilter` for `having`**, so `min`/`max` filtering is limited to numeric columns. Filtering a group on `max(created_at)` would need per-column filter inputs; it can be added later without breaking this shape.
- A group whose key really is `NULL` is indistinguishable from a column that was not grouped by — both render as `null`. Documented.

## Tests

- `tests/pglite/groupby.test.ts` (12) — counts and every aggregate per group, multi-column grouping, ungrouped key is null, `where`, `having` on `count` and on `min`, ANDed having entries and an invalid having key, boolean grouping with nulls, empty `groupBy`, empty result set.
- `tests/pglite/features.test.ts` — the generated surface, field-instance reuse with the aggregate types, the groupable-column enum, and removal via `groupBy: false` / `aggregates: false`.
- `tests/sqlite-groupby.test.ts` (6) and a group-by block in `tests/mysql.test.ts` — the dialect builders, including MySQL's `ONLY_FULL_GROUP_BY`.
- The four entity-shape tests learned the new queries, types and inputs.

Full suite green: pglite, sqlite/libsql, and the Docker pg and mysql suites. `npx tsc --noEmit` clean, no new biome diagnostics.