### PR TITLE
feat: orderBy through to-one relations and nulls first/last

### DIFF
--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -314,6 +314,7 @@ const batchedPaginatedRelationQuery = async (
   limit: number | null,
   offset: number | null,
   pkNames: readonly string[],
+  orderCtx?: RelationFilterContext,
 ): Promise<any[]> => {
   const cols = getColumns(targetTable);
 
@@ -321,7 +322,7 @@ const batchedPaginatedRelationQuery = async (
   // slices are deterministic even when the client supplies no (or a non-unique) orderBy.
   // pkNames is resolved at build time and includes composite keys.
   const orderExprs = [
-    ...(orderByArg ? extractOrderBy(targetTable, orderByArg) : []),
+    ...(orderByArg ? extractOrderBy(targetTable, orderByArg, orderCtx) : []),
     ...primaryKeyOrderExprs(targetTable, pkNames),
   ];
   const orderClause = orderExprs.length ? sql` order by ${sql.join(orderExprs, sql`, `)}` : sql``;
@@ -433,13 +434,14 @@ export const createRelationResolverFactory =
             limit ?? null,
             offset ?? null,
             targetPkNames,
+            relationFilterCtx(filterCtx, targetTableName),
           );
         } else {
           // Use plain db.select() so column refs are never aliased — avoids drizzle-orm v1
           // RQB aliasing requirements that would require referencing via aliasedTable proxy.
           let q = executor.select().from(targetTable).where(whereCondition) as any;
           if (orderByArg) {
-            q = q.orderBy(...extractOrderBy(targetTable, orderByArg));
+            q = q.orderBy(...extractOrderBy(targetTable, orderByArg, relationFilterCtx(filterCtx, targetTableName)));
           }
           rows = await q;
         }
@@ -673,6 +675,27 @@ export const extractSelectedColumnsFromTreeSQLFormat = <TColType extends Column 
   return Object.fromEntries(selectedColumns) as Record<string, TColType>;
 };
 
