### PR TITLE
feat(query): add injection-safe startsWith/endsWith/contains string operators

### DIFF
--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -778,6 +778,30 @@ const generateColumnFilterValues = (
           notLike: { type: GraphQLString },
           ilike: { type: GraphQLString },
           notIlike: { type: GraphQLString },
+          startsWith: {
+            type: GraphQLString,
+            description: 'Matches values starting with the given string. `%`, `_` and `\\` are matched literally.',
+          },
+          endsWith: {
+            type: GraphQLString,
+            description: 'Matches values ending with the given string. `%`, `_` and `\\` are matched literally.',
+          },
+          contains: {
+            type: GraphQLString,
+            description: 'Matches values containing the given string. `%`, `_` and `\\` are matched literally.',
+          },
+          iStartsWith: {
+            type: GraphQLString,
+            description: 'Case-insensitive `startsWith`.',
+          },
+          iEndsWith: {
+            type: GraphQLString,
+            description: 'Case-insensitive `endsWith`.',
+          },
+          iContains: {
+            type: GraphQLString,
+            description: 'Case-insensitive `contains`.',
+          },
         }),
     inArray: { type: colArr, description: `Array<${colDesc}>` },
     notInArray: { type: colArr, description: `Array<${colDesc}>` },
@@ -1414,6 +1438,49 @@ export const extractOrderBy = <TTable extends Table, TArgs extends OrderByArgs<a
     direction === 'asc' ? asc(getColumns(table)[column]!) : desc(getColumns(table)[column]!),
   );
 
