### PR TITLE
feat(query): add cursor (keyset) pagination to list queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,53 @@ supplies no `orderBy`:
 An explicit `orderBy` always takes precedence, composite primary keys are ordered by every
 key column, and an unpaginated list query is left unordered so no sort is paid for.
 
+## Cursor pagination
+
+`OFFSET` pagination degrades linearly and shifts under concurrent writes. List queries also
+support keyset pagination: every row returned by a list query exposes an opaque `cursor`
+field, and passing it back as `after` resumes strictly after that row.
+
+```graphql
+{
+    posts(orderBy: { createdAt: { direction: desc, priority: 1 } }, limit: 10) {
+        id
+        createdAt
+        cursor
+    }
+}
+
+# next page — same orderBy, plus the last row's cursor
+{
+    posts(
+        orderBy: { createdAt: { direction: desc, priority: 1 } }
+        limit: 10
+        after: "eyJvIjogW1siY3JlYXRlZEF0IiwgImRlc2MiXSwgWyJpZCIsICJhc2MiXV0sIC4uLn0"
+    ) {
+        id
+        createdAt
+        cursor
+    }
+}
+```
+
+-   The cursor encodes the row's position in the query's **total order** — your `orderBy`
+    columns plus the primary key as an ascending tiebreak — so pages are stable even when
+    the ordered columns aren't unique, and inserts or deletes mid-scroll don't shift the
+    window
+-   `after` compiles to a keyset predicate built from drizzle's `and`/`or`/`gt`/`lt`
+    comparisons (not SQL row-value syntax), so mixed-direction `orderBy` works
+-   `NULL`s in ordered columns follow each dialect's native `ORDER BY` placement —
+    PostgreSQL sorts them largest (last in `asc`), MySQL and SQLite smallest (first in
+    `asc`) — and the predicate matches, so rows with `NULL` in an ordered column are paged
+    through, not skipped
+-   Dates and bigints round-trip losslessly through the cursor
+-   A cursor is only valid under the ordering it was issued for — reusing it with a
+    different `orderBy` (or a malformed/corrupted cursor) returns a `GraphQLError`
+-   `after` cannot be combined with `distinct`, and a table with no primary key cannot use
+    cursor pagination (its `cursor` field resolves to `null`)
+-   If a table has a real column named `cursor`, the column wins and the meta field is
+    skipped
+
 ## Upsert
 
 `features.upsert` adds a pair of mutations per table that insert rows, or update the ones

--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -863,6 +863,17 @@ const generateTableSelectTypeFieldsCached = (table: Table, tableName: string): R
     ]),
   );
 
+  // Opaque keyset-pagination cursor. Only populated on rows returned by a list query; a real
+  // column named `cursor` keeps the field for itself instead.
+  if (!remapped[CURSOR_FIELD_NAME]) {
+    remapped[CURSOR_FIELD_NAME] = {
+      type: GraphQLString,
+      description:
+        "Opaque cursor of this row's position in the query's ordering. Pass it as `after` to resume from here. Only set on rows returned by a list query.",
+      resolve: rowCursorResolver,
+    } as ConvertedColumn;
+  }
+
   fieldMap.set(table, remapped);
 
   return remapped;
@@ -1910,6 +1921,210 @@ export const primaryKeyOrderExprs = (table: Table, pkNames: readonly string[]): 
     .map((col) => asc(col!));
 };
 