+/**
+ * Where NULL values sort relative to non-NULL values. Compiled to native
+ * `NULLS FIRST` / `NULLS LAST` on PostgreSQL and SQLite (3.30+); MySQL has no such
+ * clause, so there it is emulated with an extra `<expr> IS NULL` sort key ahead of
+ * the column itself.
+ */
+export const orderNulls = new GraphQLEnumType({
+  name: 'OrderNulls',
+  description: 'Where NULL values sort relative to non-NULL values',
+  values: {
+    first: {
+      value: 'first',
+      description: 'NULL values sort before all non-NULL values',
+    },
+    last: {
+      value: 'last',
+      description: 'NULL values sort after all non-NULL values',
+    },
+  },
+});
+
 export const innerOrder = new GraphQLInputObjectType({
   name: 'InnerOrder' as const,
   fields: {
@@ -697,6 +720,11 @@ export const innerOrder = new GraphQLInputObjectType({
     priority: {
       type: new GraphQLNonNull(GraphQLInt),
       description: 'Priority of current field',
+    },
+    nulls: {
+      type: orderNulls,
+      description:
+        "Where NULL values sort. Defaults to the database's own rule (PostgreSQL: last on asc, first on desc; MySQL/SQLite: first on asc, last on desc)",
     },
   } as const,
 });
@@ -868,20 +896,78 @@ const generateTableSelectTypeFieldsCached = (table: Table, tableName: string): R
   return remapped;
 };
 
+/**
+ * Order fields for a table's to-one relations: each takes the target table's own OrderBy
+ * input, so a list can be sorted by a related row's column (compiled as a correlated
+ * subquery in the ORDER BY — see `extractOrderBy`). To-many relations are left out: "order
+ * a parent by its many children" has no single defined value to sort on. A relation whose
+ * name collides with a column is skipped — the column keeps the field.
+ */
+const generateRelationOrderFields = (
+  tableName: string,
+  cacheCtx: TypeCacheCtx,
+  typeNameMapper: TypeNameMapper | undefined,
+  columnFields: Record<string, ConvertedInputColumn>,
+  relationMap?: Record<string, Record<string, TableNamedRelations>>,
+  tables?: Record<string, Table>,
+): Record<string, { type: GraphQLInputObjectType; description?: string }> => {
+  const relations = relationMap?.[tableName];
+  if (!relations || !tables) {
+    return {};
+  }
+
+  const fields: Record<string, { type: GraphQLInputObjectType; description?: string }> = {};
+
+  for (const [relationName, relEntry] of Object.entries(relations)) {
+    if (relationName in columnFields) {
+      continue;
+    }
+
+    const targetTable = tables[relEntry.targetTableName];
+    const relation = (relEntry as any).relation ?? relEntry;
+    if (!targetTable || !is(relation, One) || !isFilterableRelation(relation)) {
+      continue;
+    }
+
+    fields[relationName] = {
+      type: generateTableOrderTypeCached(
+        targetTable,
+        relEntry.targetTableName,
+        typeNameMapper,
+        cacheCtx,
+        relationMap,
+        tables,
+      ),
+      description: `Order by columns of the related ${relationName} row`,
+    };
+  }
+
+  return fields;
+};
+
 const generateTableOrderTypeCached = (
   table: Table,
   tableName: string,
   typeNameMapper: TypeNameMapper | undefined,
   cacheCtx: TypeCacheCtx,
+  relationMap?: Record<string, Record<string, TableNamedRelations>>,
+  tables?: Record<string, Table>,
 ) => {
   if (cacheCtx.orderTypeCache.has(table)) {
     return cacheCtx.orderTypeCache.get(table)!;
   }
 
-  const orderColumns = generateTableOrderCached(table);
+  // Fields are thunked so that relation order fields, which reference other tables' order
+  // inputs (and eventually this one again), are only resolved after this type is cached.
   const order = new GraphQLInputObjectType({
     name: `${resolveTypeName(tableName, typeNameMapper)}OrderBy`,
-    fields: orderColumns,
+    fields: () => {
+      const orderColumns = generateTableOrderCached(table);
+      return {
+        ...orderColumns,
+        ...generateRelationOrderFields(tableName, cacheCtx, typeNameMapper, orderColumns, relationMap, tables),
+      };
+    },
   });
 
   cacheCtx.orderTypeCache.set(table, order);
@@ -1067,7 +1153,9 @@ const generateSelectFields = <TWithOrder extends boolean>(
   relationAggregateFactory?: RelationAggregateFactory,
 ): SelectData<TWithOrder> => {
   const table = tables[tableName]!;
-  const order = withOrder ? generateTableOrderTypeCached(table, tableName, typeNameMapper, cacheCtx) : undefined;
+  const order = withOrder
+    ? generateTableOrderTypeCached(table, tableName, typeNameMapper, cacheCtx, relationMap, tables)
+    : undefined;
   const filters = generateTableFilterTypeCached(table, tableName, cacheCtx, typeNameMapper, relationMap, tables);
   const tableFields = generateTableSelectTypeFieldsCached(table, tableName);
 
@@ -1395,24 +1483,198 @@ export const generateTableTypes = <WithReturning extends boolean>(
   };
 };
 
+/** How NULLs are placed relative to non-NULL values in an ordered column. */
+export type OrderNullsOption = 'first' | 'last';
+
 /**
- * Column name / direction pairs from an `orderBy` argument, highest priority first. Split out
- * of `extractOrderBy` so the same ordering can be rebuilt against a subquery's fields, where
- * there is no `Table` to read columns from.
+ * Column name / direction / nulls triples from an `orderBy` argument, highest priority
+ * first. Split out of `extractOrderBy` so the same ordering can be rebuilt against a
+ * subquery's fields, where there is no `Table` to read columns from. Because there is no
+ * table, ordering through a relation cannot be compiled here — a relation-shaped entry
+ * (an object without a `direction`) is rejected with a clear error instead of being
+ * silently dropped.
  */
-export const orderByEntries = (orderArgs: Record<string, any>): [string, 'asc' | 'desc'][] =>
+export const orderByEntries = (
+  orderArgs: Record<string, any>,
+): [string, 'asc' | 'desc', OrderNullsOption | undefined][] =>
   Object.entries(orderArgs)
     .sort((a, b) => (b[1]?.priority ?? 0) - (a[1]?.priority ?? 0))
     .filter(([, config]) => config)
-    .map(([column, config]) => [column, config.direction]);
+    .map(([column, config]) => {
+      if (typeof config === 'object' && config.direction === undefined) {
+        throw new GraphQLError(`ORDER BY ${column}: ordering through a relation is not supported in this query`);
+      }
+      return [column, config.direction, config.nulls ?? undefined];
+    });
 
+/**
+ * The ORDER BY expression(s) for one ordered value. Without a `nulls` option this is the
+ * plain `asc`/`desc` of the expression. With one:
+ * - PostgreSQL and SQLite (3.30+) support `NULLS FIRST` / `NULLS LAST` natively, so the
+ *   clause is emitted as-is.
+ * - MySQL has no such clause, so it is emulated with an extra `<expr> IS NULL` sort key
+ *   ahead of the expression itself (`IS NULL DESC` puts nulls first, `ASC` puts them
+ *   last). The same GraphQL surface is kept on all three dialects.
+ *
+ * `dialectColumn` is the real table column the expression derives from — used only to
+ * detect the dialect (its `columnType` is prefixed `Pg` / `MySql` / `SQLite`), so `expr`
+ * may be the column itself, a subquery field, or a correlated subquery.
+ */
+export const orderExpressions = (
+  expr: Column | SQL | SQL.Aliased | any,
+  direction: 'asc' | 'desc',
+  nulls: OrderNullsOption | undefined,
+  dialectColumn: Column,
+): SQL[] => {
+  const directed = direction === 'asc' ? asc(expr) : desc(expr);
+
+  if (!nulls) {
+    return [directed];
+  }
+
+  const isMySql = (((dialectColumn as any).columnType as string) ?? '').startsWith('MySql');
+  if (isMySql) {
+    const nullsKey = nulls === 'first' ? desc(sql`(${expr} is null)`) : asc(sql`(${expr} is null)`);
+    return [nullsKey, directed];
+  }
+
+  return [nulls === 'first' ? sql`${directed} nulls first` : sql`${directed} nulls last`];
+};
+
+/**
+ * One ordering term, flattened out of a (possibly relation-nested) `orderBy` argument.
+ * `expression` is what the ORDER BY sorts on — the column itself, or a correlated
+ * subquery reaching it through one or more to-one relations. `column` is the leaf table
+ * column, kept for dialect detection.
+ */
+interface FlatOrderEntry {
+  expression: Column | SQL;
+  column: Column;
+  direction: 'asc' | 'desc';
+  nulls: OrderNullsOption | undefined;
+  priority: number;
+}
+
+/**
+ * The chain of aliased to-one hops a relation-ordered column is reached through. Rendered
+ * as a single correlated scalar subquery: every hop's target sits in the FROM list and
+ * its join condition (plus the relation's own `where`, when it declares one) in the WHERE.
+ */
+interface RelationOrderChain {
+  fromParts: SQL[];
+  conditions: SQL[];
+  /** The aliased target of the last hop — the table the next hop or leaf column resolves from. */
+  table: Table;
+}
+
+/** Extends the chain (or starts one from `parentTable`) with one to-one hop. */
+const extendRelationOrderChain = (
+  parentTable: Table,
+  relationName: string,
+  relEntry: TableNamedRelations,
+  ctx: RelationFilterContext,
+  chain: RelationOrderChain | undefined,
+): RelationOrderChain => {
+  const targetTable = ctx.tables[relEntry.targetTableName];
+  const relation = ((relEntry as any).relation ?? relEntry) as Relation<string>;
+
+  if (!targetTable || !is(relation, One) || !isFilterableRelation(relation)) {
+    throw new GraphQLError(`ORDER BY ${relationName}: Relation cannot be used for ordering`);
+  }
+
+  ctx.aliases ??= { n: 0 };
+  const aliasedTarget = aliasedTable(targetTable, `dgql_ord_${ctx.aliases.n++}`);
+
+  const joinCondition = buildRelationJoinCondition(parentTable, relation, aliasedTarget, relationName);
+  // A relation declared with its own `where` only ever exposes the rows it selects, so the
+  // ordering subquery has to honour it too — mirroring the relation-filter subqueries.
+  const relationWhere = (relation as any).where
+    ? relationsFilterToSQL((relation as any).isReversed ? parentTable : aliasedTarget, (relation as any).where)
+    : undefined;
+
+  return {
+    fromParts: [...(chain?.fromParts ?? []), getTableAsAliasSQL(aliasedTarget)],
+    conditions: [
+      ...(chain?.conditions ?? []),
+      ...(joinCondition ? [joinCondition] : []),
+      ...(relationWhere ? [relationWhere] : []),
+    ],
+    table: aliasedTarget,
+  };
+};
+
+/**
+ * Flattens one level of an `orderBy` argument into `out`. A column key becomes an entry
+ * directly (wrapped in a correlated subquery when reached through a relation chain); a
+ * to-one relation key recurses with the chain extended by that hop. Priorities live in one
+ * global space, so a relation's column can interleave with the parent's own columns.
+ */
+const collectOrderEntries = (
+  table: Table,
+  tableKey: string,
+  orderArgs: Record<string, any>,
+  ctx: RelationFilterContext | undefined,
+  chain: RelationOrderChain | undefined,
+  out: FlatOrderEntry[],
+): void => {
+  const columns = getColumns(table);
+  const relations = ctx?.relationMap[tableKey];
+
+  for (const [key, config] of Object.entries(orderArgs)) {
+    if (config === null || config === undefined) {
+      continue;
+    }
+
+    const column = columns[key];
+    if (column) {
+      out.push({
+        expression: chain
+          ? sql`(select ${column} from ${sql.join(chain.fromParts, sql`, `)} where ${and(...chain.conditions)})`
+          : column,
+        column,
+        direction: config.direction,
+        nulls: config.nulls ?? undefined,
+        priority: config.priority ?? 0,
+      });
+      continue;
+    }
+
+    const relEntry = relations?.[key];
+    if (!relEntry || !ctx) {
+      throw new GraphQLError(`ORDER BY ${key}: Unknown column or relation`);
+    }
+
+    const nextChain = extendRelationOrderChain(chain?.table ?? table, key, relEntry, ctx, chain);
+    collectOrderEntries(nextChain.table, relEntry.targetTableName, config, ctx, nextChain, out);
+  }
+};
+
+/**
+ * Compiles an `orderBy` argument into ORDER BY expressions, highest priority first.
+ *
+ * A key naming one of the table's columns orders by that column. A key naming a to-one
+ * relation takes the target table's own OrderBy input and orders by the related row's
+ * column(s), compiled as a correlated scalar subquery — reusing the aliased-join machinery
+ * the relation filters are built on — so it works identically on all three dialects and
+ * inside the relational query builder's aliased CTEs. Priorities share one global space
+ * across relation boundaries. Each entry may also carry `nulls: first | last`
+ * (see {@link orderExpressions} for how MySQL emulates it).
+ *
+ * `ctx` supplies the tables and relation map that relation ordering needs; callers whose
+ * inputs cannot contain relation keys may omit it.
+ */
 export const extractOrderBy = <TTable extends Table, TArgs extends OrderByArgs<any> = OrderByArgs<TTable>>(
   table: TTable,
   orderArgs: TArgs,
-): SQL[] =>
-  orderByEntries(orderArgs).map(([column, direction]) =>
-    direction === 'asc' ? asc(getColumns(table)[column]!) : desc(getColumns(table)[column]!),
-  );
+  ctx?: RelationFilterContext,
+): SQL[] => {
+  const entries: FlatOrderEntry[] = [];
+  collectOrderEntries(table, ctx?.tableKey ?? '', orderArgs, ctx, undefined, entries);
+
+  return entries
+    .sort((a, b) => b.priority - a.priority)
+    .flatMap((entry) => orderExpressions(entry.expression, entry.direction, entry.nulls, entry.column));
+};
 
 export const extractFiltersColumn = <TColumn extends Column>(
   column: TColumn,
@@ -1762,7 +2024,8 @@ const extractRelationsParamsInner = (
     const hasPagination = offset != null || limit != null;
     const pkNames = targetPkNames ?? [];
     thisRecord.orderBy = relationArgs?.orderBy
-      ? (aliasedTable: Table) => extractOrderBy(aliasedTable, relationArgs.orderBy!)
+      ? (aliasedTable: Table) =>
+          extractOrderBy(aliasedTable, relationArgs.orderBy!, relationFilterCtx(filterCtx, targetTableName))
       : hasPagination && pkNames.length
         ? (aliasedTable: Table) => primaryKeyOrderExprs(aliasedTable, pkNames)
         : undefined;
@@ -2253,7 +2516,9 @@ export const selectDistinctKeys = async (params: {
   // Both orderings must agree, so build each from the same entries — once against the table
   // (inside the window) and once against the subquery's fields (for the outer row order).
   const windowOrder = [
-    ...orderEntries.map(([column, direction]) => (direction === 'asc' ? asc(cols[column]!) : desc(cols[column]!))),
+    ...orderEntries.flatMap(([column, direction, nulls]) =>
+      orderExpressions(cols[column]!, direction, nulls, cols[column]!),
+    ),
     ...primaryKeyOrderExprs(table, pkNames),
   ];
 
@@ -2269,7 +2534,9 @@ export const selectDistinctKeys = async (params: {
     .as('__dgql_distinct');
 
   const outerOrder = [
-    ...orderEntries.map(([column, direction]) => (direction === 'asc' ? asc(sub[column]) : desc(sub[column]))),
+    ...orderEntries.flatMap(([column, direction, nulls]) =>
+      orderExpressions(sub[column], direction, nulls, cols[column]!),
+    ),
     ...pkNames.filter((name) => sub[name]).map((name) => asc(sub[name])),
   ];
 
@@ -2588,11 +2855,11 @@ export const runRelationalSelect = async (opts: {
     // directly so column refs match the CTE alias.
     orderBy: distinctKeys
       ? (aliasedTable: Table) => [
-          ...(orderBy ? extractOrderBy(aliasedTable, orderBy) : []),
+          ...(orderBy ? extractOrderBy(aliasedTable, orderBy, relationFilterCtx(filterCtx, tableName)) : []),
           ...primaryKeyOrderExprs(aliasedTable, pkNames!),
         ]
       : orderBy
-        ? (aliasedTable: Table) => extractOrderBy(aliasedTable, orderBy)
+        ? (aliasedTable: Table) => extractOrderBy(aliasedTable, orderBy, relationFilterCtx(filterCtx, tableName))
         : needsDefaultOrder && pkNames?.length
           ? (aliasedTable: Table) => primaryKeyOrderExprs(aliasedTable, pkNames)
           : undefined,

--- a/src/util/builders/pg.ts
+++ b/src/util/builders/pg.ts
@@ -166,7 +166,7 @@ const generateSelectArray = (
         }
         if (orderBy) {
           q = q.orderBy(
-            ...extractOrderBy(table, orderBy),
+            ...extractOrderBy(table, orderBy, relationFilterCtx(filterCtx, tableName)),
             ...(distinctKeys ? primaryKeyOrderExprs(table, pkNames) : []),
           ) as any;
         } else if ((distinctKeys || offset != null || limit != null) && pkNames.length) {
@@ -249,7 +249,7 @@ const generateSelectSingle = (
           q = q.where(extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName))) as any;
         }
         if (orderBy) {
-          q = q.orderBy(...extractOrderBy(table, orderBy)) as any;
+          q = q.orderBy(...extractOrderBy(table, orderBy, relationFilterCtx(filterCtx, tableName))) as any;
         } else if (pkNames.length) {
           // A single query is an implicit `limit 1` — order it so the row is deterministic.
           q = q.orderBy(...primaryKeyOrderExprs(table, pkNames)) as any;

--- a/src/util/builders/types.ts
+++ b/src/util/builders/types.ts
@@ -281,6 +281,11 @@ export type OrderByArgs<TTable extends Table> = {
   [Key in keyof TTable['_']['columns']]?: {
     direction: 'asc' | 'desc';
     priority: number;
+    /**
+     * Where NULL values sort. Native NULLS FIRST/LAST on PostgreSQL and SQLite;
+     * emulated with an extra `IS NULL` sort key on MySQL.
+     */
+    nulls?: 'first' | 'last';
   };
 };
 

--- a/tests/pglite/mysql-schema.test.ts
+++ b/tests/pglite/mysql-schema.test.ts
@@ -3,8 +3,11 @@
 // It calls generateSchemaData (generateMySQL) directly with a minimal mock db whose resolver
 // closures are never invoked — only the schema structure is inspected.
 
+import { sql } from 'drizzle-orm';
+import { MySqlDialect } from 'drizzle-orm/mysql-core';
 import { GraphQLNonNull, GraphQLObjectType } from 'graphql';
 import { describe, expect, it } from 'vitest';
+import { extractOrderBy } from '@/index';
 import { generateMySQL } from '@/util/builders';
 import * as schema from '../schema/mysql';
 
@@ -231,6 +234,46 @@ describe('MySQL generated types and inputs', () => {
     expect(entities.inputs['UsersOrderBy']).toBeDefined();
     expect(entities.inputs['CreateUsersInput']).toBeDefined();
     expect(entities.inputs['UpdateUsersInput']).toBeDefined();
+  });
+
+  it('OrderBy inputs expose to-one relation fields and the nulls option', () => {
+    const userOrderFields = entities.inputs['UsersOrderBy'].getFields();
+    // To-one relation gets the target's own OrderBy input; the to-many `posts` does not.
+    expect(userOrderFields['customer']).toBeDefined();
+    expect(userOrderFields['customer'].type.toString()).toBe('CustomersOrderBy');
+    expect(userOrderFields['posts']).toBeUndefined();
+
+    // MySQL keeps the same surface as the other dialects — `nulls` is emulated, not omitted.
+    const innerOrderFields = userOrderFields['email'].type.getFields();
+    expect(innerOrderFields['nulls']).toBeDefined();
+    expect(innerOrderFields['nulls'].type.toString()).toBe('OrderNulls');
+  });
+});
+
+// ── nulls emulation ───────────────────────────────────────────────────────────
+
+describe('MySQL nulls first/last emulation', () => {
+  const dialect = new MySqlDialect();
+  const render = (exprs: any[]) => dialect.sqlToQuery(sql.join(exprs, sql`, `)).sql.toLowerCase();
+
+  it('compiles nulls: first to an IS NULL sort key instead of NULLS FIRST', () => {
+    const exprs = extractOrderBy(schema.Users, { email: { direction: 'asc', priority: 1, nulls: 'first' } });
+    expect(exprs).toHaveLength(2);
+
+    const rendered = render(exprs);
+    expect(rendered).toContain('is null');
+    expect(rendered).not.toContain('nulls first');
+    // Nulls-first means the IS NULL key sorts descending (true before false).
+    expect(rendered).toMatch(/is null\) desc/);
+  });
+
+  it('compiles nulls: last to an ascending IS NULL sort key', () => {
+    const exprs = extractOrderBy(schema.Users, { email: { direction: 'desc', priority: 1, nulls: 'last' } });
+    expect(exprs).toHaveLength(2);
+
+    const rendered = render(exprs);
+    expect(rendered).not.toContain('nulls last');
+    expect(rendered).toMatch(/is null\) asc/);
   });
 });
 

--- a/tests/pglite/order-by.test.ts
+++ b/tests/pglite/order-by.test.ts
@@ -1,0 +1,193 @@
+import type { GraphQLEnumType, GraphQLInputObjectType } from 'graphql';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { type Context, createCtx, setupServer, setupTables, teardownServer, teardownTables } from './common';
+
+const DATA_DIR = `./tests/.temp/pgdata-order-by-${Date.now()}`;
+const ctx: Context = createCtx();
+
+beforeAll(async () => {
+  await setupServer(ctx, 5230, DATA_DIR);
+});
+afterAll(async () => {
+  await teardownServer(ctx, DATA_DIR);
+});
+beforeEach(async () => {
+  await setupTables(ctx);
+});
+afterEach(async () => {
+  await teardownTables(ctx);
+});
+
+// Seed recap: user 1 (FirstUser, email set) wrote posts 1,2,3,6; user 5 (FifthUser, no
+// email) wrote posts 4,5; user 2 (SecondUser, no email) wrote none. Post contents:
+// 1/4 = 1MESSAGE, 2/5 = 2MESSAGE, 3 = 3MESSAGE, 6 = 4MESSAGE.
+describe.sequential('orderBy through to-one relations and nulls first/last', () => {
+  describe('SDL shape', () => {
+    it('adds to-one relation fields to the OrderBy input, but not to-many ones', () => {
+      const postOrder = ctx.schema.getType('PostOrderBy') as GraphQLInputObjectType;
+      expect(postOrder).toBeDefined();
+
+      const postOrderFields = postOrder.getFields();
+      expect(postOrderFields['author']).toBeDefined();
+      expect(postOrderFields['author']!.type.toString()).toBe('UserOrderBy');
+      expect(postOrderFields['customer']).toBeDefined();
+      expect(postOrderFields['customer']!.type.toString()).toBe('CustomerOrderBy');
+
+      const userOrder = ctx.schema.getType('UserOrderBy') as GraphQLInputObjectType;
+      const userOrderFields = userOrder.getFields();
+      // To-one relation is present; the to-many `posts` relation must not be.
+      expect(userOrderFields['customer']).toBeDefined();
+      expect(userOrderFields['customer']!.type.toString()).toBe('CustomerOrderBy');
+      expect(userOrderFields['posts']).toBeUndefined();
+      // Columns keep their InnerOrder shape.
+      expect(userOrderFields['name']!.type.toString()).toBe('InnerOrder');
+    });
+
+    it('adds an optional nulls field of enum OrderNulls to InnerOrder', () => {
+      const innerOrder = ctx.schema.getType('InnerOrder') as GraphQLInputObjectType;
+      const fields = innerOrder.getFields();
+
+      expect(fields['direction']!.type.toString()).toBe('OrderDirection!');
+      expect(fields['priority']!.type.toString()).toBe('Int!');
+      expect(fields['nulls']).toBeDefined();
+      expect(fields['nulls']!.type.toString()).toBe('OrderNulls');
+
+      const orderNulls = ctx.schema.getType('OrderNulls') as GraphQLEnumType;
+      expect(orderNulls.getValues().map((v) => v.name)).toEqual(['first', 'last']);
+    });
+  });
+
+  describe('ordering by a to-one relation column', () => {
+    it('orders a list by the related row ascending', async () => {
+      const result = await ctx.gql.queryGql(`{
+        posts(orderBy: {
+          author: { name: { direction: asc, priority: 2 } }
+          id: { direction: asc, priority: 1 }
+        }) { id }
+      }`);
+
+      expect(result.errors).toBeUndefined();
+      // FifthUser < FirstUser, so user 5's posts come first.
+      expect(result.data?.posts).toEqual([{ id: 4 }, { id: 5 }, { id: 1 }, { id: 2 }, { id: 3 }, { id: 6 }]);
+    });
+
+    it('orders a list by the related row descending', async () => {
+      const result = await ctx.gql.queryGql(`{
+        posts(orderBy: {
+          author: { name: { direction: desc, priority: 2 } }
+          id: { direction: asc, priority: 1 }
+        }) { id }
+      }`);
+
+      expect(result.errors).toBeUndefined();
+      expect(result.data?.posts).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }, { id: 6 }, { id: 4 }, { id: 5 }]);
+    });
+
+    it('interleaves a relation column with a same-table column via priority', async () => {
+      const result = await ctx.gql.queryGql(`{
+        posts(orderBy: {
+          content: { direction: desc, priority: 2 }
+          author: { name: { direction: asc, priority: 1 } }
+        }) { id }
+      }`);
+
+      expect(result.errors).toBeUndefined();
+      // content desc groups: 4MESSAGE(6), 3MESSAGE(3), 2MESSAGE(2,5), 1MESSAGE(1,4);
+      // ties break by author name asc (FifthUser before FirstUser).
+      expect(result.data?.posts).toEqual([{ id: 6 }, { id: 3 }, { id: 5 }, { id: 2 }, { id: 4 }, { id: 1 }]);
+    });
+
+    it('works together with selecting the relation itself (eager RQB path)', async () => {
+      const result = await ctx.gql.queryGql(`{
+        posts(orderBy: {
+          author: { name: { direction: asc, priority: 2 } }
+          id: { direction: asc, priority: 1 }
+        }) {
+          id
+          author { name }
+        }
+      }`);
+
+      expect(result.errors).toBeUndefined();
+      expect(result.data?.posts).toEqual([
+        { id: 4, author: { name: 'FifthUser' } },
+        { id: 5, author: { name: 'FifthUser' } },
+        { id: 1, author: { name: 'FirstUser' } },
+        { id: 2, author: { name: 'FirstUser' } },
+        { id: 3, author: { name: 'FirstUser' } },
+        { id: 6, author: { name: 'FirstUser' } },
+      ]);
+    });
+
+    it('supports nulls on a relation column', async () => {
+      // FirstUser has an email; FifthUser does not — so the subquery value is NULL for
+      // posts 4 and 5. nulls: first pulls them ahead of the non-null group.
+      const result = await ctx.gql.queryGql(`{
+        posts(orderBy: {
+          author: { email: { direction: asc, priority: 2, nulls: first } }
+          id: { direction: asc, priority: 1 }
+        }) { id }
+      }`);
+
+      expect(result.errors).toBeUndefined();
+      expect(result.data?.posts).toEqual([{ id: 4 }, { id: 5 }, { id: 1 }, { id: 2 }, { id: 3 }, { id: 6 }]);
+    });
+
+    it('rejects combining distinct with relation ordering instead of silently ignoring it', async () => {
+      const result = await ctx.gql.queryGql(`{
+        posts(distinct: [content], orderBy: { author: { name: { direction: asc, priority: 1 } } }) { id }
+      }`);
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0]!.message).toContain('ordering through a relation');
+    });
+  });
+
+  describe('nulls first/last', () => {
+    it('puts nulls first on an ascending optional column', async () => {
+      // Postgres defaults to nulls LAST on asc — this only passes if NULLS FIRST is emitted.
+      const result = await ctx.gql.queryGql(`{
+        users(orderBy: {
+          email: { direction: asc, priority: 2, nulls: first }
+          id: { direction: asc, priority: 1 }
+        }) { id email }
+      }`);
+
+      expect(result.errors).toBeUndefined();
+      expect(result.data?.users).toEqual([
+        { id: 2, email: null },
+        { id: 5, email: null },
+        { id: 1, email: 'userOne@notmail.com' },
+      ]);
+    });
+
+    it('puts nulls last on a descending optional column', async () => {
+      // Postgres defaults to nulls FIRST on desc — this only passes if NULLS LAST is emitted.
+      const result = await ctx.gql.queryGql(`{
+        users(orderBy: {
+          email: { direction: desc, priority: 2, nulls: last }
+          id: { direction: asc, priority: 1 }
+        }) { id email }
+      }`);
+
+      expect(result.errors).toBeUndefined();
+      expect(result.data?.users).toEqual([
+        { id: 1, email: 'userOne@notmail.com' },
+        { id: 2, email: null },
+        { id: 5, email: null },
+      ]);
+    });
+
+    it('applies nulls ordering inside a relation list argument', async () => {
+      const result = await ctx.gql.queryGql(`{
+        user(where: { id: { eq: 1 } }) {
+          id
+          posts(orderBy: { content: { direction: asc, priority: 1, nulls: first } }) { id }
+        }
+      }`);
+
+      expect(result.errors).toBeUndefined();
+      expect(result.data?.user).toEqual({ id: 1, posts: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 6 }] });
+    });
+  });
+});

