### PR TITLE
fix: type string-array columns as [String!] and give them a String-typed filter

### DIFF
--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -48,6 +48,7 @@ import {
   GraphQLBoolean,
   GraphQLEnumType,
   GraphQLError,
+  GraphQLFloat,
   GraphQLInputObjectType,
   GraphQLInt,
   GraphQLList,
@@ -709,6 +710,7 @@ export const innerOrder = new GraphQLInputObjectType({
  * - the enum GraphQL type name → enum columns (still unique per enum)
  * - "IntArray"    → integer[]/serial[] array columns
  * - "FloatArray"  → float[]/numeric[] array columns
+ * - "StringArray" → text[]/varchar[] array columns
  * - "String"      → all other text/varchar columns
  */
 const resolveGenericFilterName = (
@@ -728,11 +730,23 @@ const resolveGenericFilterName = (
   if (columnGraphQLType.type instanceof GraphQLEnumType) {
     return columnGraphQLType.type.name;
   }
-  // Array columns — give them a distinct name so they never collide with StringFilter.
-  // integer().array() columns have a `dimensions` property set on them.
+  // Array columns — give them a distinct name so they never collide with StringFilter
+  // or with each other. integer().array() / text().array() columns have a `dimensions`
+  // property set on them. The description is stripped for scalar base types before we
+  // get here, so fall back to the list's inner type to tell Int/Float/String apart.
   if (columnGraphQLType.type instanceof GraphQLList) {
     const desc = (columnGraphQLType as any).description ?? '';
-    return desc.includes('Integer') ? 'IntArray' : 'FloatArray';
+    let inner: unknown = columnGraphQLType.type.ofType;
+    if (inner instanceof GraphQLNonNull) {
+      inner = inner.ofType;
+    }
+    if (desc.includes('Integer') || inner === GraphQLInt) {
+      return 'IntArray';
+    }
+    if (desc.includes('Float') || inner === GraphQLFloat) {
+      return 'FloatArray';
+    }
+    return 'StringArray';
   }
   // Date / timestamp columns (check Drizzle internal columnType string)
   const ct: string = (column as any).columnType ?? '';

--- a/src/util/type-converter/index.ts
+++ b/src/util/type-converter/index.ts
@@ -103,6 +103,20 @@ const columnToGraphQLCore = (
         return isInput ? { type: GraphQLString, description: 'Date' } : { type: GraphQLDate, description: 'Date' };
       }
 
+      {
+        // text().array() columns keep dataType='string' but gain a `dimensions` property,
+        // just like the numeric arrays handled in the 'number' branch below. The 'array'
+        // case (baseColumn recursion) still covers drizzle versions that report
+        // dataType='array'; this is a fallback beside it, not a replacement.
+        const dims = (column as any).dimensions as number | undefined;
+        if (dims !== undefined && dims > 0) {
+          return {
+            type: new GraphQLList(new GraphQLNonNull(GraphQLString)),
+            description: 'Array<String>',
+          };
+        }
+      }
+
       return { type: GraphQLString, description: 'String' };
     case 'bigint':
       return { type: GraphQLBigIntString, description: 'BigInt' };

--- a/tests/pglite/string-array.test.ts
+++ b/tests/pglite/string-array.test.ts
@@ -1,0 +1,177 @@
+// Regression tests for string-array columns (GitHub issue #15).
+// Under drizzle-orm 1.x a text().array() column keeps dataType 'string' and sets
+// `dimensions`, so the type converter must not degrade it to a plain String — and
+// the generic filter for it must be String-typed, distinct from Int/Float arrays.
+import { PGlite } from '@electric-sql/pglite';
+import { buildRelations, sql } from 'drizzle-orm';
+import { doublePrecision, integer, pgTable, serial, text } from 'drizzle-orm/pg-core';
+import { drizzle } from 'drizzle-orm/pglite';
+import { type GraphQLInputObjectType, type GraphQLObjectType, type GraphQLSchema, graphql } from 'graphql';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildSchema } from '@/index';
+
+const Docs = pgTable('docs', {
+  id: serial('id').primaryKey(),
+  tags: text('tags').array(),
+  counts: integer('counts').array(),
+  scores: doublePrecision('scores').array(),
+});
+const relations = buildRelations({ Docs }, {});
+const schema = { Docs, relations };
+
+const DATA_DIR = `./tests/.temp/pgdata-string-array-${Date.now()}`;
+
+let pglite: PGlite;
+let db: any;
+let gqlSchema: GraphQLSchema;
+let entities: any;
+
+const run = (source: string, variableValues?: Record<string, any>) =>
+  graphql({ schema: gqlSchema, source, contextValue: {}, variableValues });
+
+const fieldTypeName = (typeName: string, fieldName: string) =>
+  String((entities.types[typeName] as GraphQLObjectType).getFields()[fieldName]!.type);
+
+const filterFieldType = (fieldName: string) =>
+  (entities.inputs['DocsFilters'] as GraphQLInputObjectType).getFields()[fieldName]!.type as GraphQLInputObjectType;
+
+beforeAll(async () => {
+  pglite = new PGlite(DATA_DIR);
+  await pglite.waitReady;
+  db = (drizzle as any)({ client: pglite, schema, relations, logger: !!process.env['LOG_SQL'] });
+
+  await db.execute(
+    sql`CREATE TABLE "docs" (
+      "id" serial PRIMARY KEY NOT NULL,
+      "tags" text[],
+      "counts" integer[],
+      "scores" double precision[]
+    );`,
+  );
+
+  const built = buildSchema(db);
+  gqlSchema = built.schema;
+  entities = built.entities;
+});
+
+afterAll(async () => {
+  await pglite?.close().catch(() => {});
+});
+
+describe.sequential('string-array schema shape', () => {
+  it('types a text().array() column as [String!] on the object type', () => {
+    expect(fieldTypeName('Docs', 'tags')).toBe('[String!]');
+  });
+
+  it('keeps numeric array columns typed as [Int!] / [Float!]', () => {
+    expect(fieldTypeName('Docs', 'counts')).toBe('[Int!]');
+    expect(fieldTypeName('Docs', 'scores')).toBe('[Float!]');
+  });
+
+  it('types the column as [String!] on the create and update inputs', () => {
+    const createFields = (entities.inputs['CreateDocsInput'] as GraphQLInputObjectType).getFields();
+    expect(String(createFields['tags']!.type)).toBe('[String!]');
+
+    const updateFields = (entities.inputs['UpdateDocsInput'] as GraphQLInputObjectType).getFields();
+    expect(String(updateFields['tags']!.type)).toBe('[String!]');
+  });
+});
+
+describe.sequential('array filter types', () => {
+  it('gives string-array columns a String-typed StringArrayFilter', () => {
+    const filter = filterFieldType('tags');
+    expect(filter.name).toBe('StringArrayFilter');
+
+    const fields = filter.getFields();
+    expect(String(fields['eq']!.type)).toBe('[String!]');
+    expect(String(fields['ne']!.type)).toBe('[String!]');
+    expect(String(fields['inArray']!.type)).toBe('[[String!]!]');
+    expect(String(fields['notInArray']!.type)).toBe('[[String!]!]');
+  });
+
+  it('keeps int and float array filters distinct from the string-array filter', () => {
+    const countsFilter = filterFieldType('counts');
+    const scoresFilter = filterFieldType('scores');
+    const tagsFilter = filterFieldType('tags');
+
+    expect(countsFilter.name).toBe('IntArrayFilter');
+    expect(String(countsFilter.getFields()['eq']!.type)).toBe('[Int!]');
+    expect(String(countsFilter.getFields()['inArray']!.type)).toBe('[[Int!]!]');
+
+    expect(scoresFilter.name).toBe('FloatArrayFilter');
+    expect(String(scoresFilter.getFields()['eq']!.type)).toBe('[Float!]');
+
+    expect(tagsFilter).not.toBe(scoresFilter);
+    expect(tagsFilter).not.toBe(countsFilter);
+    expect(countsFilter).not.toBe(scoresFilter);
+  });
+});
+
+describe.sequential('string-array round-trips', () => {
+  it('stores and returns an array of strings', async () => {
+    const insert = await run(`mutation {
+      createDocsSingle(values: { tags: ["alpha", "beta"], counts: [1, 2], scores: [1.5, 2.5] }) {
+        id
+        tags
+        counts
+        scores
+      }
+    }`);
+    expect(insert.errors).toBeUndefined();
+    expect((insert.data as any).createDocsSingle).toEqual({
+      id: 1,
+      tags: ['alpha', 'beta'],
+      counts: [1, 2],
+      scores: [1.5, 2.5],
+    });
+
+    const read = await run(`{ docsSingle(where: { id: { eq: 1 } }) { tags } }`);
+    expect(read.errors).toBeUndefined();
+    expect((read.data as any).docsSingle.tags).toEqual(['alpha', 'beta']);
+  });
+
+  it('accepts a string array passed as a variable', async () => {
+    const res = await run(`mutation ($v: CreateDocsInput!) { createDocsSingle(values: $v) { tags } }`, {
+      v: { tags: ['from', 'variable'] },
+    });
+    expect(res.errors).toBeUndefined();
+    expect((res.data as any).createDocsSingle.tags).toEqual(['from', 'variable']);
+  });
+
+  it('updates a string-array column', async () => {
+    const res = await run(`mutation {
+      updateDocs(where: { id: { eq: 1 } }, set: { tags: ["updated"] }) { id tags }
+    }`);
+    expect(res.errors).toBeUndefined();
+    expect((res.data as any).updateDocs).toEqual([{ id: 1, tags: ['updated'] }]);
+  });
+
+  it('rejects a non-string element', async () => {
+    const res = await run(`mutation { createDocsSingle(values: { tags: [true] }) { tags } }`);
+    expect(res.errors?.[0]?.message).toMatch(/String cannot represent a non string value/);
+  });
+});
+
+describe.sequential('string-array filter execution', () => {
+  it('filters with eq on a string-array column', async () => {
+    const seed = await run(`mutation {
+      createDocs(values: [{ tags: ["x", "y"] }, { tags: ["z"] }]) { id }
+    }`);
+    expect(seed.errors).toBeUndefined();
+
+    const res = await run(`{ docs(where: { tags: { eq: ["x", "y"] } }) { tags } }`);
+    expect(res.errors).toBeUndefined();
+    expect((res.data as any).docs).toEqual([{ tags: ['x', 'y'] }]);
+  });
+
+  it('filters with inArray on a string-array column', async () => {
+    const res = await run(`{ docs(where: { tags: { inArray: [["z"], ["nope"]] } }) { tags } }`);
+    expect(res.errors).toBeUndefined();
+    expect((res.data as any).docs).toEqual([{ tags: ['z'] }]);
+  });
+
+  it('rejects a Float value where a string-array filter expects strings', async () => {
+    const res = await run(`{ docs(where: { tags: { eq: [1.5] } }) { tags } }`);
+    expect(res.errors?.[0]?.message).toMatch(/String cannot represent a non string value/);
+  });
+});


### PR DESCRIPTION
## Summary

Under drizzle-orm 1.x, a Postgres `text().array()` column does not report `dataType: 'array'` — it keeps `dataType: 'string'` and sets `dimensions`. Two bugs fell out of that:

1. **String-array columns degraded to `String`.** The `'string'` branch of `columnToGraphQLCore` (`src/util/type-converter/index.ts`) fell straight through to `GraphQLString`, so a `text[]` column was typed `String` in the object type and in the create/update inputs while values still round-tripped as arrays at runtime. This adds a `dimensions > 0` fallback that returns `[String!]`, mirroring the fallback the `'number'` branch already has. The existing `case 'array'` / `baseColumn` recursion is left untouched — the dimensions check is a fallback beside it, not a replacement.

2. **Array filter types collapsed into `FloatArray`.** `resolveGenericFilterName` (`src/util/builders/common.ts`) named every non-Integer `GraphQLList` filter `FloatArray`, and since generic filter input types are cached by that name, the first array column encountered minted the `FloatArray` filter and every later array column silently reused it with `Float`-typed `eq`/`inArray`/etc. List filters are now classified as `IntArray` / `FloatArray` / `StringArray`, keyed off the description with a fallback to the list's inner named type — descriptions are stripped for scalar base types (`string`/`number`/`boolean`) before this point, so the inner-type fallback is what makes the classification reliable for dimension-based arrays.

## Tests

New `tests/pglite/string-array.test.ts` (12 tests, standalone PGlite instance, no server port) covering:

- `text().array()` typed as `[String!]` on the object type and on the create/update inputs
- `integer().array()` / `doublePrecision().array()` still typed `[Int!]` / `[Float!]`
- `StringArrayFilter` with `eq: [String!]` and `inArray: [[String!]!]`, distinct from `IntArrayFilter` and `FloatArrayFilter`
- Round-tripping string arrays through create (inline and via variables) and update mutations
- Filter execution (`eq`, `inArray`) on a string-array column, and type errors when Float/Boolean values are passed where strings are expected

Verified with `npx tsc --noEmit`, `biome check`, and `npx vitest run tests/pglite/ tests/sqlite.test.ts tests/sqlite-custom.test.ts` (31 files, 410 tests, all passing).

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)