+/**
+ * Escape character pinned via `ESCAPE` on every generated safe-LIKE predicate. Bound as a
+ * query parameter (never spliced into the SQL text), so no dialect-specific string-literal
+ * escaping rules apply to it.
+ */
+const LIKE_ESCAPE_CHAR = '\\';
+
+/**
+ * Escapes the LIKE wildcards (`%`, `_`) and the escape character itself (`\`) in a literal
+ * search term, so the term only ever matches literally inside a LIKE pattern.
+ */
+const escapeLikeValue = (value: string): string => value.replace(/[\\%_]/g, (char) => `\\${char}`);
+
+/**
+ * The injection-safe string operators: the caller passes a literal search term, the library
+ * builds the LIKE pattern with the term's `%` / `_` / `\` escaped and the `ESCAPE` clause pinned.
+ * The `i`-prefixed variants match case-insensitively.
+ */
+const safeLikeOps: Record<string, { buildPattern: (value: string) => string; insensitive: boolean }> = {
+  startsWith: { buildPattern: (value) => `${escapeLikeValue(value)}%`, insensitive: false },
+  endsWith: { buildPattern: (value) => `%${escapeLikeValue(value)}`, insensitive: false },
+  contains: { buildPattern: (value) => `%${escapeLikeValue(value)}%`, insensitive: false },
+  iStartsWith: { buildPattern: (value) => `${escapeLikeValue(value)}%`, insensitive: true },
+  iEndsWith: { buildPattern: (value) => `%${escapeLikeValue(value)}`, insensitive: true },
+  iContains: { buildPattern: (value) => `%${escapeLikeValue(value)}%`, insensitive: true },
+};
+
+/**
+ * `LIKE <pattern> ESCAPE '\'` for a safe string operator. Case-insensitive variants use
+ * Postgres's native `ILIKE`; MySQL and SQLite have no `ILIKE`, so they compare `lower()`
+ * on both sides instead (mirroring how the raw `ilike` operator is Postgres-only).
+ */
+const safeLikeCondition = (column: Column, pattern: string, insensitive: boolean): SQL => {
+  if (!insensitive) {
+    return sql`${column} like ${pattern} escape ${LIKE_ESCAPE_CHAR}`;
+  }
+
+  const isPg = (((column as any).columnType ?? '') as string).startsWith('Pg');
+  return isPg
+    ? sql`${column} ilike ${pattern} escape ${LIKE_ESCAPE_CHAR}`
+    : sql`lower(${column}) like ${pattern.toLowerCase()} escape ${LIKE_ESCAPE_CHAR}`;
+};
+
 export const extractFiltersColumn = <TColumn extends Column>(
   column: TColumn,
   columnName: string,
@@ -1459,6 +1526,9 @@ export const extractFiltersColumn = <TColumn extends Column>(
       variants.push(singleValueOps[operatorName]!(column, singleValue));
     } else if (operatorName in stringValueOps) {
       variants.push(stringValueOps[operatorName]!(column, operatorValue as string));
+    } else if (operatorName in safeLikeOps) {
+      const { buildPattern, insensitive } = safeLikeOps[operatorName]!;
+      variants.push(safeLikeCondition(column, buildPattern(operatorValue as string), insensitive));
     } else if (operatorName in arrayValueOps) {
       if (!(operatorValue as any[]).length) {
         throw new GraphQLError(`WHERE ${columnName}: Unable to use operator ${operatorName} with an empty array!`);

--- a/src/util/builders/types.ts
+++ b/src/util/builders/types.ts
@@ -256,6 +256,12 @@ export type FilterColumnOperatorsCore<TColumn extends Column, TColType = GetColu
   notLike: string;
   ilike: string;
   notIlike: string;
+  startsWith: string;
+  endsWith: string;
+  contains: string;
+  iStartsWith: string;
+  iEndsWith: string;
+  iContains: string;
   inArray: Array<TColType>;
   notInArray: Array<TColType>;
   isNull: boolean;

--- a/tests/pglite/safe-string-operators.test.ts
+++ b/tests/pglite/safe-string-operators.test.ts
@@ -1,0 +1,330 @@
+import { GraphQLInputObjectType } from 'graphql';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { type Context, createCtx, schema, setupServer, setupTables, teardownServer, teardownTables } from './common';
+
+const DATA_DIR = `./tests/.temp/pgdata-safe-string-operators-${Date.now()}`;
+
+const ctx: Context = createCtx();
+
+beforeAll(async () => {
+  await setupServer(ctx, 5210, DATA_DIR);
+});
+
+afterAll(async () => {
+  await teardownServer(ctx, DATA_DIR);
+});
+
+beforeEach(async () => {
+  await setupTables(ctx);
+});
+
+afterEach(async () => {
+  await teardownTables(ctx);
+});
+
+/** Rows whose names contain LIKE special characters — the injection cases. */
+const insertSpecialNames = async () => {
+  await ctx.db.insert(schema.Users).values([
+    { id: 10, name: '100% real' },
+    { id: 11, name: '100x real' },
+    { id: 12, name: 'user_name' },
+    { id: 13, name: 'userXname' },
+    { id: 14, name: 'back\\slash' },
+    { id: 15, name: 'backslash' },
+  ]);
+};
+
+describe.sequential('Safe string operator tests', () => {
+  it('startsWith matches literal prefixes', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				users(where: { name: { startsWith: "Fi" } }, orderBy: { id: { priority: 0, direction: asc } }) {
+					id
+					name
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        users: [
+          { id: 1, name: 'FirstUser' },
+          { id: 5, name: 'FifthUser' },
+        ],
+      },
+    });
+  });
+
+  it('endsWith matches literal suffixes', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				users(where: { name: { endsWith: "ondUser" } }) {
+					id
+					name
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        users: [{ id: 2, name: 'SecondUser' }],
+      },
+    });
+  });
+
+  it('contains matches literal substrings', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				users(where: { name: { contains: "cond" } }) {
+					id
+					name
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        users: [{ id: 2, name: 'SecondUser' }],
+      },
+    });
+  });
+
+  it('startsWith is case-sensitive on Postgres', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				users(where: { name: { startsWith: "first" } }) {
+					id
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        users: [],
+      },
+    });
+  });
+
+  it('a literal % in the search term is not a wildcard', async () => {
+    await insertSpecialNames();
+
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				users(where: { name: { contains: "100%" } }) {
+					id
+					name
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        users: [{ id: 10, name: '100% real' }],
+      },
+    });
+  });
+
+  it('a literal _ in the search term is not a wildcard', async () => {
+    await insertSpecialNames();
+
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				users(where: { name: { contains: "r_n" } }) {
+					id
+					name
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        users: [{ id: 12, name: 'user_name' }],
+      },
+    });
+  });
+
+  it('a literal backslash in the search term matches literally', async () => {
+    await insertSpecialNames();
+
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				users(where: { name: { contains: "back\\\\sl" } }) {
+					id
+					name
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        users: [{ id: 14, name: 'back\\slash' }],
+      },
+    });
+  });
+
+  it('startsWith and endsWith escape wildcards too', async () => {
+    await insertSpecialNames();
+
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				startsWithUnderscore: users(where: { name: { startsWith: "user_" } }) {
+					id
+					name
+				}
+				endsWithPercent: users(where: { name: { endsWith: "% real" } }) {
+					id
+					name
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        startsWithUnderscore: [{ id: 12, name: 'user_name' }],
+        endsWithPercent: [{ id: 10, name: '100% real' }],
+      },
+    });
+  });
+
+  it('iStartsWith, iEndsWith and iContains match case-insensitively', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				iStartsWith: users(where: { name: { iStartsWith: "first" } }) {
+					id
+					name
+				}
+				iEndsWith: users(where: { name: { iEndsWith: "ONDUSER" } }) {
+					id
+					name
+				}
+				iContains: users(where: { name: { iContains: "SECOND" } }) {
+					id
+					name
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        iStartsWith: [{ id: 1, name: 'FirstUser' }],
+        iEndsWith: [{ id: 2, name: 'SecondUser' }],
+        iContains: [{ id: 2, name: 'SecondUser' }],
+      },
+    });
+  });
+
+  it('case-insensitive variants still escape wildcards', async () => {
+    await insertSpecialNames();
+
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				users(where: { name: { iContains: "100%" } }) {
+					id
+					name
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        users: [{ id: 10, name: '100% real' }],
+      },
+    });
+  });
+
+  it('safe operators work inside OR', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				users(
+					where: { name: { OR: [{ startsWith: "First" }, { endsWith: "ondUser" }] } }
+					orderBy: { id: { priority: 0, direction: asc } }
+				) {
+					id
+					name
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        users: [
+          { id: 1, name: 'FirstUser' },
+          { id: 2, name: 'SecondUser' },
+        ],
+      },
+    });
+  });
+
+  it('safe operators work in relation field filters', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				users(where: { id: { eq: 5 } }) {
+					id
+					posts(where: { content: { startsWith: "2" } }) {
+						id
+						content
+					}
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        users: [
+          {
+            id: 5,
+            posts: [{ id: 5, content: '2MESSAGE' }],
+          },
+        ],
+      },
+    });
+  });
+
+  it('raw like keeps its wildcard semantics', async () => {
+    await insertSpecialNames();
+
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				users(where: { name: { like: "100_ real" } }, orderBy: { id: { priority: 0, direction: asc } }) {
+					id
+					name
+				}
+			}
+		`);
+
+    // With raw like, _ is a wildcard: both '100%' and '100x' match.
+    expect(res).toStrictEqual({
+      data: {
+        users: [
+          { id: 10, name: '100% real' },
+          { id: 11, name: '100x real' },
+        ],
+      },
+    });
+  });
+
+  it('exposes the safe operators on string filters but not id filters', () => {
+    const safeOps = ['startsWith', 'endsWith', 'contains', 'iStartsWith', 'iEndsWith', 'iContains'];
+
+    const stringFilter = ctx.schema.getType('StringFilter');
+    expect(stringFilter).toBeInstanceOf(GraphQLInputObjectType);
+    const stringFields = Object.keys((stringFilter as GraphQLInputObjectType).getFields());
+    for (const op of safeOps) {
+      expect(stringFields).toContain(op);
+    }
+
+    const stringFilterOr = ctx.schema.getType('StringFilterOr');
+    expect(stringFilterOr).toBeInstanceOf(GraphQLInputObjectType);
+    const stringOrFields = Object.keys((stringFilterOr as GraphQLInputObjectType).getFields());
+    for (const op of safeOps) {
+      expect(stringOrFields).toContain(op);
+    }
+
+    const idFilter = ctx.schema.getType('IdFilter');
+    expect(idFilter).toBeInstanceOf(GraphQLInputObjectType);
+    const idFields = Object.keys((idFilter as GraphQLInputObjectType).getFields());
+    for (const op of safeOps) {
+      expect(idFields).not.toContain(op);
+    }
+  });
+});

--- a/tests/sqlite.test.ts
+++ b/tests/sqlite.test.ts
@@ -1944,6 +1944,87 @@ describe.sequential('Arguments tests', async () => {
   });
 });
 
+describe.sequential('Safe string operator tests', () => {
+  it('startsWith, endsWith and contains match literally, escaping wildcards', async () => {
+    await ctx.db.insert(schema.Users).values([
+      { id: 10, name: '100% real' },
+      { id: 11, name: '100x real' },
+      { id: 12, name: 'user_name' },
+      { id: 13, name: 'userXname' },
+      { id: 14, name: 'back\\slash' },
+      { id: 15, name: 'backslash' },
+    ]);
+
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				literalPercent: users(where: { name: { contains: "100%" } }) {
+					id
+					name
+				}
+				literalUnderscore: users(where: { name: { startsWith: "user_" } }) {
+					id
+					name
+				}
+				literalBackslash: users(where: { name: { contains: "back\\\\sl" } }) {
+					id
+					name
+				}
+				endsWith: users(where: { name: { endsWith: "% real" } }) {
+					id
+					name
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        literalPercent: [{ id: 10, name: '100% real' }],
+        literalUnderscore: [{ id: 12, name: 'user_name' }],
+        literalBackslash: [{ id: 14, name: 'back\\slash' }],
+        endsWith: [{ id: 10, name: '100% real' }],
+      },
+    });
+  });
+
+  it('case-insensitive variants match via lower() on SQLite', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				iStartsWith: users(where: { name: { iStartsWith: "first" } }) {
+					id
+					name
+				}
+				iEndsWith: users(where: { name: { iEndsWith: "ONDUSER" } }) {
+					id
+					name
+				}
+				iContains: users(where: { name: { iContains: "SECOND" } }) {
+					id
+					name
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        iStartsWith: [{ id: 1, name: 'FirstUser' }],
+        iEndsWith: [{ id: 2, name: 'SecondUser' }],
+        iContains: [{ id: 2, name: 'SecondUser' }],
+      },
+    });
+  });
+
+  it('exposes the safe operators on SQLite string filters', () => {
+    const safeOps = ['startsWith', 'endsWith', 'contains', 'iStartsWith', 'iEndsWith', 'iContains'];
+
+    const stringFilter = ctx.schema.getType('StringFilter');
+    expect(stringFilter).toBeInstanceOf(GraphQLInputObjectType);
+    const stringFields = Object.keys((stringFilter as GraphQLInputObjectType).getFields());
+    for (const op of safeOps) {
+      expect(stringFields).toContain(op);
+    }
+  });
+});
+
 describe.sequential('Aggregate query tests', () => {
   it(`Count`, async () => {
     const res = await ctx.gql.queryGql(/* GraphQL */ `


### PR DESCRIPTION
## Summary

String filters only exposed raw `like` / `notLike` / `ilike` / `notIlike`, so every search box wired to `` like: `%${term}%` `` treated a user-typed `%`, `_` or `\` as pattern syntax. This adds six injection-safe, String-typed operators to the generic `StringFilter` (and every other non-Id generic filter, matching where `like` already appears):

| Operator | Compiles to |
|---|---|
| `startsWith` | `LIKE 'esc(v)%' ESCAPE '\'` |
| `endsWith` | `LIKE '%esc(v)' ESCAPE '\'` |
| `contains` | `LIKE '%esc(v)%' ESCAPE '\'` |
| `iStartsWith` / `iEndsWith` / `iContains` | case-insensitive variants of the above |

`esc()` escapes `\`, `%` and `_` in the search term, so the value only ever matches literally.

## Implementation notes

- **Escaping + pinned `ESCAPE`**: predicates are built with drizzle-orm's `sql` template. Both the pattern and the escape character are bound as query parameters (`LIKE ? ESCAPE ?`), so no dialect-specific string-literal escaping rules apply, and SQLite — which has no default escape character — gets one pinned explicitly.
- **Case-insensitive variants on every dialect**: Postgres uses its native `ILIKE`; MySQL and SQLite have no `ILIKE`, so the i-variants compare `lower(column) LIKE lower(pattern)` there instead of being omitted. Dialect detection reads the column's `columnType` at filter-extraction time, so the shared `genericFilterCache` / filter input generation in `src/util/builders/common.ts` is unchanged in shape and the SDL is identical across dialects.
- **Raw operators untouched**: `like` / `notLike` / `ilike` / `notIlike` keep their wildcard semantics for callers who want real patterns, and `IdFilter` still exposes no pattern operators at all.
- `FilterColumnOperatorsCore` in `src/util/builders/types.ts` picks up the six new operator keys for the typed resolver helpers.

## Tests

- New `tests/pglite/safe-string-operators.test.ts` (14 tests): prefix/suffix/substring matching, Postgres case-sensitivity of the plain variants, literal `%` / `_` / `\` matched literally (the injection cases, for both plain and i-variants), i-variants via `ILIKE`, operators inside `OR` and relation field filters, raw `like` wildcard semantics unchanged, and SDL presence on `StringFilter` / `StringFilterOr` plus absence on `IdFilter`.
- New `Safe string operator tests` block in `tests/sqlite.test.ts`: wildcard escaping and the `lower()` fallback path on SQLite, plus SDL presence.
- `npx tsc --noEmit`: clean. `npx biome check`: no new diagnostics on touched files.
- `npx vitest run tests/pglite/ tests/sqlite.test.ts tests/sqlite-custom.test.ts`: 415 passed (31 files). Docker-based pg/mysql suites not run per contribution guidance.

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)
