### PR TITLE
feat(schema): emit non-null to-one relation fields for optional: false relations

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,6 +623,28 @@ Generated schemas resolve nested relations without N+1 query explosions:
 > **SQLite 3.25+**. Relations without pagination, and all other query/mutation paths,
 > have no such requirement.
 
+### Relation nullability
+
+A **to-many** relation field is always `[Target!]!`. A **to-one** relation field is
+nullable by default, but honors the relation's declared optionality: declaring
+`optional: false` on a Drizzle `one` relation — the assertion that the related row always
+exists, i.e. a `NOT NULL` foreign key — emits the field as `Target!`:
+
+```Typescript
+const relations = buildRelations({ Users, Posts }, {
+    Posts: {
+        // posts.author_id is NOT NULL → author: Users!
+        author: r.one.Users({ from: r.Posts.authorId, to: r.Users.id, optional: false }),
+    },
+})
+```
+
+Only the explicit `optional: false` declaration is honored — required-ness is never
+inferred from column nullability, since a `NOT NULL` `from` column does not guarantee a
+related row exists when the constraint lives on the other side of the join. Note that on a
+required relation, a `where` argument that filters out the related row (or a dangling
+foreign key) resolves to `null` and therefore surfaces as a GraphQL non-null error.
+
 ### Overriding a relation's resolver without overfetching
 
 By default the eager `with:` pre-fetch is driven purely by the GraphQL selection set:

--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -1196,10 +1196,17 @@ const generateSelectFields = <TWithOrder extends boolean>(
       const resolve = resolverFactory?.({ tableName, relationName, relEntry: relEntry as TableNamedRelations, isOne });
 
       if (isOne) {
+        // Honor the relation's declared optionality: `r.one.Target({ ..., optional: false })`
+        // asserts the related row always exists (a NOT NULL foreign key), so the field is
+        // emitted as `Target!`. The default (`optional: true` / omitted) stays nullable.
+        // Column nullability alone is NOT used to infer this — a notNull `from` column does
+        // not guarantee a related row exists when the FK constraint lives on the other side
+        // (e.g. `Users.customer` joins the notNull `Users.id` to `Customers.userId`).
+        const isRequired = (relation as One<any, any>).optional === false;
         rawRelationFields.push([
           relationName,
           {
-            type: relType,
+            type: isRequired ? new GraphQLNonNull(relType) : relType,
             args: {
               where: { type: relSelectData.filters },
             },

--- a/tests/pglite/relation-nullability.test.ts
+++ b/tests/pglite/relation-nullability.test.ts
@@ -1,0 +1,179 @@
+import { mkdir, rm } from 'node:fs/promises';
+import { PGlite } from '@electric-sql/pglite';
+import { buildRelations, createRelationsHelper, sql } from 'drizzle-orm';
+import { integer, pgTable, serial, text } from 'drizzle-orm/pg-core';
+import { drizzle } from 'drizzle-orm/pglite';
+import {
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLSchema,
+  graphql,
+  isNonNullType,
+  isObjectType,
+} from 'graphql';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildSchema } from '@/index';
+
+// ── Schema: required vs optional to-one relations ─────────────────────────────
+const Authors = pgTable('authors', {
+  id: serial('id').primaryKey(),
+  name: text('name').notNull(),
+});
+const Books = pgTable('books', {
+  id: serial('id').primaryKey(),
+  title: text('title').notNull(),
+  authorId: integer('author_id')
+    .notNull()
+    .references(() => Authors.id),
+  editorId: integer('editor_id').references(() => Authors.id),
+});
+const r = createRelationsHelper({ Authors, Books });
+const relations = buildRelations(
+  { Authors, Books },
+  {
+    Authors: {
+      books: r.many.Books({ from: r.Authors.id, to: r.Books.authorId }),
+      // To-one whose `from` column (Authors.id) is NOT NULL, but with no `optional: false`
+      // declaration — an author may have no book, so this must stay nullable.
+      featuredBook: r.one.Books({ from: r.Authors.id, to: r.Books.authorId }),
+    },
+    Books: {
+      // NOT NULL FK declared required — emitted as `Authors!`.
+      author: r.one.Authors({ from: r.Books.authorId, to: r.Authors.id, optional: false }),
+      // Nullable FK, default optionality — stays `Authors`.
+      editor: r.one.Authors({ from: r.Books.editorId, to: r.Authors.id }),
+    },
+  },
+);
+const schema = { Authors, Books, relations };
+
+const DATA_DIR = `./tests/.temp/pgdata-relation-nullability-${Date.now()}`;
+let pglite: PGlite;
+let db: any;
+let gqlSchema: GraphQLSchema;
+let entities: any;
+
+beforeAll(async () => {
+  await mkdir(DATA_DIR, { recursive: true });
+  pglite = new PGlite(DATA_DIR);
+  await pglite.waitReady;
+  db = (drizzle as any)({ client: pglite, schema, relations, logger: !!process.env['LOG_SQL'] });
+
+  await db.execute(sql`CREATE TABLE "authors" ("id" serial PRIMARY KEY NOT NULL, "name" text NOT NULL);`);
+  await db.execute(
+    sql`CREATE TABLE "books" (
+      "id" serial PRIMARY KEY NOT NULL,
+      "title" text NOT NULL,
+      "author_id" integer NOT NULL REFERENCES "authors"("id"),
+      "editor_id" integer REFERENCES "authors"("id")
+    );`,
+  );
+  await db.insert(Authors).values([
+    { id: 1, name: 'FirstAuthor' },
+    { id: 2, name: 'SecondAuthor' },
+  ]);
+  await db.insert(Books).values([
+    { id: 1, title: 'Edited', authorId: 1, editorId: 2 },
+    { id: 2, title: 'Unedited', authorId: 2, editorId: null },
+  ]);
+  // Seeding used explicit ids; advance the serial sequences so inserts without an id work.
+  await db.execute(sql`SELECT setval('authors_id_seq', 100);`);
+  await db.execute(sql`SELECT setval('books_id_seq', 100);`);
+
+  const built = buildSchema(db);
+  gqlSchema = built.schema;
+  entities = built.entities;
+});
+
+afterAll(async () => {
+  await pglite?.close().catch(() => {});
+  await rm(DATA_DIR, { recursive: true, force: true }).catch(() => {});
+});
+
+describe.sequential('to-one relation nullability', () => {
+  it('emits a to-one relation declared optional: false as Target!', () => {
+    const booksType = gqlSchema.getType('Books') as GraphQLObjectType;
+    const authorField = booksType.getFields()['author']!;
+    expect(isNonNullType(authorField.type)).toBe(true);
+    expect((authorField.type as GraphQLNonNull<GraphQLObjectType>).ofType.name).toBe('Authors');
+  });
+
+  it('keeps a to-one relation with default optionality nullable', () => {
+    const booksType = gqlSchema.getType('Books') as GraphQLObjectType;
+    const editorField = booksType.getFields()['editor']!;
+    expect(isObjectType(editorField.type)).toBe(true);
+    expect((editorField.type as GraphQLObjectType).name).toBe('Authors');
+  });
+
+  it('does not infer required-ness from column nullability alone', () => {
+    // Authors.featuredBook joins the NOT NULL Authors.id, but no row is guaranteed
+    // to exist on the other side — the field must stay nullable.
+    const authorsType = gqlSchema.getType('Authors') as GraphQLObjectType;
+    const featuredField = authorsType.getFields()['featuredBook']!;
+    expect(isNonNullType(featuredField.type)).toBe(false);
+    expect((featuredField.type as GraphQLObjectType).name).toBe('Books');
+  });
+
+  it('resolves required and optional to-one relations through the generated queries', async () => {
+    const result = await graphql({
+      schema: gqlSchema,
+      source: `{ books { id title author { name } editor { name } } }`,
+      contextValue: {},
+    });
+    expect(result.errors).toBeUndefined();
+    const books: any[] = (result.data as any)?.books ?? [];
+    expect(books.find((b) => b.id === 1)).toEqual({
+      id: 1,
+      title: 'Edited',
+      author: { name: 'FirstAuthor' },
+      editor: { name: 'SecondAuthor' },
+    });
+    expect(books.find((b) => b.id === 2)).toEqual({
+      id: 2,
+      title: 'Unedited',
+      author: { name: 'SecondAuthor' },
+      editor: null,
+    });
+  });
+
+  it('resolves a required to-one relation through the batch field resolver (lazy path)', async () => {
+    const allTypes = entities.types as Record<string, GraphQLObjectType>;
+    const BooksType = allTypes['Books']!;
+    const lazySchema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: {
+          books: {
+            type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(BooksType))) as any,
+            resolve: () => db.select().from(Books),
+          },
+        },
+      }),
+    });
+    const result = await graphql({
+      schema: lazySchema,
+      source: `{ books { id author { name } editor { name } } }`,
+      contextValue: {},
+    });
+    expect(result.errors).toBeUndefined();
+    const books: any[] = (result.data as any)?.books ?? [];
+    expect(books.find((b) => b.id === 1)?.author).toEqual({ name: 'FirstAuthor' });
+    expect(books.find((b) => b.id === 2)?.author).toEqual({ name: 'SecondAuthor' });
+    expect(books.find((b) => b.id === 2)?.editor).toBeNull();
+  });
+
+  it('returns the required relation as non-null from mutation payloads', async () => {
+    const result = await graphql({
+      schema: gqlSchema,
+      source: `mutation {
+        createBooks(values: [{ title: "New", authorId: 1 }]) { title author { name } editor { name } }
+      }`,
+      contextValue: {},
+    });
+    expect(result.errors).toBeUndefined();
+    const created: any[] = (result.data as any)?.createBooks ?? [];
+    expect(created).toHaveLength(1);
+    expect(created[0]).toEqual({ title: 'New', author: { name: 'FirstAuthor' }, editor: null });
+  });
+});


