### PR TITLE
feat: throw on unknown filter keys and operators instead of silently dropping them

### DIFF
--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -1467,6 +1467,12 @@ export const extractFiltersColumn = <TColumn extends Column>(
       variants.push(arrayValueOps[operatorName]!(column, arrayValue));
     } else if (operatorName in nullableOps) {
       variants.push(nullableOps[operatorName]!(column));
+    } else {
+      // An unrecognized operator must throw rather than be dropped: when the generated
+      // schema is stitched/merged with another schema, foreign operators (e.g. `equals`,
+      // `contains`, `mode`) can pass input validation, and silently dropping them could
+      // turn a constrained where into an unbounded one.
+      throw new GraphQLError(`WHERE ${columnName}: Unknown operator: ${operatorName}`);
     }
   }
 
@@ -1615,14 +1621,22 @@ const extractRelationFilter = (
     return buildRelationExists(parentTable, relationName, relEntry, value, 'some', ctx);
   }
 
+  const relationMatchModes: readonly RelationMatchMode[] = ['some', 'none', 'every'];
+
   const variants: SQL[] = [];
-  for (const mode of ['some', 'none', 'every'] as const) {
-    const inner = value[mode];
+  for (const [mode, inner] of Object.entries(value)) {
     if (inner === undefined || inner === null) {
       continue;
     }
 
-    const extracted = buildRelationExists(parentTable, relationName, relEntry, inner, mode, ctx);
+    // Unknown keys inside the some/none/every wrapper must throw rather than be dropped —
+    // a stitched schema can contribute foreign keys here too, and dropping them all would
+    // silently turn the relation filter into no filter at all.
+    if (!relationMatchModes.includes(mode as RelationMatchMode)) {
+      throw new GraphQLError(`WHERE ${relationName}: Unknown relation filter key: ${mode}`);
+    }
+
+    const extracted = buildRelationExists(parentTable, relationName, relEntry, inner, mode as RelationMatchMode, ctx);
     if (extracted) {
       variants.push(extracted);
     }
@@ -1673,11 +1687,18 @@ export const extractFilters = <TTable extends Table>(
     }
 
     const column = columns[fieldName];
+
+    // A key that is neither a column nor a filterable relation must throw rather than be
+    // dropped: when the generated schema is stitched/merged with another schema, same-named
+    // inputs can contribute foreign keys that pass input validation, and a where that loses
+    // all of its keys silently becomes an unbounded select/update/delete.
+    if (!column && !(relations?.[fieldName] && relationCtx)) {
+      throw new GraphQLError(`WHERE ${tableName}: Unknown filter key: ${fieldName}`);
+    }
+
     const extracted = column
       ? extractFiltersColumn(column, fieldName, operators)
-      : relations?.[fieldName] && relationCtx
-        ? extractRelationFilter(table, fieldName, relations[fieldName]!, operators as any, relationCtx)
-        : undefined;
+      : extractRelationFilter(table, fieldName, relations![fieldName]!, operators as any, relationCtx!);
 
     if (extracted) {
       variants.push(extracted);

--- a/tests/pglite/unknown-filter-keys.test.ts
+++ b/tests/pglite/unknown-filter-keys.test.ts
@@ -1,0 +1,171 @@
+import { getColumns } from 'drizzle-orm';
+import { GraphQLError } from 'graphql';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  buildNamedRelations,
+  extractFilters,
+  extractFiltersColumn,
+  type RelationFilterContext,
+} from '@/util/builders/common';
+import { type Context, createCtx, schema, setupServer, setupTables, teardownServer, teardownTables } from './common';
+
+const DATA_DIR = `./tests/.temp/pgdata-unknown-filter-keys-${Date.now()}`;
+const ctx: Context = createCtx();
+
+beforeAll(async () => {
+  await setupServer(ctx, 5180, DATA_DIR);
+});
+afterAll(async () => {
+  await teardownServer(ctx, DATA_DIR);
+});
+beforeEach(async () => {
+  await setupTables(ctx);
+});
+afterEach(async () => {
+  await teardownTables(ctx);
+});
+
+const tables = {
+  Users: schema.Users,
+  Customers: schema.Customers,
+  Posts: schema.Posts,
+  Tags: schema.Tags,
+};
+
+/**
+ * Builds the same relation filter context the generators hand to every resolver, narrowed
+ * to one table — so these tests exercise extractFilters exactly the way a resolver does
+ * when a stitched/merged schema lets foreign keys through input validation.
+ */
+const relationCtxFor = (tableKey: string): RelationFilterContext => ({
+  tables,
+  relationMap: buildNamedRelations((ctx.db as any)._.relations ?? {}, Object.entries(tables)),
+  tableKey,
+});
+
+describe('extractFilters unknown key handling (stitched-schema scenario)', () => {
+  it('throws a GraphQLError for a key that is neither a column nor a relation', () => {
+    expect(() => extractFilters(schema.Users, 'users', { equals: { eq: 1 } } as any, relationCtxFor('Users'))).toThrow(
+      /Unknown filter key: equals/,
+    );
+
+    try {
+      extractFilters(schema.Users, 'users', { equals: { eq: 1 } } as any, relationCtxFor('Users'));
+      expect.unreachable('extractFilters should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(GraphQLError);
+    }
+  });
+
+  it('throws for an unknown key even without a relation filter context', () => {
+    expect(() => extractFilters(schema.Tags, 'tags', { contains: 'foo' } as any)).toThrow(
+      /WHERE tags: Unknown filter key: contains/,
+    );
+  });
+
+  it('throws for a relation key when no relation filter context is available', () => {
+    expect(() => extractFilters(schema.Users, 'users', { posts: { some: { id: { eq: 1 } } } } as any)).toThrow(
+      /WHERE users: Unknown filter key: posts/,
+    );
+  });
+
+  it('throws for an unknown key inside a table-level OR variant', () => {
+    expect(() =>
+      extractFilters(schema.Users, 'users', { OR: [{ id: { eq: 1 } }, { equals: 1 }] } as any, relationCtxFor('Users')),
+    ).toThrow(/Unknown filter key: equals/);
+  });
+
+  it('throws for an unknown key inside a to-many relation wrapper', () => {
+    expect(() =>
+      extractFilters(schema.Users, 'users', { posts: { equals: { id: { eq: 1 } } } } as any, relationCtxFor('Users')),
+    ).toThrow(/WHERE posts: Unknown relation filter key: equals/);
+  });
+
+  it('throws for an unknown key nested inside a some/none/every filter', () => {
+    expect(() =>
+      extractFilters(schema.Users, 'users', { posts: { some: { foo: { eq: 1 } } } } as any, relationCtxFor('Users')),
+    ).toThrow(/Unknown filter key: foo/);
+  });
+
+  it('throws for an unknown key inside a to-one relation filter', () => {
+    expect(() =>
+      extractFilters(schema.Users, 'users', { customer: { equals: 1 } } as any, relationCtxFor('Users')),
+    ).toThrow(/Unknown filter key: equals/);
+  });
+});
+
+describe('extractFiltersColumn unknown operator handling', () => {
+  const nameColumn = getColumns(schema.Users).name;
+
+  it('throws a GraphQLError for an unrecognized operator', () => {
+    expect(() => extractFiltersColumn(nameColumn, 'name', { contains: 'First' } as any)).toThrow(
+      /WHERE name: Unknown operator: contains/,
+    );
+
+    try {
+      extractFiltersColumn(nameColumn, 'name', { equals: 'First' } as any);
+      expect.unreachable('extractFiltersColumn should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(GraphQLError);
+    }
+  });
+
+  it('throws for an unrecognized operator via extractFilters', () => {
+    expect(() => extractFilters(schema.Users, 'users', { name: { mode: 'insensitive' } } as any)).toThrow(
+      /WHERE name: Unknown operator: mode/,
+    );
+  });
+
+  it('throws for an unrecognized operator inside a column-level OR variant', () => {
+    expect(() => extractFiltersColumn(nameColumn, 'name', { OR: [{ eq: 'a' }, { contains: 'b' }] } as any)).toThrow(
+      /WHERE name: Unknown operator: contains/,
+    );
+  });
+});
+
+describe('legitimate filters are unaffected', () => {
+  it('extracts column operators, OR variants and null-valued keys without throwing', () => {
+    expect(extractFilters(schema.Users, 'users', { id: { eq: 1 }, name: { ilike: '%user%' } } as any)).toBeDefined();
+    expect(extractFilters(schema.Users, 'users', { OR: [{ id: { eq: 1 } }, { id: { eq: 2 } }] } as any)).toBeDefined();
+    expect(extractFilters(schema.Users, 'users', { email: { isNull: true } } as any)).toBeDefined();
+    // Explicit nulls mean "no filter" and are still skipped, not treated as unknown.
+    expect(extractFilters(schema.Users, 'users', { name: null, id: { eq: 1 } } as any)).toBeDefined();
+    expect(extractFilters(schema.Users, 'users', { name: { isNull: false } } as any)).toBeUndefined();
+  });
+
+  it('extracts relation filters (some/none/every and to-one) without throwing', () => {
+    const relationCtx = relationCtxFor('Users');
+    expect(
+      extractFilters(schema.Users, 'users', { posts: { some: { content: { eq: '1MESSAGE' } } } } as any, relationCtx),
+    ).toBeDefined();
+    expect(
+      extractFilters(
+        schema.Users,
+        'users',
+        { posts: { none: { content: { eq: 'x' } }, every: { content: { isNotNull: true } } } } as any,
+        relationCtx,
+      ),
+    ).toBeDefined();
+    expect(
+      extractFilters(schema.Users, 'users', { customer: { address: { eq: 'AdOne' } } } as any, relationCtx),
+    ).toBeDefined();
+  });
+});
+
+describe.sequential('end-to-end: valid filters still resolve', () => {
+  it('filters by column and relation through the generated schema', async () => {
+    const res = await ctx.gql.queryGql(`{
+      users(where: { name: { eq: "FirstUser" }, posts: { some: { content: { eq: "1MESSAGE" } } } }) { id }
+    }`);
+    expect(res.errors).toBeUndefined();
+    expect(res.data?.users).toEqual([{ id: 1 }]);
+  });
+
+  it('filters a relation field with a nested where argument', async () => {
+    const res = await ctx.gql.queryGql(`{
+      users(where: { id: { eq: 1 } }) { id posts(where: { content: { like: "1%" } }) { id content } }
+    }`);
+    expect(res.errors).toBeUndefined();
+    expect(res.data?.users).toEqual([{ id: 1, posts: [{ id: 1, content: '1MESSAGE' }] }]);
+  });
+});


### PR DESCRIPTION
## Summary

`extractFilters` and `extractFiltersColumn` in `src/util/builders/common.ts` silently skipped `where` keys they did not recognize. Normally GraphQL input validation blocks such keys, but when the generated schema is stitched/merged with another schema, same-named input types can contribute foreign keys (`equals`, `contains`, `mode`, ...) that pass validation and were then silently dropped. A `where` that loses all of its keys becomes no `where` at all — a select returns every row, and an `update`/`delete` hits the entire table with no error anywhere.

## Changes

- `extractFilters` now throws a `GraphQLError` (`WHERE <table>: Unknown filter key: <key>`) for a key that is neither a column nor a filterable relation (including inside table-level `OR` variants). This matches the values path, where `remapFromGraphQLSingleInput` already throws `Unknown column: <key>`.
- `extractFiltersColumn` now throws a `GraphQLError` (`WHERE <column>: Unknown operator: <op>`) for an unrecognized operator (including inside column-level `OR` variants).
- The to-many relation filter wrapper now throws (`WHERE <relation>: Unknown relation filter key: <key>`) for keys other than `some` / `none` / `every`, since a stitched schema can contribute foreign keys there too.
- Legitimate special keys are unaffected: `OR` at table and column level, `some`/`none`/`every`, to-one relation shorthand filters, nested relation filters, relation-field `where`/`orderBy`/`limit`/`offset` args, and explicit `null` values (still treated as "no filter").

## Tests

New `tests/pglite/unknown-filter-keys.test.ts` (14 tests) unit-tests `extractFilters` / `extractFiltersColumn` directly with the real relation filter context — the way a stitched schema would reach them past input validation — and adds end-to-end sanity checks that valid filters still resolve through the generated schema.

- `npx tsc --noEmit` — clean
- `npx biome check` — clean (only pre-existing infos)
- `npx vitest run tests/pglite/ tests/sqlite.test.ts tests/sqlite-custom.test.ts` — 31 files, 412 tests passed

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)