--- a/tests/sqlite.test.ts
+++ b/tests/sqlite.test.ts
@@ -4544,3 +4544,44 @@ describe.sequential('Mutation relation eager-load tests', () => {
     expect(posts.find((p) => p.content === 'B')?.author?.id).toBe(5);
   });
 });
+
+describe.sequential('Relation orderBy and nulls tests', () => {
+  it('orders a list by a to-one relation column', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+      {
+        posts(orderBy: {
+          author: { name: { direction: asc, priority: 2 } }
+          id: { direction: asc, priority: 1 }
+        }) {
+          id
+        }
+      }
+    `);
+
+    expect(res.errors).toBeUndefined();
+    // FifthUser (posts 4, 5) sorts before FirstUser (posts 1, 2, 3, 6).
+    expect(res.data?.posts).toStrictEqual([{ id: 4 }, { id: 5 }, { id: 1 }, { id: 2 }, { id: 3 }, { id: 6 }]);
+  });
+
+  it('emits NULLS LAST on an ascending optional column', async () => {
+    // SQLite defaults to nulls FIRST on asc — this only passes if NULLS LAST is emitted.
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+      {
+        users(orderBy: {
+          email: { direction: asc, priority: 2, nulls: last }
+          id: { direction: asc, priority: 1 }
+        }) {
+          id
+          email
+        }
+      }
+    `);
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data?.users).toStrictEqual([
+      { id: 1, email: 'userOne@notmail.com' },
+      { id: 2, email: null },
+      { id: 5, email: null },
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #23

## What this adds

Two new capabilities on the existing per-table `orderBy` object shape (the input shape is unchanged — no list-shaped restructure, per the issue's scoping):

### 1. Ordering through to-one relations

```graphql
posts(orderBy: {
  author: { name: { direction: asc, priority: 2 } }
  id: { direction: asc, priority: 1 }
}) { id }
```

- Each `${Type}OrderBy` input gains a field per **to-one** relation, typed as the target table's own `OrderBy` input (thunked + cached, so mutually-referencing tables work; nesting through several to-one hops comes along for free).
- Compiled as a **correlated scalar subquery** in the `ORDER BY` — `(select "dgql_ord_0"."name" from "users" "dgql_ord_0" where "dgql_ord_0"."id" = "posts"."author_id")` — reusing the relation-filter machinery from 3.0.0: `buildRelationJoinCondition`, `aliasedTable` with a namespaced `dgql_ord_N` alias counter (distinct from the filters' `dgql_rel_N`, so the two coexist in one query), and the relation's own declared `where`, which the subquery honours just like the filter `EXISTS` subqueries do. Works identically on all three dialects and inside the relational query builder's aliased CTEs (the join columns are matched by SQL name, as the filters already do).
- Priorities share one global space, so a relation's column interleaves with the parent's own columns.
- **To-many relations are excluded** (out of scope per the issue — there is no single related value to sort on), as are `.through()` relations — mirroring the relation-filter surface, where a missing field is a clean GraphQL validation error instead of a silently ignored input.
- `distinct` + relation ordering is **rejected with a descriptive error** rather than silently dropped: the distinct pass rebuilds the ordering against its row-number subquery's fields, where a relation subquery cannot be expressed.

### 2. `nulls: first | last` per ordered column

```graphql
users(orderBy: { email: { direction: asc, priority: 1, nulls: last } }) { id }
```

- New optional `nulls` field on the shared `InnerOrder` input, typed by a new `OrderNulls` enum (`first` / `last`). Also works on relation-ordered columns (the subquery yields `NULL` when the related row or its column is `NULL`).

### Dialect decisions (documented in code)

| Dialect | Compilation |
|---|---|
| PostgreSQL | native `NULLS FIRST` / `NULLS LAST` |
| SQLite | native `NULLS FIRST` / `NULLS LAST` (supported since SQLite 3.30) |
| MySQL | **emulated** — MySQL has no `NULLS FIRST/LAST` clause, so an extra `(col IS NULL) DESC/ASC` sort key is emitted ahead of the column itself (`DESC` puts nulls first, `ASC` puts them last) |

The MySQL surface is kept identical rather than omitting the field: unlike `onConflict.target` (where MySQL's `ON DUPLICATE KEY UPDATE` genuinely cannot honour the input, so the field is omitted), `nulls` **can** be honoured on MySQL via the `IS NULL` key — same semantics, one schema across dialects.

## Tests

- `tests/pglite/order-by.test.ts` (new, port 5230): relation ordering asc/desc, interleaving with a same-table column via priority, the eager RQB path with the relation selected, `nulls` on a relation column, the `distinct` rejection, `nulls: first`/`last` on an optional column against Postgres' defaults, and `nulls` inside a relation list argument; SDL shape of the OrderBy input (to-one fields present, to-many absent, `nulls: OrderNulls` on `InnerOrder`).
- `tests/sqlite.test.ts`: relation ordering + `NULLS LAST` on ascending (non-default for SQLite, which defaults nulls-first on asc).
- `tests/pglite/mysql-schema.test.ts`: MySQL OrderBy input shape (relation fields + `nulls` present), and unit tests rendering the MySQL `ORDER BY` SQL to prove the `IS NULL` emulation is emitted instead of `NULLS FIRST/LAST`.

Verified: `npx tsc --noEmit` clean, `biome check` clean on changed files, `npx vitest run tests/pglite/ tests/sqlite.test.ts tests/sqlite-custom.test.ts` — 31 files, 414 tests passing. (Docker-based pg/mysql suites not run.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