+// ── cursor (keyset) pagination ───────────────────────────────────────────────
+
+/** Name of the field on generated select types that exposes a row's opaque pagination cursor. */
+export const CURSOR_FIELD_NAME = 'cursor';
+
+/**
+ * Property the list resolvers stash each row's computed cursor under. Namespaced so it can't
+ * collide with a real column; the `cursor` field's resolver reads it back off the row.
+ */
+const ROW_CURSOR_PROP = '__drizzle_graphql_cursor';
+
+/**
+ * Where a dialect's default sort places NULLs relative to non-NULL values:
+ * - `nulls-largest` — PostgreSQL: NULLs sort as the largest values (last in ASC, first in DESC).
+ * - `nulls-smallest` — MySQL and SQLite: NULLs sort as the smallest values (first in ASC, last
+ *   in DESC).
+ * The keyset predicate has to agree with the dialect's ORDER BY, so each builder passes its own.
+ */
+export type NullOrdering = 'nulls-largest' | 'nulls-smallest';
+
+/** One key of the total order a cursor is defined over: column property name + direction. */
+export type CursorOrderEntry = [string, 'asc' | 'desc'];
+
+/**
+ * The total order a list query's rows follow when cursor pagination is in play: the request's
+ * `orderBy` entries (highest priority first), then the primary key ascending as a tiebreak —
+ * skipping PK columns the `orderBy` already names, so no key appears twice.
+ */
+export const cursorOrderingEntries = (
+  orderBy: Record<string, any> | undefined,
+  pkNames: readonly string[],
+): CursorOrderEntry[] => {
+  const entries: CursorOrderEntry[] = orderBy ? orderByEntries(orderBy) : [];
+  const seen = new Set(entries.map(([column]) => column));
+  for (const pk of pkNames) {
+    if (!seen.has(pk)) {
+      entries.push([pk, 'asc']);
+    }
+  }
+  return entries;
+};
+
+/**
+ * Serializes one ordering-tuple value into a JSON-safe shape. Dates and bigints don't survive
+ * JSON.stringify losslessly (bigint throws, Date turns into an untagged string), so they are
+ * tagged; decimals already arrive from the driver as strings, which are lossless as-is.
+ */
+const encodeCursorValue = (value: any): any => {
+  if (value instanceof Date) {
+    return { $type: 'date', value: value.toISOString() };
+  }
+  if (typeof value === 'bigint') {
+    return { $type: 'bigint', value: value.toString() };
+  }
+  return value;
+};
+
+const decodeCursorValue = (value: any): any => {
+  if (value && typeof value === 'object' && typeof value.$type === 'string') {
+    if (value.$type === 'date') {
+      return new Date(value.value);
+    }
+    if (value.$type === 'bigint') {
+      return BigInt(value.value);
+    }
+  }
+  return value;
+};
+
+/**
+ * Encodes a row's position in the given total order as an opaque cursor: base64url of a JSON
+ * payload holding the ordering spec (`o`) and the row's values for it (`v`). The spec rides
+ * along so a later request can verify the cursor was issued for the same ordering it is using.
+ */
+export const encodeCursor = (entries: CursorOrderEntry[], row: Record<string, any>): string => {
+  const payload = {
+    o: entries,
+    v: entries.map(([column]) => encodeCursorValue(row[column] ?? null)),
+  };
+  return Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
+};
+
+/**
+ * Decodes an `after` cursor and validates it against the ordering the current request pages
+ * over. A cursor issued under a different `orderBy` would combine one ordering's predicate
+ * with another's sort — silently wrong pages — so a mismatch is an error, as is anything that
+ * doesn't decode to the expected payload shape.
+ */
+export const decodeCursor = (after: string, entries: CursorOrderEntry[]): any[] => {
+  let payload: any;
+  try {
+    payload = JSON.parse(Buffer.from(after, 'base64url').toString('utf8'));
+  } catch (_e) {
+    throw new GraphQLError('Invalid cursor: unable to decode it. Pass a cursor returned by a previous page.');
+  }
+
+  if (
+    !payload ||
+    typeof payload !== 'object' ||
+    !Array.isArray(payload.o) ||
+    !Array.isArray(payload.v) ||
+    payload.o.length !== payload.v.length
+  ) {
+    throw new GraphQLError('Invalid cursor: malformed payload. Pass a cursor returned by a previous page.');
+  }
+
+  const matchesOrdering =
+    payload.o.length === entries.length &&
+    payload.o.every(
+      (entry: any, i: number) => Array.isArray(entry) && entry[0] === entries[i]![0] && entry[1] === entries[i]![1],
+    );
+  if (!matchesOrdering) {
+    throw new GraphQLError(
+      "Invalid cursor: it was issued for a different ordering. Pass the same orderBy the cursor's page used.",
+    );
+  }
+
+  return payload.v.map(decodeCursorValue);
+};
+
+/**
+ * The keyset predicate selecting rows strictly after the cursor position in the given total
+ * order — the expanded lexicographic form
+ * `after(k0) OR (k0 = v0 AND after(k1)) OR (k0 = v0 AND k1 = v1 AND after(k2)) …`,
+ * built with and/or/gt/lt/eq rather than SQL row-value syntax, which cannot express mixed
+ * asc/desc directions and mishandles NULLs.
+ *
+ * NULL handling follows the dialect's default sort position (see {@link NullOrdering}): where
+ * NULLs sort last for a key's direction, "after a non-NULL value" includes the NULL rows and
+ * nothing sorts after a NULL one; where NULLs sort first, "after NULL" is every non-NULL row.
+ * `table` may be the aliased RQB proxy.
+ */
+export const buildCursorCondition = (
+  table: Table,
+  entries: CursorOrderEntry[],
+  values: any[],
+  nullOrdering: NullOrdering,
+): SQL => {
+  const cols = getColumns(table);
+  const disjuncts: SQL[] = [];
+  const equalities: SQL[] = [];
+
+  entries.forEach(([column, direction], i) => {
+    const col = cols[column];
+    if (!col) {
+      throw new GraphQLError(`Invalid cursor: unknown column '${column}'.`);
+    }
+
+    const value = values[i];
+    const nullsSortLast = (direction === 'asc') === (nullOrdering === 'nulls-largest');
+
+    let strictlyAfter: SQL | undefined;
+    if (value === null || value === undefined) {
+      // Nothing sorts after NULL when NULLs are last; every non-NULL row does when first.
+      strictlyAfter = nullsSortLast ? undefined : isNotNull(col);
+    } else {
+      const comparison = direction === 'asc' ? gt(col, value) : lt(col, value);
+      strictlyAfter = nullsSortLast ? or(comparison, isNull(col)) : comparison;
+    }
+
+    if (strictlyAfter) {
+      disjuncts.push(equalities.length ? and(...equalities, strictlyAfter)! : strictlyAfter);
+    }
+    equalities.push(value === null || value === undefined ? isNull(col) : eq(col, value));
+  });
+
+  if (!disjuncts.length) {
+    // Every key's strict term was impossible (e.g. a NULLs-last cursor position of all NULLs) —
+    // nothing sorts after this cursor.
+    return sql`1 = 0`;
+  }
+
+  return disjuncts.length > 1 ? or(...disjuncts)! : disjuncts[0]!;
+};
+
+/**
+ * Whether the selection asks for the `cursor` meta field. A real column named `cursor` keeps
+ * the field for itself, so the meta field only exists (and is only computed) when the table
+ * has no such column.
+ */
+export const isCursorFieldSelected = (tree: Record<string, ResolveTree> | undefined, table: Table): boolean => {
+  if (!tree) {
+    return false;
+  }
+  if (getColumns(table)[CURSOR_FIELD_NAME]) {
+    return false;
+  }
+  return Object.values(tree).some((field) => field.name === CURSOR_FIELD_NAME);
+};
+
+/**
+ * Computes and attaches each row's opaque cursor (under a namespaced property the `cursor`
+ * field's resolver reads). Must run on the raw driver rows, before output remapping rewrites
+ * dates and bigints into their transport forms.
+ */
+export const attachRowCursors = (rows: Record<string, any>[], entries: CursorOrderEntry[]): void => {
+  for (const row of rows) {
+    row[ROW_CURSOR_PROP] = encodeCursor(entries, row);
+  }
+};
+
+/** Resolver for the `cursor` meta field: reads the value a list resolver attached, if any. */
+export const rowCursorResolver = (source: any): string | null => source?.[ROW_CURSOR_PROP] ?? null;
+
 /**
  * Every set of columns that uniquely identifies a row of `table`: the primary key first,
  * then each unique constraint and unique index, then each column declared `.unique()`
@@ -2488,11 +2703,16 @@ export const selectArrayArgs = (
   orderArgs: GraphQLInputObjectType,
   filterArgs: GraphQLInputObjectType,
   distinctEnum?: GraphQLEnumType,
-): Record<string, { type: any }> => ({
+): Record<string, { type: any; description?: string }> => ({
   offset: { type: GraphQLInt },
   limit: { type: GraphQLInt },
   orderBy: { type: orderArgs },
   where: { type: filterArgs },
+  after: {
+    type: GraphQLString,
+    description:
+      "Keyset pagination: only return rows strictly after this cursor (a row's `cursor` field from a previous page, under the same orderBy).",
+  },
   ...(distinctEnum ? { distinct: { type: new GraphQLList(new GraphQLNonNull(distinctEnum)) } } : {}),
 });
 
@@ -2531,6 +2751,8 @@ export const runRelationalSelect = async (opts: {
   pkNames?: readonly string[];
   db?: any;
   distinct?: string[];
+  after?: string;
+  nullOrdering?: NullOrdering;
 }): Promise<any> => {
   const {
     queryBase,
@@ -2547,8 +2769,30 @@ export const runRelationalSelect = async (opts: {
     single,
     filterCtx,
     pkNames,
+    after,
   } = opts;
   const distinct = opts.distinct?.length ? opts.distinct : undefined;
+
+  // ── keyset (cursor) pagination ──
+  // Active when the request passes `after` or selects the `cursor` meta field. The cursor is
+  // defined over a total order — the request's orderBy plus the primary-key tiebreak — so both
+  // need the PK; a table without one gets an error for `after` and null cursors otherwise.
+  const cursorSelected = !single && isCursorFieldSelected(parsedInfo.fieldsByTypeName[typeName], table);
+  let cursorEntries: CursorOrderEntry[] | undefined;
+  if (!single && (after != null || cursorSelected)) {
+    if (after != null && distinct) {
+      throw new GraphQLError("'after' cannot be combined with 'distinct'.");
+    }
+    if (!pkNames?.length) {
+      if (after != null) {
+        throw new GraphQLError(`Table ${tableName} has no primary key, so cursor pagination cannot be used on it.`);
+      }
+      // `cursor` was selected but no total order exists — the field resolves to null.
+    } else {
+      cursorEntries = cursorOrderingEntries(orderBy, pkNames);
+    }
+  }
+  const cursorValues = after != null && cursorEntries ? decodeCursor(after, cursorEntries) : undefined;
   // Taking a slice of an unordered result lets the database return any rows it likes, so
   // `limit`/`offset` pages can overlap or skip rows between requests, and a single query
   // can return a different row each time. Default to the primary key whenever the query is
@@ -2591,17 +2835,38 @@ export const runRelationalSelect = async (opts: {
           ...(orderBy ? extractOrderBy(aliasedTable, orderBy) : []),
           ...primaryKeyOrderExprs(aliasedTable, pkNames!),
         ]
-      : orderBy
-        ? (aliasedTable: Table) => extractOrderBy(aliasedTable, orderBy)
-        : needsDefaultOrder && pkNames?.length
-          ? (aliasedTable: Table) => primaryKeyOrderExprs(aliasedTable, pkNames)
-          : undefined,
+      : cursorEntries
+        ? // Cursor pagination needs a total order: the request's orderBy plus the PK tiebreak,
+          // exactly the ordering the cursor encodes and the keyset predicate compares against.
+          (aliasedTable: Table) => {
+            const aliasedCols = getColumns(aliasedTable);
+            return cursorEntries!.map(([column, direction]) =>
+              direction === 'asc' ? asc(aliasedCols[column]!) : desc(aliasedCols[column]!),
+            );
+          }
+        : orderBy
+          ? (aliasedTable: Table) => extractOrderBy(aliasedTable, orderBy)
+          : needsDefaultOrder && pkNames?.length
+            ? (aliasedTable: Table) => primaryKeyOrderExprs(aliasedTable, pkNames)
+            : undefined,
     where: distinctKeys
       ? { RAW: (aliasedTable: Table) => primaryKeyRestriction(aliasedTable, pkNames!, distinctKeys!) }
-      : where
+      : where || cursorValues
         ? {
             RAW: (aliasedTable: Table) =>
-              extractFilters(aliasedTable, tableName, where, relationFilterCtx(filterCtx, tableName)),
+              and(
+                where
+                  ? extractFilters(aliasedTable, tableName, where, relationFilterCtx(filterCtx, tableName))
+                  : undefined,
+                cursorValues
+                  ? buildCursorCondition(
+                      aliasedTable,
+                      cursorEntries!,
+                      cursorValues,
+                      opts.nullOrdering ?? 'nulls-smallest',
+                    )
+                  : undefined,
+              ),
           }
         : undefined,
     with: relationMap[tableName]
@@ -2614,8 +2879,21 @@ export const runRelationalSelect = async (opts: {
     return result ? remapToGraphQLSingleOutput(result, tableName, table, relationMap) : undefined;
   }
 
+  // Computing each row's cursor needs the whole ordering tuple, which the client has no
+  // reason to have selected — force those columns into the fetch (GraphQL only returns
+  // the fields the query asked for, so extra properties never leak into the response).
+  if (cursorEntries && cursorSelected) {
+    for (const [column] of cursorEntries) {
+      params.columns[column] = true;
+    }
+  }
+
   params.limit = distinctKeys ? undefined : opts.limit;
   const result = await queryBase.findMany(params);
+  if (cursorEntries && cursorSelected) {
+    // On the raw rows, before remapping rewrites dates/bigints into transport forms.
+    attachRowCursors(result, cursorEntries);
+  }
   return remapToGraphQLArrayOutput(result, tableName, table, relationMap);
 };
 

--- a/src/util/builders/mysql.ts
+++ b/src/util/builders/mysql.ts
@@ -113,6 +113,8 @@ const generateSelectArray = (
           filterCtx,
           pkNames,
           db: executor,
+          // MySQL sorts NULLs as the smallest values (first in ASC).
+          nullOrdering: 'nulls-smallest',
         });
       } catch (e) {
         throw toGraphQLError(e);

--- a/src/util/builders/pg.ts
+++ b/src/util/builders/pg.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck — vendored file, drizzle-orm 1.0 type compat not guaranteed
-import { is, One, type Table, type View } from 'drizzle-orm';
+import { and, asc, desc, getColumns, is, One, type Table, type View } from 'drizzle-orm';
 import type { RelationalQueryBuilder } from 'drizzle-orm/mysql-core/query-builders/query';
 import { getTableConfig, type PgAsyncDatabase, type PgColumn, PgTable } from 'drizzle-orm/pg-core';
 import type { GraphQLFieldConfig, GraphQLFieldConfigArgumentMap, ThunkObjMap } from 'graphql';
@@ -15,10 +15,15 @@ import { parseResolveInfo } from 'graphql-parse-resolve-info';
 import type { GeneratedEntities } from '../../types.ts';
 import {
   aggregateFieldComplexity,
+  attachRowCursors,
   attachTargetPrimaryKeys,
+  buildCursorCondition,
   buildNamedRelations,
+  type CursorOrderEntry,
   computeResolverFieldNames,
   createRelationResolverFactory,
+  cursorOrderingEntries,
+  decodeCursor,
   eagerLoadMutationRelations,
   excludedColumnRef,
   extractFilters,
@@ -29,6 +34,7 @@ import {
   generateTableTypes,
   getPrimaryKeyPropNamesFromConfig,
   getUniqueColumnSets,
+  isCursorFieldSelected,
   listFieldComplexity,
   type OnConflictArg,
   prepareMutationRelationColumns,
@@ -123,20 +129,53 @@ const generateSelectArray = (
             filterCtx,
             pkNames,
             db: executor,
+            // PostgreSQL sorts NULLs as the largest values (last in ASC).
+            nullOrdering: 'nulls-largest',
           });
         }
 
         // Fallback for tables without relational query builder support.
         // Use SQL column objects (not Record<string,true>) so db.select() receives valid expressions.
-        const { offset, limit, orderBy, where, distinct } = args;
+        const { offset, limit, orderBy, where, distinct, after } = args;
         const selectedColumnsSql = extractSelectedColumnsFromTreeSQLFormat<PgColumn>(
           parsedInfo.fieldsByTypeName[typeName]!,
           table,
           { tableName, relationMap, tables },
         );
-        const whereSql = where
+
+        // Keyset pagination (see runRelationalSelect, which handles the RQB path).
+        const cursorSelected = isCursorFieldSelected(parsedInfo.fieldsByTypeName[typeName], table);
+        let cursorEntries: CursorOrderEntry[] | undefined;
+        if (after != null || cursorSelected) {
+          if (after != null && distinct?.length) {
+            throw new GraphQLError("'after' cannot be combined with 'distinct'.");
+          }
+          if (!pkNames.length) {
+            if (after != null) {
+              throw new GraphQLError(
+                `Table ${tableName} has no primary key, so cursor pagination cannot be used on it.`,
+              );
+            }
+          } else {
+            cursorEntries = cursorOrderingEntries(orderBy, pkNames);
+            if (cursorSelected) {
+              // The whole ordering tuple is needed to compute each row's cursor.
+              const allColumns = getColumns(table);
+              for (const [column] of cursorEntries) {
+                selectedColumnsSql[column] ??= allColumns[column] as PgColumn;
+              }
+            }
+          }
+        }
+        const cursorCondition =
+          after != null && cursorEntries
+            ? buildCursorCondition(table, cursorEntries, decodeCursor(after, cursorEntries), 'nulls-largest')
+            : undefined;
+
+        const baseWhereSql = where
           ? extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName))
           : undefined;
+        const whereSql = cursorCondition ? and(baseWhereSql, cursorCondition) : baseWhereSql;
 
         // `distinct` picks the surviving rows in its own pass; the main query is then narrowed
         // to those primary keys and re-orders them the same way. See runRelationalSelect.
@@ -164,7 +203,15 @@ const generateSelectArray = (
         } else if (whereSql) {
           q = q.where(whereSql) as any;
         }
-        if (orderBy) {
+        if (cursorEntries && !distinctKeys) {
+          // Cursor pagination pages over a total order: orderBy plus the PK tiebreak.
+          const allColumns = getColumns(table);
+          q = q.orderBy(
+            ...cursorEntries.map(([column, direction]) =>
+              direction === 'asc' ? asc(allColumns[column]!) : desc(allColumns[column]!),
+            ),
+          ) as any;
+        } else if (orderBy) {
           q = q.orderBy(
             ...extractOrderBy(table, orderBy),
             ...(distinctKeys ? primaryKeyOrderExprs(table, pkNames) : []),
@@ -181,7 +228,11 @@ const generateSelectArray = (
             q = q.limit(limit) as any;
           }
         }
-        return remapToGraphQLArrayOutput(await q, tableName, table, relationMap);
+        const rows = await q;
+        if (cursorEntries && cursorSelected) {
+          attachRowCursors(rows, cursorEntries);
+        }
+        return remapToGraphQLArrayOutput(rows, tableName, table, relationMap);
       } catch (e) {
         throw toGraphQLError(e);
       }

--- a/src/util/builders/sqlite.ts
+++ b/src/util/builders/sqlite.ts
@@ -122,6 +122,8 @@ const generateSelectArray = (
           filterCtx,
           pkNames,
           db: executor,
+          // SQLite sorts NULLs as the smallest values (first in ASC).
+          nullOrdering: 'nulls-smallest',
         });
       } catch (e) {
         throw toGraphQLError(e);

--- a/src/util/builders/types.ts
+++ b/src/util/builders/types.ts
@@ -64,6 +64,8 @@ export type TableSelectArgs = {
   where: Filters<Table>;
   orderBy: OrderByArgs<Table>;
   distinct: string[];
+  /** Opaque keyset-pagination cursor — only return rows strictly after it. List queries only. */
+  after: string;
 };
 
 export type ProcessedTableSelectArgs = {

--- a/tests/mysql.test.ts
+++ b/tests/mysql.test.ts
@@ -2770,6 +2770,12 @@ describe.sequential('Returned data tests', () => {
                         type: z.instanceof(GraphQLInputObjectType),
                       })
                       .strict(),
+                    after: z
+                      .object({
+                        type: z.instanceof(GraphQLScalarType),
+                        description: z.string(),
+                      })
+                      .strict(),
                     distinct: z
                       .object({
                         type: z.instanceof(GraphQLList),
@@ -2834,6 +2840,12 @@ describe.sequential('Returned data tests', () => {
                         type: z.instanceof(GraphQLInputObjectType),
                       })
                       .strict(),
+                    after: z
+                      .object({
+                        type: z.instanceof(GraphQLScalarType),
+                        description: z.string(),
+                      })
+                      .strict(),
                     distinct: z
                       .object({
                         type: z.instanceof(GraphQLList),
@@ -2896,6 +2908,12 @@ describe.sequential('Returned data tests', () => {
                     where: z
                       .object({
                         type: z.instanceof(GraphQLInputObjectType),
+                      })
+                      .strict(),
+                    after: z
+                      .object({
+                        type: z.instanceof(GraphQLScalarType),
+                        description: z.string(),
                       })
                       .strict(),
                     distinct: z

--- a/tests/pg.test.ts
+++ b/tests/pg.test.ts
@@ -2339,6 +2339,12 @@ describe.sequential('Returned data tests', () => {
                         type: z.instanceof(GraphQLInputObjectType),
                       })
                       .strict(),
+                    after: z
+                      .object({
+                        type: z.instanceof(GraphQLScalarType),
+                        description: z.string(),
+                      })
+                      .strict(),
                     distinct: z
                       .object({
                         type: z.instanceof(GraphQLList),
@@ -2401,6 +2407,12 @@ describe.sequential('Returned data tests', () => {
                     where: z
                       .object({
                         type: z.instanceof(GraphQLInputObjectType),
+                      })
+                      .strict(),
+                    after: z
+                      .object({
+                        type: z.instanceof(GraphQLScalarType),
+                        description: z.string(),
                       })
                       .strict(),
                     distinct: z
@@ -2467,6 +2479,12 @@ describe.sequential('Returned data tests', () => {
                         type: z.instanceof(GraphQLInputObjectType),
                       })
                       .strict(),
+                    after: z
+                      .object({
+                        type: z.instanceof(GraphQLScalarType),
+                        description: z.string(),
+                      })
+                      .strict(),
                     distinct: z
                       .object({
                         type: z.instanceof(GraphQLList),
@@ -2529,6 +2547,12 @@ describe.sequential('Returned data tests', () => {
                     where: z
                       .object({
                         type: z.instanceof(GraphQLInputObjectType),
+                      })
+                      .strict(),
+                    after: z
+                      .object({
+                        type: z.instanceof(GraphQLScalarType),
+                        description: z.string(),
                       })
                       .strict(),
                     distinct: z

--- a/tests/pglite/cursor-pagination.test.ts
+++ b/tests/pglite/cursor-pagination.test.ts
@@ -1,0 +1,310 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { type Context, createCtx, schema, setupServer, setupTables, teardownServer, teardownTables } from './common';
+
+const DATA_DIR = `./tests/.temp/pgdata-cursor-pagination-${Date.now()}`;
+
+const ctx: Context = createCtx();
+
+beforeAll(async () => {
+  await setupServer(ctx, 5250, DATA_DIR);
+});
+
+afterAll(async () => {
+  await teardownServer(ctx, DATA_DIR);
+});
+
+beforeEach(async () => {
+  await setupTables(ctx);
+});
+
+afterEach(async () => {
+  await teardownTables(ctx);
+});
+
+/**
+ * Pages through a list query by feeding each page's last `cursor` back as `after`,
+ * until an empty page comes back. Returns the pages of rows.
+ */
+const collectPages = async (buildQuery: (afterArg: string) => string): Promise<any[][]> => {
+  const pages: any[][] = [];
+  let after: string | null = null;
+
+  for (let i = 0; i < 25; i++) {
+    const res = await ctx.gql.queryGql(buildQuery(after === null ? '' : `after: "${after}", `));
+    expect(res.errors).toBeUndefined();
+    const rows = Object.values(res.data as Record<string, any[]>)[0]!;
+    if (!rows.length) {
+      return pages;
+    }
+    pages.push(rows);
+    const lastCursor = rows[rows.length - 1].cursor;
+    expect(typeof lastCursor).toBe('string');
+    after = lastCursor;
+  }
+
+  throw new Error('cursor pagination did not terminate');
+};
+
+describe.sequential('Cursor (keyset) pagination', () => {
+  it('pages through the whole table in default PK order with no duplicates or gaps', async () => {
+    const pages = await collectPages(
+      (afterArg) => /* GraphQL */ `
+			{
+				posts(${afterArg}limit: 2) {
+					id
+					cursor
+				}
+			}
+		`,
+    );
+
+    expect(pages.map((page) => page.map((row) => row.id))).toStrictEqual([
+      [1, 2],
+      [3, 4],
+      [5, 6],
+    ]);
+  });
+
+  it('every row of a page carries its own distinct cursor', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				posts(limit: 3) {
+					id
+					cursor
+				}
+			}
+		`);
+
+    expect(res.errors).toBeUndefined();
+    const cursors = res.data.posts.map((row: any) => row.cursor);
+    expect(cursors).toHaveLength(3);
+    for (const cursor of cursors) {
+      expect(typeof cursor).toBe('string');
+      expect(cursor.length).toBeGreaterThan(0);
+    }
+    expect(new Set(cursors).size).toBe(3);
+  });
+
+  it('pages under a custom ascending orderBy, tiebroken by primary key', async () => {
+    // content asc; '1MESSAGE' and '2MESSAGE' each appear twice, so the PK tiebreak decides.
+    const pages = await collectPages(
+      (afterArg) => /* GraphQL */ `
+			{
+				posts(${afterArg}limit: 2, orderBy: { content: { priority: 1, direction: asc } }) {
+					id
+					cursor
+				}
+			}
+		`,
+    );
+
+    expect(pages.map((page) => page.map((row) => row.id))).toStrictEqual([
+      [1, 4],
+      [2, 5],
+      [3, 6],
+    ]);
+  });
+
+  it('pages under a custom descending orderBy, tiebroken by primary key', async () => {
+    const pages = await collectPages(
+      (afterArg) => /* GraphQL */ `
+			{
+				posts(${afterArg}limit: 2, orderBy: { content: { priority: 1, direction: desc } }) {
+					id
+					cursor
+				}
+			}
+		`,
+    );
+
+    expect(pages.map((page) => page.map((row) => row.id))).toStrictEqual([
+      [6, 3],
+      [2, 5],
+      [1, 4],
+    ]);
+  });
+
+  it('pages under a mixed-direction orderBy (asc + desc)', async () => {
+    // content asc, then authorId desc, then the PK tiebreak — the expanded lexicographic
+    // predicate has to flip its comparison per key.
+    const pages = await collectPages(
+      (afterArg) => /* GraphQL */ `
+			{
+				posts(${afterArg}limit: 2, orderBy: {
+					content: { priority: 2, direction: asc }
+					authorId: { priority: 1, direction: desc }
+				}) {
+					id
+					authorId
+					content
+					cursor
+				}
+			}
+		`,
+    );
+
+    expect(pages.map((page) => page.map((row) => row.id))).toStrictEqual([
+      [4, 1],
+      [5, 2],
+      [3, 6],
+    ]);
+  });
+
+  it('a row inserted mid-scroll does not shift the window', async () => {
+    const firstPage = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				posts(limit: 2) {
+					id
+					cursor
+				}
+			}
+		`);
+    expect(firstPage.errors).toBeUndefined();
+    expect(firstPage.data.posts.map((row: any) => row.id)).toStrictEqual([1, 2]);
+    const after = firstPage.data.posts[1].cursor;
+
+    // A row landing before the current position: offset pagination would now re-serve id 2.
+    await ctx.db.insert(schema.Posts).values([{ id: 0, authorId: 1, content: '0MESSAGE' }]);
+
+    const secondPage = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				posts(after: "${after}", limit: 2) {
+					id
+					cursor
+				}
+			}
+		`);
+    expect(secondPage.errors).toBeUndefined();
+    expect(secondPage.data.posts.map((row: any) => row.id)).toStrictEqual([3, 4]);
+  });
+
+  it('round-trips date values through the cursor', async () => {
+    // All users share createdAt, so the cursor carries a timestamp AND relies on the PK
+    // tiebreak to make progress — a lossy date encoding would repeat or skip rows.
+    const pages = await collectPages(
+      (afterArg) => /* GraphQL */ `
+			{
+				users(${afterArg}limit: 1, orderBy: { createdAt: { priority: 1, direction: asc } }) {
+					id
+					createdAt
+					cursor
+				}
+			}
+		`,
+    );
+
+    expect(pages.map((page) => page.map((row) => row.id))).toStrictEqual([[1], [2], [5]]);
+    expect(pages[0]![0]!.createdAt).toBe('2024-04-02T06:44:41.785Z');
+  });
+
+  it('pages across NULL values in the ordered column', async () => {
+    // email is NULL for users 2 and 5. In PostgreSQL, DESC puts NULLs first, so the scan
+    // starts inside the NULL group and has to cross into the non-NULL rows.
+    const pages = await collectPages(
+      (afterArg) => /* GraphQL */ `
+			{
+				users(${afterArg}limit: 1, orderBy: { email: { priority: 1, direction: desc } }) {
+					id
+					email
+					cursor
+				}
+			}
+		`,
+    );
+
+    expect(pages.map((page) => page.map((row) => row.id))).toStrictEqual([[2], [5], [1]]);
+  });
+
+  it('rejects a malformed cursor with a GraphQL error', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				posts(after: "not-a-real-cursor!!!", limit: 2) {
+					id
+				}
+			}
+		`);
+
+    expect(res.data ?? undefined).toBeUndefined();
+    expect(res.errors?.[0]?.message).toContain('Invalid cursor');
+  });
+
+  it('rejects a syntactically valid cursor whose payload is not a cursor', async () => {
+    const bogus = Buffer.from(JSON.stringify({ hello: 'world' }), 'utf8').toString('base64url');
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				posts(after: "${bogus}", limit: 2) {
+					id
+				}
+			}
+		`);
+
+    expect(res.data ?? undefined).toBeUndefined();
+    expect(res.errors?.[0]?.message).toContain('Invalid cursor');
+  });
+
+  it('rejects a cursor issued under a different orderBy', async () => {
+    const firstPage = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				posts(limit: 1) {
+					id
+					cursor
+				}
+			}
+		`);
+    expect(firstPage.errors).toBeUndefined();
+    const after = firstPage.data.posts[0].cursor;
+
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				posts(after: "${after}", limit: 1, orderBy: { content: { priority: 1, direction: asc } }) {
+					id
+				}
+			}
+		`);
+
+    expect(res.data ?? undefined).toBeUndefined();
+    expect(res.errors?.[0]?.message).toContain('different ordering');
+  });
+
+  it('rejects combining after with distinct', async () => {
+    const firstPage = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				posts(limit: 1) {
+					id
+					cursor
+				}
+			}
+		`);
+    expect(firstPage.errors).toBeUndefined();
+    const after = firstPage.data.posts[0].cursor;
+
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				posts(after: "${after}", distinct: [content]) {
+					id
+				}
+			}
+		`);
+
+    expect(res.data ?? undefined).toBeUndefined();
+    expect(res.errors?.[0]?.message).toContain("'after' cannot be combined with 'distinct'");
+  });
+
+  it('cursor pagination composes with where filters', async () => {
+    const pages = await collectPages(
+      (afterArg) => /* GraphQL */ `
+			{
+				posts(${afterArg}limit: 2, where: { authorId: { eq: 1 } }) {
+					id
+					cursor
+				}
+			}
+		`,
+    );
+
+    expect(pages.map((page) => page.map((row) => row.id))).toStrictEqual([
+      [1, 2],
+      [3, 6],
+    ]);
+  });
+});

--- a/tests/pglite/returned-data.test.ts
+++ b/tests/pglite/returned-data.test.ts
@@ -57,6 +57,12 @@ describe.sequential('Returned data tests', () => {
                         type: z.instanceof(GraphQLInputObjectType),
                       })
                       .strict(),
+                    after: z
+                      .object({
+                        type: z.instanceof(GraphQLScalarType),
+                        description: z.string(),
+                      })
+                      .strict(),
                     distinct: z
                       .object({
                         type: z.instanceof(GraphQLList),
@@ -119,6 +125,12 @@ describe.sequential('Returned data tests', () => {
                     where: z
                       .object({
                         type: z.instanceof(GraphQLInputObjectType),
+                      })
+                      .strict(),
+                    after: z
+                      .object({
+                        type: z.instanceof(GraphQLScalarType),
+                        description: z.string(),
                       })
                       .strict(),
                     distinct: z
@@ -185,6 +197,12 @@ describe.sequential('Returned data tests', () => {
                         type: z.instanceof(GraphQLInputObjectType),
                       })
                       .strict(),
+                    after: z
+                      .object({
+                        type: z.instanceof(GraphQLScalarType),
+                        description: z.string(),
+                      })
+                      .strict(),
                     distinct: z
                       .object({
                         type: z.instanceof(GraphQLList),
@@ -247,6 +265,12 @@ describe.sequential('Returned data tests', () => {
                     where: z
                       .object({
                         type: z.instanceof(GraphQLInputObjectType),
+                      })
+                      .strict(),
+                    after: z
+                      .object({
+                        type: z.instanceof(GraphQLScalarType),
+                        description: z.string(),
                       })
                       .strict(),
                     distinct: z

--- a/tests/sqlite.test.ts
+++ b/tests/sqlite.test.ts
@@ -2501,6 +2501,12 @@ describe.sequential('Returned data tests', () => {
                         type: z.instanceof(GraphQLInputObjectType),
                       })
                       .strict(),
+                    after: z
+                      .object({
+                        type: z.instanceof(GraphQLScalarType),
+                        description: z.string(),
+                      })
+                      .strict(),
                     distinct: z
                       .object({
                         type: z.instanceof(GraphQLList),
@@ -2565,6 +2571,12 @@ describe.sequential('Returned data tests', () => {
                         type: z.instanceof(GraphQLInputObjectType),
                       })
                       .strict(),
+                    after: z
+                      .object({
+                        type: z.instanceof(GraphQLScalarType),
+                        description: z.string(),
+                      })
+                      .strict(),
                     distinct: z
                       .object({
                         type: z.instanceof(GraphQLList),
@@ -2627,6 +2639,12 @@ describe.sequential('Returned data tests', () => {
                     where: z
                       .object({
                         type: z.instanceof(GraphQLInputObjectType),
+                      })
+                      .strict(),
+                    after: z
+                      .object({
+                        type: z.instanceof(GraphQLScalarType),
+                        description: z.string(),
                       })
                       .strict(),
                     distinct: z


### PR DESCRIPTION
Adds keyset (cursor) pagination to generated list queries: an opaque `after: String` argument plus a per-row `cursor: String` meta field on the select output types.

Closes #25

## Usage

```graphql
{
    posts(orderBy: { createdAt: { direction: desc, priority: 1 } }, limit: 10) {
        id
        createdAt
        cursor
    }
}
```

Pass the last row's `cursor` back as `after` (with the same `orderBy`) to get the next page — no OFFSET, no shifted windows under concurrent writes.

## Design

**Total order.** A cursor is only meaningful under a total order, so when `after` is passed or the `cursor` field is selected, the query is ordered by the request's `orderBy` entries (priority order) plus the primary key ascending as a tiebreak (deduped when `orderBy` already names PK columns). Requests that use neither keep today's ordering behavior untouched.

**Cursor format.** base64url of JSON `{ o: [[column, direction], ...], v: [values...] }` — the ordering spec plus the row's values for that tuple. Values are captured from the raw driver rows *before* output remapping, and `Date`/`bigint` values are tagged (`{$type: 'date' | 'bigint', value}`) so they round-trip losslessly instead of going through ISO-string/string coercion.

**Predicate.** `after` compiles to the expanded lexicographic OR form

```
(a > :a) OR (a = :a AND b < :b) OR (a = :a AND b = :b AND pk > :pk)
```

built with drizzle's `and`/`or`/`gt`/`lt`/`eq` — deliberately **not** SQL row-value comparison syntax, which breaks under mixed-direction orderings and NULLs. Shared machinery lives in `src/util/builders/common.ts`; all three dialect builders use it (pg both in the RQB path and the non-RQB fallback select path).

**NULL semantics.** Each dialect declares its native NULL placement (`nulls-largest` for PostgreSQL, `nulls-smallest` for MySQL/SQLite) and the keyset predicate mirrors it with `isNull`/`isNotNull` branches, so rows with NULL in an ordered column are paged through in the same position the dialect's `ORDER BY` puts them — never skipped or duplicated.

**Validation and errors** (all `GraphQLError`):

- malformed/corrupted cursor → "Invalid cursor: unable to decode it" / "malformed payload"
- cursor reused under a different `orderBy` → "issued for a different ordering" (the embedded `o` spec is checked against the request)
- `after` combined with `distinct` → rejected (distinct collapses rows after ordering, so a keyset over the ordering tuple is not sound)
- `after` on a table with no primary key → rejected (no total order available); the `cursor` field resolves to `null` there

**Why a per-row `cursor` field, not a Relay connection.** Generated list queries return flat `[Type!]!` lists; a `pageInfo` wrapper would break the existing generated type surface. The issue asks for minimal exposure, so the row type gets a nullable `cursor` meta field (skipped when a real column named `cursor` exists — the column wins).

## Tests

New `tests/pglite/cursor-pagination.test.ts` (port 5250) — 13 tests covering: stable forward pagination under default PK order, custom `orderBy` asc/desc, a mixed-direction pair, insertion mid-scroll not shifting the window, date round-trip through the cursor, NULL-column ordering, malformed-cursor and wrong-ordering errors, `after`+`distinct` rejection, and composition with `where`. The strict resolver-shape ("Entities") tests in the pglite/sqlite/pg/mysql suites were updated for the new `after` arg.

Verification: `npx tsc --noEmit` clean; biome clean on all changed files; `npx vitest run tests/pglite/ tests/sqlite.test.ts tests/sqlite-custom.test.ts` → 31 files, 411 tests, all passing. Docker-based pg/mysql suites not run locally (per contributing guidance) but their arg-shape tests were updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
