### PR TITLE
feat!: recursive AND, NOT and OR boolean filter tree

### DIFF
--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -465,8 +465,8 @@ export const createRelationResolverFactory =
 
 /** Per-call cache context — created fresh on each generateSchemaData call to avoid type name collisions. */
 export interface TypeCacheCtx {
-  /** Cache of generic filter type pairs, keyed by generic name (e.g. "String", "DateTime"). */
-  genericFilterCache: Map<string, { main: GraphQLInputObjectType; or: GraphQLInputObjectType }>;
+  /** Cache of generic filter types, keyed by generic name (e.g. "String", "DateTime"). */
+  genericFilterCache: Map<string, GraphQLInputObjectType>;
   /**
    * Cache of shared select object types, keyed by table name.
    * Value: the ${capitalize(tableName)} type (columns + relation fields).
@@ -754,7 +754,7 @@ const generateColumnFilterValues = (
   const genericName = resolveGenericFilterName(column, columnName, columnGraphQLType);
   const cached = cacheCtx.genericFilterCache.get(genericName);
   if (cached) {
-    return cached.main;
+    return cached;
   }
 
   const colType = columnGraphQLType.type;
@@ -785,22 +785,28 @@ const generateColumnFilterValues = (
     isNotNull: { type: GraphQLBoolean },
   };
 
-  const orType = new GraphQLInputObjectType({
-    name: `${genericName}FilterOr`,
-    fields: { ...baseFields },
-  });
-
-  const mainType = new GraphQLInputObjectType({
+  // The boolean branches are recursive — each branch is this filter type itself — so the
+  // fields are thunked and reference the type being constructed.
+  const mainType: GraphQLInputObjectType = new GraphQLInputObjectType({
     name: `${genericName}Filter`,
-    fields: {
+    fields: () => ({
       ...baseFields,
       OR: {
-        type: new GraphQLList(new GraphQLNonNull(orType)),
+        type: new GraphQLList(new GraphQLNonNull(mainType)),
+        description: 'At least one branch matches; ANDed with any sibling operators',
       },
-    },
+      AND: {
+        type: new GraphQLList(new GraphQLNonNull(mainType)),
+        description: 'Every branch matches',
+      },
+      NOT: {
+        type: mainType,
+        description: 'Negates the nested operators',
+      },
+    }),
   });
 
-  cacheCtx.genericFilterCache.set(genericName, { main: mainType, or: orType });
+  cacheCtx.genericFilterCache.set(genericName, mainType);
   return mainType;
 };
 
@@ -1020,17 +1026,24 @@ const generateTableFilterTypeCached = (
     };
   };
 
-  const orFilters = new GraphQLInputObjectType({
-    name: `${resolveTypeName(tableName, typeNameMapper)}FiltersOr`,
-    fields: buildFields,
-  });
-
-  const filters = new GraphQLInputObjectType({
+  // The boolean branches (OR / AND / NOT) are recursive — each branch is this filter type
+  // itself — so the thunk references the type being constructed. Siblings and branches
+  // compose: sibling fields are implicitly ANDed with the OR / AND / NOT groups.
+  const filters: GraphQLInputObjectType = new GraphQLInputObjectType({
     name: `${resolveTypeName(tableName, typeNameMapper)}Filters`,
     fields: () => ({
       ...buildFields(),
       OR: {
-        type: new GraphQLList(new GraphQLNonNull(orFilters)),
+        type: new GraphQLList(new GraphQLNonNull(filters)),
+        description: 'At least one branch matches; ANDed with any sibling fields',
+      },
+      AND: {
+        type: new GraphQLList(new GraphQLNonNull(filters)),
+        description: 'Every branch matches',
+      },
+      NOT: {
+        type: filters,
+        description: 'Negates the nested filters',
       },
     }),
   });
@@ -1419,29 +1432,11 @@ export const extractFiltersColumn = <TColumn extends Column>(
   columnName: string,
   operators: FilterColumnOperators<TColumn>,
 ): SQL | undefined => {
-  if (!operators.OR?.length) {
-    delete operators.OR;
-  }
+  // Boolean branches compose with sibling operators: siblings and the AND list are ANDed
+  // together, NOT negates its whole branch, and the OR group is ANDed with the rest.
+  const { OR, AND, NOT, ...restOperators } = operators;
 
-  const entries = Object.entries(operators as FilterColumnOperatorsCore<TColumn>);
-
-  if (operators.OR) {
-    if (entries.length > 1) {
-      throw new GraphQLError(`WHERE ${columnName}: Cannot specify both fields and 'OR' in column operators!`);
-    }
-
-    const variants = [] as SQL[];
-
-    for (const variant of operators.OR) {
-      const extracted = extractFiltersColumn(column, columnName, variant);
-
-      if (extracted) {
-        variants.push(extracted);
-      }
-    }
-
-    return variants.length ? (variants.length > 1 ? or(...variants) : variants[0]) : undefined;
-  }
+  const entries = Object.entries(restOperators as FilterColumnOperatorsCore<TColumn>);
 
   const singleValueOps: Record<string, (...args: any[]) => SQL> = { eq, ne, gt, gte, lt, lte };
   const stringValueOps: Record<string, (...args: any[]) => SQL> = { like, notLike, ilike, notIlike };
@@ -1467,6 +1462,36 @@ export const extractFiltersColumn = <TColumn extends Column>(
       variants.push(arrayValueOps[operatorName]!(column, arrayValue));
     } else if (operatorName in nullableOps) {
       variants.push(nullableOps[operatorName]!(column));
+    }
+  }
+
+  if (AND?.length) {
+    for (const variant of AND) {
+      const extracted = extractFiltersColumn(column, columnName, variant);
+      if (extracted) {
+        variants.push(extracted);
+      }
+    }
+  }
+
+  if (NOT) {
+    const extracted = extractFiltersColumn(column, columnName, NOT);
+    if (extracted) {
+      variants.push(not(extracted));
+    }
+  }
+
+  if (OR?.length) {
+    const orVariants = [] as SQL[];
+    for (const variant of OR) {
+      const extracted = extractFiltersColumn(column, columnName, variant);
+      if (extracted) {
+        orVariants.push(extracted);
+      }
+    }
+
+    if (orVariants.length) {
+      variants.push(orVariants.length > 1 ? or(...orVariants)! : orVariants[0]!);
     }
   }
 
@@ -1637,31 +1662,13 @@ export const extractFilters = <TTable extends Table>(
   filters: Filters<TTable>,
   relationCtx?: RelationFilterContext,
 ): SQL | undefined => {
-  if (!filters.OR?.length) {
-    delete filters.OR;
-  }
+  // Boolean branches compose with sibling fields: siblings and the AND list are ANDed
+  // together, NOT negates its whole branch, and the OR group is ANDed with the rest —
+  // `{ a: …, OR: [{ b: … }, { c: … }] }` reads as `a AND (b OR c)`. Every branch is the
+  // filter type itself, so the tree nests arbitrarily.
+  const { OR, AND, NOT, ...fieldFilters } = filters;
 
-  const entries = Object.entries(filters as FiltersCore<TTable>);
-  if (!entries.length) {
-    return;
-  }
-
-  if (filters.OR) {
-    if (entries.length > 1) {
-      throw new GraphQLError(`WHERE ${tableName}: Cannot specify both fields and 'OR' in table filters!`);
-    }
-
-    const variants = [] as SQL[];
-
-    for (const variant of filters.OR) {
-      const extracted = extractFilters(table, tableName, variant, relationCtx);
-      if (extracted) {
-        variants.push(extracted);
-      }
-    }
-
-    return variants.length ? (variants.length > 1 ? or(...variants) : variants[0]) : undefined;
-  }
+  const entries = Object.entries(fieldFilters as FiltersCore<TTable>);
 
   const columns = getColumns(table);
   const relations = relationCtx?.relationMap[relationCtx.tableKey];
@@ -1681,6 +1688,36 @@ export const extractFilters = <TTable extends Table>(
 
     if (extracted) {
       variants.push(extracted);
+    }
+  }
+
+  if (AND?.length) {
+    for (const variant of AND) {
+      const extracted = extractFilters(table, tableName, variant, relationCtx);
+      if (extracted) {
+        variants.push(extracted);
+      }
+    }
+  }
+
+  if (NOT) {
+    const extracted = extractFilters(table, tableName, NOT, relationCtx);
+    if (extracted) {
+      variants.push(not(extracted));
+    }
+  }
+
+  if (OR?.length) {
+    const orVariants = [] as SQL[];
+    for (const variant of OR) {
+      const extracted = extractFilters(table, tableName, variant, relationCtx);
+      if (extracted) {
+        orVariants.push(extracted);
+      }
+    }
+
+    if (orVariants.length) {
+      variants.push(orVariants.length > 1 ? or(...orVariants)! : orVariants[0]!);
     }
   }
 

--- a/src/util/builders/types.ts
+++ b/src/util/builders/types.ts
@@ -266,7 +266,9 @@ export type FilterColumnOperators<
   TColumn extends Column,
   TOperators extends FilterColumnOperatorsCore<TColumn> = FilterColumnOperatorsCore<TColumn>,
 > = TOperators & {
-  OR?: TOperators[];
+  OR?: FilterColumnOperators<TColumn, TOperators>[];
+  AND?: FilterColumnOperators<TColumn, TOperators>[];
+  NOT?: FilterColumnOperators<TColumn, TOperators>;
 };
 
 export type FiltersCore<TTable extends Table> = Partial<{
@@ -274,7 +276,9 @@ export type FiltersCore<TTable extends Table> = Partial<{
 }>;
 
 export type Filters<TTable extends Table, TFilterType = FiltersCore<TTable>> = TFilterType & {
-  OR?: TFilterType[];
+  OR?: Filters<TTable, TFilterType>[];
+  AND?: Filters<TTable, TFilterType>[];
+  NOT?: Filters<TTable, TFilterType>;
 };
 
 export type OrderByArgs<TTable extends Table> = {

--- a/tests/pglite/boolean-filters.test.ts
+++ b/tests/pglite/boolean-filters.test.ts
@@ -1,0 +1,192 @@
+import { type GraphQLInputObjectType, GraphQLList, GraphQLNonNull } from 'graphql';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { type Context, createCtx, setupServer, setupTables, teardownServer, teardownTables } from './common';
+
+const DATA_DIR = `./tests/.temp/pgdata-boolean-filters-${Date.now()}`;
+const ctx: Context = createCtx();
+
+beforeAll(async () => {
+  await setupServer(ctx, 5200, DATA_DIR);
+});
+afterAll(async () => {
+  await teardownServer(ctx, DATA_DIR);
+});
+beforeEach(async () => {
+  await setupTables(ctx);
+});
+afterEach(async () => {
+  await teardownTables(ctx);
+});
+
+// Seed recap: user 1 (FirstUser) wrote posts 1,2,3,6; user 5 (FifthUser) wrote posts 4,5;
+// user 2 (SecondUser) wrote none.
+describe.sequential('boolean filter tree (table level)', () => {
+  it('ANDs sibling fields with an OR group — A AND (B OR C)', async () => {
+    const result = await ctx.gql.queryGql(`{
+      users(
+        where: { name: { like: "F%" }, OR: [{ id: { eq: 1 } }, { id: { eq: 2 } }] }
+        orderBy: { id: { direction: asc, priority: 1 } }
+      ) { id }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([{ id: 1 }]);
+  });
+
+  it('keeps OR-only filters working as before', async () => {
+    const result = await ctx.gql.queryGql(`{
+      users(
+        where: { OR: [{ id: { eq: 1 } }, { id: { eq: 2 } }] }
+        orderBy: { id: { direction: asc, priority: 1 } }
+      ) { id }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([{ id: 1 }, { id: 2 }]);
+  });
+
+  it('supports an explicit AND list', async () => {
+    const result = await ctx.gql.queryGql(`{
+      users(
+        where: { AND: [{ id: { gte: 1 } }, { id: { lte: 2 } }] }
+        orderBy: { id: { direction: asc, priority: 1 } }
+      ) { id }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([{ id: 1 }, { id: 2 }]);
+  });
+
+  it('supports NOT of a clause', async () => {
+    const result = await ctx.gql.queryGql(`{
+      users(where: { NOT: { name: { like: "F%" } } }) { id }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([{ id: 2 }]);
+  });
+
+  it('supports NOT over an OR (nested recursion)', async () => {
+    const result = await ctx.gql.queryGql(`{
+      users(where: { NOT: { OR: [{ id: { eq: 1 } }, { id: { eq: 2 } }] } }) { id }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([{ id: 5 }]);
+  });
+
+  it('nests AND, NOT and OR arbitrarily', async () => {
+    const result = await ctx.gql.queryGql(`{
+      users(
+        where: {
+          AND: [
+            { NOT: { id: { eq: 2 } } }
+            { OR: [{ name: { like: "Fir%" } }, { name: { like: "Fif%" } }] }
+          ]
+        }
+        orderBy: { id: { direction: asc, priority: 1 } }
+      ) { id }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([{ id: 1 }, { id: 5 }]);
+  });
+
+  it('supports NOT of a relation filter', async () => {
+    const result = await ctx.gql.queryGql(`{
+      users(where: { NOT: { posts: { some: {} } } }) { id }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([{ id: 2 }]);
+  });
+
+  it('treats an empty NOT as no restriction', async () => {
+    const result = await ctx.gql.queryGql(`{
+      users(where: { NOT: {} }, orderBy: { id: { direction: asc, priority: 1 } }) { id }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([{ id: 1 }, { id: 2 }, { id: 5 }]);
+  });
+
+  it('applies the boolean tree to mutations too', async () => {
+    const result = await ctx.gql.queryGql(`mutation {
+      deletePost(where: { authorId: { eq: 1 }, OR: [{ content: { eq: "1MESSAGE" } }, { content: { eq: "2MESSAGE" } }] }) { id }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.deletePost).toEqual([{ id: 1 }, { id: 2 }]);
+
+    const remaining = await ctx.gql.queryGql(`{ postsAggregate { count } }`);
+    expect(remaining.data?.postsAggregate).toEqual({ count: 4 });
+  });
+});
+
+describe.sequential('boolean filter tree (column level)', () => {
+  it('ANDs sibling operators with an OR group', async () => {
+    const result = await ctx.gql.queryGql(`{
+      users(where: { id: { lte: 1, OR: [{ eq: 1 }, { eq: 2 }] } }) { id }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([{ id: 1 }]);
+  });
+
+  it('supports an explicit AND list of operators', async () => {
+    const result = await ctx.gql.queryGql(`{
+      users(
+        where: { id: { AND: [{ gte: 1 }, { lte: 2 }] } }
+        orderBy: { id: { direction: asc, priority: 1 } }
+      ) { id }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([{ id: 1 }, { id: 2 }]);
+  });
+
+  it('supports NOT over an OR of operators', async () => {
+    const result = await ctx.gql.queryGql(`{
+      users(where: { id: { NOT: { OR: [{ eq: 1 }, { eq: 2 }] } } }) { id }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([{ id: 5 }]);
+  });
+});
+
+describe('boolean filter tree schema shape', () => {
+  const input = (name: string) => ctx.schema.getType(name) as GraphQLInputObjectType;
+
+  it('exposes recursive AND, NOT and OR on table filter inputs', () => {
+    const filters = input('UserFilters');
+    const fields = filters.getFields();
+
+    const orType = fields['OR']!.type as GraphQLList<GraphQLNonNull<GraphQLInputObjectType>>;
+    expect(orType).toBeInstanceOf(GraphQLList);
+    expect(orType.ofType).toBeInstanceOf(GraphQLNonNull);
+    expect(orType.ofType.ofType).toBe(filters);
+
+    const andType = fields['AND']!.type as GraphQLList<GraphQLNonNull<GraphQLInputObjectType>>;
+    expect(andType).toBeInstanceOf(GraphQLList);
+    expect(andType.ofType.ofType).toBe(filters);
+
+    expect(fields['NOT']!.type).toBe(filters);
+  });
+
+  it('exposes recursive AND, NOT and OR on column filter inputs', () => {
+    const filter = input('StringFilter');
+    const fields = filter.getFields();
+
+    expect((fields['OR']!.type as any).ofType.ofType).toBe(filter);
+    expect((fields['AND']!.type as any).ofType.ofType).toBe(filter);
+    expect(fields['NOT']!.type).toBe(filter);
+  });
+
+  it('no longer generates the parallel FiltersOr / FilterOr types', () => {
+    expect(ctx.schema.getType('UserFiltersOr')).toBeUndefined();
+    expect(ctx.schema.getType('PostFiltersOr')).toBeUndefined();
+    expect(ctx.schema.getType('StringFilterOr')).toBeUndefined();
+    expect(ctx.schema.getType('IdFilterOr')).toBeUndefined();
+  });
+});

--- a/tests/pglite/error-paths.test.ts
+++ b/tests/pglite/error-paths.test.ts
@@ -31,22 +31,6 @@ describe.sequential('Filter extraction errors', () => {
     expect(res.errors![0]!.message).toMatch(/Unable to use operator notInArray with an empty array/);
   });
 
-  it('column-level OR mixed with other operators returns a GraphQL error', async () => {
-    const res = await ctx.gql.queryGql(`{
-      users(where: { id: { eq: 1, OR: [{ eq: 2 }] } }) { id }
-    }`);
-    expect(res.errors).toBeDefined();
-    expect(res.errors![0]!.message).toMatch(/Cannot specify both fields and 'OR' in column operators/);
-  });
-
-  it('table-level OR mixed with column filter returns a GraphQL error', async () => {
-    const res = await ctx.gql.queryGql(`{
-      users(where: { id: { eq: 1 }, OR: [{ id: { eq: 2 } }] }) { id }
-    }`);
-    expect(res.errors).toBeDefined();
-    expect(res.errors![0]!.message).toMatch(/Cannot specify both fields and 'OR' in table filters/);
-  });
-
   it('inArray on a relation field with empty array returns a GraphQL error', async () => {
     const res = await ctx.gql.queryGql(`{
       users { id posts(where: { id: { inArray: [] } }) { id } }

--- a/tests/pglite/relation-filters.test.ts
+++ b/tests/pglite/relation-filters.test.ts
@@ -196,14 +196,14 @@ describe.sequential('relation filters', () => {
     it('leaves relation fields off tables that have no relations', () => {
       const fields = input('TagFilters').getFields();
 
-      expect(Object.keys(fields).sort()).toEqual(['OR', 'description', 'id', 'name']);
+      expect(Object.keys(fields).sort()).toEqual(['AND', 'NOT', 'OR', 'description', 'id', 'name']);
     });
 
-    it('offers relation filters in the OR variant too', () => {
+    it('offers relation filters in the OR branches too (recursive filter type)', () => {
       const orField = input('UserFilters').getFields()['OR']!;
       const orType = (orField.type as any).ofType.ofType as GraphQLInputObjectType;
 
-      expect(orType.name).toBe('UserFiltersOr');
+      expect(orType).toBe(input('UserFilters'));
       expect(orType.getFields()['posts']).toBeDefined();
     });
   });


### PR DESCRIPTION
## Summary

Filter inputs previously supported only an implicit AND across sibling fields plus a single one-level `OR: [FiltersOr!]` — and `extractFilters` threw if `OR` appeared beside any other key, so `A AND (B OR C)` had to be distributed by hand and `NOT` of a whole clause was not expressible at all.

This PR turns the filter surface into a full recursive boolean tree, at both the table level and the column-operator level:

- **`AND: [Filters!]` and `NOT: Filters`** alongside the existing `OR` on every generated filter input (`${Table}Filters`) and column filter input (`${Type}Filter`).
- **`OR` composes with sibling fields** — `{ a: …, OR: [{ b: … }, { c: … }] }` now reads as `a AND (b OR c)` instead of throwing `Cannot specify both fields and 'OR'`.
- **Branches are recursive** — each `OR`/`AND` element and `NOT` value is the filter input type itself (GraphQL input recursion via thunked fields), so `NOT { OR: […] }`, `AND: [{ NOT: … }, { OR: […] }]`, etc. nest arbitrarily and map straight onto drizzle's `and()`/`or()`/`not()`.
- **Retires the parallel `${Table}FiltersOr` / `${Type}FilterOr` types**, which the recursive shape makes redundant. Relation filter inputs (to-one inline filters, `some`/`none`/`every` wrappers) share this machinery, so relation filters work inside every branch — including `NOT` of a relation `EXISTS`.

### Implementation

- `src/util/builders/common.ts`
  - `generateTableFilterTypeCached` / `generateColumnFilterValues`: single self-referential input type with thunked `OR`/`AND`/`NOT` fields; `FiltersOr`/`FilterOr` types removed (the `genericFilterCache` now stores one type per generic name).
  - `extractFilters` / `extractFiltersColumn`: destructure `OR`/`AND`/`NOT` off the input, extract sibling fields as before, then AND together siblings + `AND` branches + `not(NOT branch)` + `or(...OR branches)`, recursing for every branch. The throw-on-OR-beside-siblings paths are gone.
- `src/util/builders/types.ts`: `Filters` and `FilterColumnOperators` are now recursive (`OR`/`AND` lists and `NOT` reference the same filter type).

### Tests

- New `tests/pglite/boolean-filters.test.ts` (15 tests): siblings + `OR` (`A AND (B OR C)`), explicit `AND` lists, `NOT` of a clause, `NOT` over an `OR` (nested recursion), arbitrary nesting, `NOT` of a relation filter, empty `NOT`, mutations, column-level siblings + `OR` / `AND` / `NOT`-over-`OR`, backwards-compatible OR-only usage, and SDL shape (recursive `OR`/`AND`/`NOT` field types; `*FiltersOr`/`*FilterOr` absent from the schema).
- Deliberately updated existing tests that asserted the old behavior:
  - `tests/pglite/error-paths.test.ts`: removed the two tests asserting the throw when `OR` appears beside sibling fields/operators (that combination is now valid and covered positively in the new file).
  - `tests/pglite/relation-filters.test.ts`: the `OR` branch type is now `UserFilters` itself (was `UserFiltersOr`), and `TagFilters` field list now includes `AND`/`NOT`.

Verified with `npx tsc --noEmit`, `npx biome check`, and `npx vitest run tests/pglite/ tests/sqlite.test.ts tests/sqlite-custom.test.ts` — 411 tests passing.

### Breaking change

Marked `feat!`: the generated `${Table}FiltersOr` / `${Type}FilterOr` input types no longer exist. All previously valid inline queries keep working (`OR` accepts a superset of the old fields), but operations that referenced the retired type names in variable definitions (e.g. `query($v: [UserFiltersOr!])`) must switch to the corresponding `Filters`/`Filter` type, and SDL-based codegen output will change accordingly.

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)