### PR DESCRIPTION
## Summary

`generateSelectFields` in `src/util/builders/common.ts` emitted every to-one relation field as the bare (nullable) object type, ignoring the relation's declared optionality. Now a `one` relation declared with `optional: false` — Drizzle's assertion that the related row always exists, i.e. a `NOT NULL` foreign key — is emitted as `Target!`. Relations with default optionality (`optional` omitted or `true`) are unchanged.

Since all three dialect builders (pg, mysql, sqlite) build their relation fields through the shared `generateSelectFields` in `common.ts` (verified — the dialect files only build resolver maps, never field types), a single change covers every dialect.

## Design choice: hard guarantee, gated only on the explicit declaration

The issue offered two designs — unconditional non-null, or an opt-in `strictRelationNullability` build flag. This PR goes with the **unconditional** behavior, for two reasons:

1. **It is already per-relation opt-in.** `optional` defaults to `true` in drizzle-orm, so nothing changes unless the user explicitly wrote `optional: false` on that relation. That declaration is the same assertion Drizzle itself acts on — its relational query builder types the result of a required `one` relation as non-nullable. The generated GraphQL schema now simply matches the contract the user already declared (and Prisma's generated types share).
2. **The batch field resolver is safe for it.** The resolver loads the target by FK value; with a `NOT NULL` FK the parent value can never be null, so the only ways the field resolves to `null` are a dangling foreign key or a client-supplied `where` argument on the relation field that filters out the required row. Both surface as a GraphQL non-null error — which is arguably the correct outcome for a contract violation / contradictory filter, and matches the issue's "broken reference" framing. This caveat is documented in the README section added here.

One deliberate narrowing versus the issue text: required-ness is **not** inferred from "every FK column in `from` is notNull". That inference is unsound in Drizzle's relation model — e.g. `Users.customer: r.one.Customers({ from: r.Users.id, to: r.Customers.userId })` has a `NOT NULL` `from` column (`users.id`), but no customer row is guaranteed to exist because the FK constraint lives on the other side of the join. Only the explicit `optional: false` declaration is honored; the code comments capture why.

## Changes

- `src/util/builders/common.ts` — wrap the to-one relation field type in `GraphQLNonNull` when `relation.optional === false` (shared by the pg/mysql/sqlite builders).
- `tests/pglite/relation-nullability.test.ts` — new PGlite suite (no HTTP server, so no port usage): required to-one emitted as `Authors!`; default-optionality to-one stays nullable; no inference from column nullability alone (`NOT NULL` `from` column without `optional: false` stays nullable); resolution through the generated queries (eager path), through the batch field resolver (lazy `entities.types` path), and through a mutation payload.
- `README.md` — new "Relation nullability" section documenting the behavior and the `where`-argument caveat.

## Test results

- `npx tsc --noEmit` — clean
- `npx biome check` — no new issues (only pre-existing style infos shared with the existing suite)
- `npx vitest run tests/pglite/ tests/sqlite.test.ts tests/sqlite-custom.test.ts` — 31 files, 404 tests, all passing (Docker-based pg/mysql suites not run)

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)
