### PR TITLE
feat(mutations): add update<Table>Many batch update with per-row values

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,9 @@ export type {
   SchemaFeatures,
   SelectResolver,
   SelectSingleResolver,
+  UpdateManyArgs,
+  UpdateManyEntry,
+  UpdateManyResolver,
   UpdateResolver,
   UpsertArgs,
   UpsertArrResolver,
@@ -108,6 +111,7 @@ export const buildSchema = <TDbClient extends AnyDrizzleDB<any>>(
     distinct: config?.features?.distinct ?? true,
     insert: config?.features?.insert ?? true,
     update: config?.features?.update ?? true,
+    updateMany: config?.features?.updateMany ?? true,
     delete: config?.features?.delete ?? true,
     upsert: config?.features?.upsert ?? false,
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,6 +100,19 @@ export type UpdateArgs<TTable extends Table> = Partial<{
 }>;
 
 /**
+ * One entry of an `update<Table>Many` mutation: the rows `where` matches get this
+ * entry's `set` applied. An omitted `where` matches every row, same as `update<Table>`.
+ */
+export type UpdateManyEntry<TTable extends Table> = {
+  where?: Filters<TTable>;
+  set: GetRemappedTableUpdateDataType<TTable>;
+};
+
+export type UpdateManyArgs<TTable extends Table> = {
+  updates: Array<UpdateManyEntry<TTable>>;
+};
+
+/**
  * The `onConflict` argument of the generated upsert mutations.
  *
  * `target` and `where` exist on PostgreSQL and SQLite only: MySQL's
@@ -208,6 +221,19 @@ export type UpdateResolver<TTable extends Table, IsReturnless extends boolean> =
   context: any,
   info: GraphQLResolveInfo,
 ) => Promise<IsReturnless extends false ? GetRemappedTableDataType<TTable> | undefined : MutationReturnlessResult>;
+
+/**
+ * Resolver for `update<Table>Many`: per-entry `set`/`where` pairs applied in input order
+ * inside one transaction. Where the dialect returns rows, the result holds each entry's
+ * updated rows in entry order, with `null` standing in for an entry whose `where`
+ * matched no rows.
+ */
+export type UpdateManyResolver<TTable extends Table, IsReturnless extends boolean> = (
+  source: any,
+  args: UpdateManyArgs<TTable>,
+  context: any,
+  info: GraphQLResolveInfo,
+) => Promise<IsReturnless extends false ? Array<GetRemappedTableDataType<TTable> | null> : MutationReturnlessResult>;
 
 /** Resolver for `upsert<Table>Single`. */
 export type UpsertResolver<TTable extends Table, IsReturnless extends boolean> = (
@@ -433,6 +459,26 @@ export type MutationsCore<
       }
     : never;
 } & {
+  [TName in keyof TSchemaTables as TName extends string
+    ? `update${Capitalize<TName>}Many`
+    : never]: TName extends string
+    ? {
+        type: IsReturnless extends true
+          ? TOutputs['MutationReturn'] extends GraphQLObjectType
+            ? TOutputs['MutationReturn']
+            : never
+          : // The list items are nullable: an entry whose `where` matched no rows
+            // yields `null` in its slot, keeping the result aligned with the input.
+            GraphQLNonNull<GraphQLList<TOutputs[`${Capitalize<TName>}Item`]>>;
+        args: {
+          updates: {
+            type: GraphQLNonNull<GraphQLList<GraphQLNonNull<TInputs[`${Capitalize<TName>}UpdateManyInput`]>>>;
+          };
+        };
+        resolve: UpdateManyResolver<TSchemaTables[TName], IsReturnless>;
+      }
+    : never;
+} & {
   [TName in keyof TSchemaTables as TName extends string ? `delete${Capitalize<TName>}` : never]: TName extends string
     ? {
         type: IsReturnless extends true
@@ -456,6 +502,10 @@ export type GeneratedInputs<TSchema extends Record<string, Table>> = {
   [TName in keyof TSchema as TName extends string ? `${Capitalize<TName>}InsertInput` : never]: GraphQLInputObjectType;
 } & {
   [TName in keyof TSchema as TName extends string ? `${Capitalize<TName>}UpdateInput` : never]: GraphQLInputObjectType;
+} & {
+  [TName in keyof TSchema as TName extends string
+    ? `${Capitalize<TName>}UpdateManyInput`
+    : never]: GraphQLInputObjectType;
 } & {
   [TName in keyof TSchema as TName extends string ? `${Capitalize<TName>}OrderBy` : never]: GraphQLInputObjectType;
 } & {
@@ -535,6 +585,14 @@ export type SchemaFeatures = {
   insert?: boolean;
   /** `update<Table>` mutations. @default true */
   update?: boolean;
+  /**
+   * `update<Table>Many` mutations — batch update with a per-entry `set` and `where`,
+   * executed inside one transaction. Only generated when `update` is also enabled,
+   * since the entries reuse the update `set` input.
+   *
+   * @default true
+   */
+  updateMany?: boolean;
   /** `delete<Table>` mutations. @default true */
   delete?: boolean;
   /**

--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -2449,6 +2449,7 @@ export const computeResolverFieldNames = (
   upsertArrayFieldName: string;
   upsertSingleFieldName: string;
   updateFieldName: string;
+  updateManyFieldName: string;
   deleteFieldName: string;
 } => {
   const mapped = typeNameMapper?.(tableName);
@@ -2467,6 +2468,9 @@ export const computeResolverFieldNames = (
     ? `${upsertPrefix}${capitalize(mapped.singular)}`
     : `${upsertPrefix}${capitalize(tableName)}${suffixes.single}`;
   const updateFieldName = `${prefixes.update}${mapped ? capitalize(mapped.singular) : capitalize(tableName)}`;
+  // The batch variant is plural like the array insert/upsert, with an explicit `Many`
+  // suffix so it never collides with the single-set update.
+  const updateManyFieldName = `${prefixes.update}${mapped ? capitalize(mapped.plural) : capitalize(tableName)}Many`;
   const deleteFieldName = `${prefixes.delete}${mapped ? capitalize(mapped.singular) : capitalize(tableName)}`;
   return {
     typeName,
@@ -2479,8 +2483,35 @@ export const computeResolverFieldNames = (
     upsertArrayFieldName,
     upsertSingleFieldName,
     updateFieldName,
+    updateManyFieldName,
     deleteFieldName,
   };
+};
+
+/**
+ * The per-entry input of `update<Table>Many`: `{ where, set }`, reusing the table's
+ * update `set` input and filter input. Shared by all three dialect builders.
+ */
+export const generateUpdateManyInput = (params: {
+  typeName: string;
+  updatePrefix: string;
+  updateInput: GraphQLInputObjectType;
+  tableFilters: GraphQLInputObjectType;
+}): GraphQLInputObjectType => {
+  const { typeName, updatePrefix, updateInput, tableFilters } = params;
+  return new GraphQLInputObjectType({
+    name: `${capitalize(updatePrefix)}${typeName}ManyInput`,
+    description: `One entry of a batch update of ${typeName}: the rows \`where\` matches get this entry's \`set\` applied.`,
+    fields: {
+      where: {
+        type: tableFilters,
+        description: 'Rows this entry updates. An omitted filter updates every row.',
+      },
+      set: {
+        type: new GraphQLNonNull(updateInput),
+      },
+    },
+  });
 };
 
 /** GraphQL argument map for a list/array select field. */

--- a/src/util/builders/mysql.ts
+++ b/src/util/builders/mysql.ts
@@ -25,6 +25,7 @@ import {
   generateDistinctEnum,
   generateOnConflictInput,
   generateTableTypes,
+  generateUpdateManyInput,
   getPrimaryKeyPropNamesFromConfig,
   listFieldComplexity,
   mysqlValuesColumnRef,
@@ -352,6 +353,80 @@ const generateUpdate = (
   };
 };
 
+/**
+ * `update<Table>Many` — batch update with a per-entry `set` and `where`.
+ *
+ * The entries run as one UPDATE statement each, in input order, inside a single
+ * transaction (a savepoint when the request context already carries one), so a failing
+ * entry rolls the whole batch back and a row matched by several entries sees them applied
+ * in order. MySQL has no RETURNING, so — like every other MySQL mutation — the result is
+ * `{ isSuccess: true }` rather than the updated rows.
+ */
+const generateUpdateMany = (
+  db: MySqlDatabase<any, any, any>,
+  tableName: string,
+  table: MySqlTable,
+  updateManyInput: GraphQLInputObjectType,
+  fieldName: string,
+  filterCtx?: RelationFilterBase,
+): CreatedResolver => {
+  const queryArgs = {
+    updates: {
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(updateManyInput))),
+    },
+  } as const satisfies GraphQLFieldConfigArgumentMap;
+
+  return {
+    name: fieldName,
+    resolver: async (
+      _source,
+      args: { updates: { where?: Filters<Table>; set: Record<string, any> }[] },
+      context,
+      _info,
+    ) => {
+      try {
+        const { updates } = args;
+        if (!updates.length) {
+          throw new GraphQLError('No updates were provided!');
+        }
+
+        // Remap and validate every entry before the transaction opens, so a malformed
+        // entry rejects the request instead of rolling back mid-batch.
+        const entries = updates.map(({ where, set }) => {
+          const input = remapFromGraphQLSingleInput(set, table);
+          if (!Object.keys(input).length) {
+            throw new GraphQLError('Unable to update with no values specified!');
+          }
+          return {
+            set: input,
+            filters: where
+              ? extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName))
+              : undefined,
+          };
+        });
+
+        const executor = resolveExecutor(db, context);
+        // On a caller-supplied transaction this opens a savepoint, so the batch stays
+        // atomic without breaking the outer transaction.
+        await executor.transaction(async (tx) => {
+          for (const entry of entries) {
+            let query = tx.update(table).set(entry.set);
+            if (entry.filters) {
+              query = query.where(entry.filters) as any;
+            }
+            await query;
+          }
+        });
+
+        return { isSuccess: true };
+      } catch (e) {
+        throw toGraphQLError(e);
+      }
+    },
+    args: queryArgs,
+  };
+};
+
 const generateDelete = (
   db: MySqlDatabase<any, any, any>,
   tableName: string,
@@ -503,6 +578,7 @@ export const generateSchemaData = <
       upsertArrayFieldName,
       upsertSingleFieldName,
       updateFieldName,
+      updateManyFieldName,
       deleteFieldName,
     } = computeResolverFieldNames(tableName, typeNameMapper, prefixes, suffixes);
 
@@ -562,6 +638,21 @@ export const generateSchemaData = <
           updateInput,
           tableFilters,
           updateFieldName,
+          filterCtx,
+        )
+      : undefined;
+    // The batch update reuses the update `set` input, so it needs `update` on too.
+    const updateManyInput =
+      features.update && features.updateMany
+        ? generateUpdateManyInput({ typeName, updatePrefix: prefixes.update, updateInput, tableFilters })
+        : undefined;
+    const updateManyGenerated = updateManyInput
+      ? generateUpdateMany(
+          db,
+          tableName,
+          schema[tableName] as MySqlTable,
+          updateManyInput,
+          updateManyFieldName,
           filterCtx,
         )
       : undefined;
@@ -642,6 +733,7 @@ export const generateSchemaData = <
       upsertArrGenerated,
       upsertSingleGenerated,
       updateGenerated,
+      updateManyGenerated,
       deleteGenerated,
     ]) {
       if (generated) {
@@ -659,6 +751,7 @@ export const generateSchemaData = <
       ...(features.insert || onConflictInput ? [insertInput] : []),
       ...(onConflictInput ? [onConflictInput] : []),
       ...(features.update ? [updateInput] : []),
+      ...(updateManyInput ? [updateManyInput] : []),
       tableFilters,
       tableOrder,
     ];

--- a/src/util/builders/pg.ts
+++ b/src/util/builders/pg.ts
@@ -27,6 +27,7 @@ import {
   generateDistinctEnum,
   generateOnConflictInput,
   generateTableTypes,
+  generateUpdateManyInput,
   getPrimaryKeyPropNamesFromConfig,
   getUniqueColumnSets,
   listFieldComplexity,
@@ -579,6 +580,124 @@ const generateUpdate = (
   };
 };
 
+/**
+ * `update<Table>Many` — batch update with a per-entry `set` and `where`.
+ *
+ * The entries run as one UPDATE statement each, in input order, inside a single
+ * transaction (a savepoint when the request context already carries one), so a failing
+ * entry rolls the whole batch back and a row matched by several entries sees them applied
+ * in order. The result lists each entry's updated rows in entry order, with `null`
+ * standing in for an entry whose `where` matched no rows, so the common one-row-per-entry
+ * case stays aligned with the input.
+ */
+const generateUpdateMany = (
+  db: PgAsyncDatabase<any, any, any>,
+  tableName: string,
+  table: PgTable,
+  tables: Record<string, Table>,
+  relationMap: Record<string, Record<string, TableNamedRelations>>,
+  updateManyInput: GraphQLInputObjectType,
+  fieldName: string,
+  typeName: string,
+  typeNameMapper?: TypeNameMapper,
+  filterCtx?: RelationFilterBase,
+): CreatedResolver => {
+  const queryArgs = {
+    updates: {
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(updateManyInput))),
+    },
+  } as const satisfies GraphQLFieldConfigArgumentMap;
+
+  // Derived once at build time — PK prop names don't change per request.
+  const pkNames = pgPrimaryKeyPropNames(table);
+
+  return {
+    name: fieldName,
+    resolver: async (
+      _source,
+      args: { updates: { where?: Filters<Table>; set: Record<string, any> }[] },
+      context,
+      info,
+    ) => {
+      try {
+        const { updates } = args;
+        if (!updates.length) {
+          throw new GraphQLError('No updates were provided!');
+        }
+
+        const parsedInfo = parseResolveInfo(info, {
+          deep: true,
+        }) as ResolveTree;
+
+        const { columns, hasRelations, withParams } = prepareMutationRelationColumns({
+          relationMap,
+          tables,
+          tableName,
+          typeName,
+          typeNameMapper,
+          table,
+          pkNames,
+          parsedInfo,
+        });
+
+        // Remap and validate every entry before the transaction opens, so a malformed
+        // entry rejects the request instead of rolling back mid-batch.
+        const entries = updates.map(({ where, set }) => {
+          const input = remapFromGraphQLSingleInput(set, table);
+          if (!Object.keys(input).length) {
+            throw new GraphQLError('Unable to update with no values specified!');
+          }
+          return {
+            set: input,
+            filters: where
+              ? extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName))
+              : undefined,
+          };
+        });
+
+        const executor = resolveExecutor(db, context);
+        // On a caller-supplied transaction this opens a savepoint, so the batch stays
+        // atomic without breaking the outer transaction.
+        const perEntry: Record<string, any>[][] = await executor.transaction(async (tx) => {
+          const results: Record<string, any>[][] = [];
+          for (const entry of entries) {
+            let query = tx.update(table).set(entry.set);
+            if (entry.filters) {
+              query = query.where(entry.filters) as any;
+            }
+            results.push(await (query.returning(columns) as any));
+          }
+          return results;
+        });
+
+        const flatRows = perEntry.flat();
+        const enriched = hasRelations
+          ? await eagerLoadMutationRelations(executor, tableName, flatRows, pkNames, withParams)
+          : flatRows;
+
+        // Rebuild the per-entry slots: a no-match entry contributes `null`, a multi-match
+        // entry contributes each of its rows.
+        const output: (Record<string, any> | null)[] = [];
+        let offset = 0;
+        for (const rows of perEntry) {
+          if (!rows.length) {
+            output.push(null);
+            continue;
+          }
+          for (let i = 0; i < rows.length; i++) {
+            output.push(remapToGraphQLSingleOutput(enriched[offset + i], tableName, table, relationMap));
+          }
+          offset += rows.length;
+        }
+        return output;
+      } catch (e) {
+        throw toGraphQLError(e);
+      }
+    },
+    args: queryArgs,
+  };
+};
+
 const generateDelete = (
   db: PgAsyncDatabase<any, any, any>,
   tableName: string,
@@ -741,6 +860,7 @@ export function generateSchemaData<
       upsertArrayFieldName,
       upsertSingleFieldName,
       updateFieldName,
+      updateManyFieldName,
       deleteFieldName,
     } = computeResolverFieldNames(tableName, typeNameMapper, prefixes, suffixes);
 
@@ -853,6 +973,25 @@ export function generateSchemaData<
           updateInput,
           tableFilters,
           updateFieldName,
+          typeName,
+          typeNameMapper,
+          filterCtx,
+        )
+      : undefined;
+    // The batch update reuses the update `set` input, so it needs `update` on too.
+    const updateManyInput =
+      features.update && features.updateMany
+        ? generateUpdateManyInput({ typeName, updatePrefix: prefixes.update, updateInput, tableFilters })
+        : undefined;
+    const updateManyGenerated = updateManyInput
+      ? generateUpdateMany(
+          db,
+          tableName,
+          schema[tableName] as PgTable,
+          tables,
+          eagerRelations,
+          updateManyInput,
+          updateManyFieldName,
           typeName,
           typeNameMapper,
           filterCtx,
@@ -973,6 +1112,14 @@ export function generateSchemaData<
         resolve: updateGenerated.resolver,
       };
     }
+    if (updateManyGenerated) {
+      mutations[updateManyGenerated.name] = {
+        // Nullable items: a no-match entry yields `null` in its slot.
+        type: new GraphQLNonNull(new GraphQLList(singleTableItemOutput)),
+        args: updateManyGenerated.args,
+        resolve: updateManyGenerated.resolver,
+      };
+    }
     if (deleteGenerated) {
       mutations[deleteGenerated.name] = {
         type: arrTableItemOutput,
@@ -987,6 +1134,7 @@ export function generateSchemaData<
       ...(features.insert || onConflictInput ? [insertInput] : []),
       ...(onConflictInput ? [onConflictInput] : []),
       ...(features.update ? [updateInput] : []),
+      ...(updateManyInput ? [updateManyInput] : []),
       tableFilters,
       tableOrder,
     ];

--- a/src/util/builders/sqlite.ts
+++ b/src/util/builders/sqlite.ts
@@ -27,6 +27,7 @@ import {
   generateDistinctEnum,
   generateOnConflictInput,
   generateTableTypes,
+  generateUpdateManyInput,
   getPrimaryKeyPropNamesFromConfig,
   getUniqueColumnSets,
   listFieldComplexity,
@@ -497,6 +498,144 @@ const generateUpdate = (
   };
 };
 
+/**
+ * `update<Table>Many` — batch update with a per-entry `set` and `where`.
+ *
+ * The entries run as one UPDATE statement each, in input order, inside a single
+ * transaction (a savepoint when the request context already carries one), so a failing
+ * entry rolls the whole batch back and a row matched by several entries sees them applied
+ * in order. The result lists each entry's updated rows in entry order, with `null`
+ * standing in for an entry whose `where` matched no rows, so the common one-row-per-entry
+ * case stays aligned with the input.
+ */
+const generateUpdateMany = (
+  db: BaseSQLiteDatabase<any, any, any, any>,
+  tableName: string,
+  table: SQLiteTable,
+  tables: Record<string, Table>,
+  relationMap: Record<string, Record<string, TableNamedRelations>>,
+  updateManyInput: GraphQLInputObjectType,
+  fieldName: string,
+  typeName: string,
+  typeNameMapper?: TypeNameMapper,
+  filterCtx?: RelationFilterBase,
+): CreatedResolver => {
+  const queryArgs = {
+    updates: {
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(updateManyInput))),
+    },
+  } as const satisfies GraphQLFieldConfigArgumentMap;
+
+  // Derived once at build time — PK prop names don't change per request.
+  const pkNames = sqlitePrimaryKeyPropNames(table);
+
+  return {
+    name: fieldName,
+    resolver: async (
+      _source,
+      args: { updates: { where?: Filters<Table>; set: Record<string, any> }[] },
+      context,
+      info,
+    ) => {
+      try {
+        const { updates } = args;
+        if (!updates.length) {
+          throw new GraphQLError('No updates were provided!');
+        }
+
+        const parsedInfo = parseResolveInfo(info, {
+          deep: true,
+        }) as ResolveTree;
+
+        const { columns, hasRelations, withParams } = prepareMutationRelationColumns({
+          relationMap,
+          tables,
+          tableName,
+          typeName,
+          typeNameMapper,
+          table,
+          pkNames,
+          parsedInfo,
+        });
+
+        // Remap and validate every entry before the transaction opens, so a malformed
+        // entry rejects the request instead of rolling back mid-batch.
+        const entries = updates.map(({ where, set }) => {
+          const input = remapFromGraphQLSingleInput(set, table);
+          if (!Object.keys(input).length) {
+            throw new GraphQLError('Unable to update with no values specified!');
+          }
+          return {
+            set: input,
+            filters: where
+              ? extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName))
+              : undefined,
+          };
+        });
+
+        const runEntry = (tx: any, entry: (typeof entries)[number]) => {
+          let query = tx.update(table).set(entry.set);
+          if (entry.filters) {
+            query = query.where(entry.filters);
+          }
+          // `.all()` instead of awaiting the thenable: a sync driver (better-sqlite3)
+          // executes it immediately, which is the only way the statement still runs
+          // inside the synchronous native transaction below.
+          return query.returning(columns).all();
+        };
+
+        const executor = resolveExecutor(db, context);
+        // On a caller-supplied transaction this opens a savepoint, so the batch stays
+        // atomic without breaking the outer transaction. A sync driver's transaction
+        // callback must not be async — it would commit before any awaited statement ran —
+        // so the driver kind is probed from the first statement's result instead.
+        const perEntry: Record<string, any>[][] = await executor.transaction((tx: any) => {
+          const first = runEntry(tx, entries[0]!);
+          if (typeof (first as any)?.then === 'function') {
+            // Async driver: await sequentially so the entries apply in input order.
+            return (async () => {
+              const results: Record<string, any>[][] = [await first];
+              for (let i = 1; i < entries.length; i++) {
+                results.push(await runEntry(tx, entries[i]!));
+              }
+              return results;
+            })();
+          }
+          const results: Record<string, any>[][] = [first];
+          for (let i = 1; i < entries.length; i++) {
+            results.push(runEntry(tx, entries[i]!));
+          }
+          return results;
+        });
+
+        const flatRows = perEntry.flat();
+        const enriched = hasRelations
+          ? await eagerLoadMutationRelations(executor, tableName, flatRows, pkNames, withParams)
+          : flatRows;
+
+        // Rebuild the per-entry slots: a no-match entry contributes `null`, a multi-match
+        // entry contributes each of its rows.
+        const output: (Record<string, any> | null)[] = [];
+        let offset = 0;
+        for (const rows of perEntry) {
+          if (!rows.length) {
+            output.push(null);
+            continue;
+          }
+          for (let i = 0; i < rows.length; i++) {
+            output.push(remapToGraphQLSingleOutput(enriched[offset + i], tableName, table, relationMap));
+          }
+          offset += rows.length;
+        }
+        return output;
+      } catch (e) {
+        throw toGraphQLError(e);
+      }
+    },
+    args: queryArgs,
+  };
+};
+
 const generateDelete = (
   db: BaseSQLiteDatabase<any, any, any, any>,
   tableName: string,
@@ -653,6 +792,7 @@ export const generateSchemaData = <
       upsertArrayFieldName,
       upsertSingleFieldName,
       updateFieldName,
+      updateManyFieldName,
       deleteFieldName,
     } = computeResolverFieldNames(tableName, typeNameMapper, prefixes, suffixes);
 
@@ -765,6 +905,25 @@ export const generateSchemaData = <
           updateInput,
           tableFilters,
           updateFieldName,
+          typeName,
+          typeNameMapper,
+          filterCtx,
+        )
+      : undefined;
+    // The batch update reuses the update `set` input, so it needs `update` on too.
+    const updateManyInput =
+      features.update && features.updateMany
+        ? generateUpdateManyInput({ typeName, updatePrefix: prefixes.update, updateInput, tableFilters })
+        : undefined;
+    const updateManyGenerated = updateManyInput
+      ? generateUpdateMany(
+          db,
+          tableName,
+          schema[tableName] as SQLiteTable,
+          tables,
+          eagerRelations,
+          updateManyInput,
+          updateManyFieldName,
           typeName,
           typeNameMapper,
           filterCtx,
@@ -885,6 +1044,14 @@ export const generateSchemaData = <
         resolve: updateGenerated.resolver,
       };
     }
+    if (updateManyGenerated) {
+      mutations[updateManyGenerated.name] = {
+        // Nullable items: a no-match entry yields `null` in its slot.
+        type: new GraphQLNonNull(new GraphQLList(singleTableItemOutput)),
+        args: updateManyGenerated.args,
+        resolve: updateManyGenerated.resolver,
+      };
+    }
     if (deleteGenerated) {
       mutations[deleteGenerated.name] = {
         type: arrTableItemOutput,
@@ -899,6 +1066,7 @@ export const generateSchemaData = <
       ...(features.insert || onConflictInput ? [insertInput] : []),
       ...(onConflictInput ? [onConflictInput] : []),
       ...(features.update ? [updateInput] : []),
+      ...(updateManyInput ? [updateManyInput] : []),
       tableFilters,
       tableOrder,
     ];

--- a/src/util/builders/types.ts
+++ b/src/util/builders/types.ts
@@ -27,6 +27,7 @@ export type GeneratorFeatures = {
   distinct: boolean;
   insert: boolean;
   update: boolean;
+  updateMany: boolean;
   delete: boolean;
   upsert: boolean;
 };

--- a/tests/mysql.test.ts
+++ b/tests/mysql.test.ts
@@ -26,6 +26,7 @@ import {
   type InsertResolver,
   type SelectResolver,
   type SelectSingleResolver,
+  type UpdateManyResolver,
   type UpdateResolver,
 } from '@/index';
 import * as schema from './schema/mysql';
@@ -3117,6 +3118,23 @@ describe.sequential('Returned data tests', () => {
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
+            updateUsersMany: z
+              .object({
+                args: z
+                  .object({
+                    updates: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLObjectType),
+              })
+              .strict(),
             updateUsers: z
               .object({
                 args: z
@@ -3178,6 +3196,23 @@ describe.sequential('Returned data tests', () => {
                 args: z
                   .object({
                     values: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLObjectType),
+              })
+              .strict(),
+            updatePostsMany: z
+              .object({
+                args: z
+                  .object({
+                    updates: z
                       .object({
                         type: z.instanceof(GraphQLNonNull),
                       })
@@ -3263,6 +3298,23 @@ describe.sequential('Returned data tests', () => {
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
+            updateCustomersMany: z
+              .object({
+                args: z
+                  .object({
+                    updates: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLObjectType),
+              })
+              .strict(),
             updateCustomers: z
               .object({
                 args: z
@@ -3325,16 +3377,19 @@ describe.sequential('Returned data tests', () => {
             UsersOrderBy: z.instanceof(GraphQLInputObjectType),
             CreateUsersInput: z.instanceof(GraphQLInputObjectType),
             UpdateUsersInput: z.instanceof(GraphQLInputObjectType),
+            UpdateUsersManyInput: z.instanceof(GraphQLInputObjectType),
             PostsFilters: z.instanceof(GraphQLInputObjectType),
             PostsHaving: z.instanceof(GraphQLInputObjectType),
             PostsOrderBy: z.instanceof(GraphQLInputObjectType),
             CreatePostsInput: z.instanceof(GraphQLInputObjectType),
             UpdatePostsInput: z.instanceof(GraphQLInputObjectType),
+            UpdatePostsManyInput: z.instanceof(GraphQLInputObjectType),
             CustomersFilters: z.instanceof(GraphQLInputObjectType),
             CustomersHaving: z.instanceof(GraphQLInputObjectType),
             CustomersOrderBy: z.instanceof(GraphQLInputObjectType),
             CreateCustomersInput: z.instanceof(GraphQLInputObjectType),
             UpdateCustomersInput: z.instanceof(GraphQLInputObjectType),
+            UpdateCustomersManyInput: z.instanceof(GraphQLInputObjectType),
           })
           .strict(),
         fieldResolvers: z.record(z.string(), z.record(z.string(), z.function())).optional(),
@@ -3535,6 +3590,34 @@ describe.sequential('Type tests', () => {
           resolve: UpdateResolver<typeof schema.Users, true>;
         };
       } & {
+        readonly updateCustomersMany: {
+          type: GraphQLObjectType;
+          args: {
+            updates: {
+              type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLInputObjectType>>>;
+            };
+          };
+          resolve: UpdateManyResolver<typeof schema.Customers, true>;
+        };
+        readonly updatePostsMany: {
+          type: GraphQLObjectType;
+          args: {
+            updates: {
+              type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLInputObjectType>>>;
+            };
+          };
+          resolve: UpdateManyResolver<typeof schema.Posts, true>;
+        };
+        readonly updateUsersMany: {
+          type: GraphQLObjectType;
+          args: {
+            updates: {
+              type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLInputObjectType>>>;
+            };
+          };
+          resolve: UpdateManyResolver<typeof schema.Users, true>;
+        };
+      } & {
         readonly deleteCustomers: {
           type: GraphQLObjectType;
           args: {
@@ -3590,6 +3673,10 @@ describe.sequential('Type tests', () => {
         readonly UpdateUsersInput: GraphQLInputObjectType;
         readonly UpdateCustomersInput: GraphQLInputObjectType;
         readonly UpdatePostsInput: GraphQLInputObjectType;
+      } & {
+        readonly UpdateUsersManyInput: GraphQLInputObjectType;
+        readonly UpdateCustomersManyInput: GraphQLInputObjectType;
+        readonly UpdatePostsManyInput: GraphQLInputObjectType;
       }
     >();
   });

--- a/tests/pg.test.ts
+++ b/tests/pg.test.ts
@@ -25,6 +25,7 @@ import {
   type InsertResolver,
   type SelectResolver,
   type SelectSingleResolver,
+  type UpdateManyResolver,
   type UpdateResolver,
 } from '@/index';
 import * as schema from './schema/pg';
@@ -2797,6 +2798,23 @@ describe.sequential('Returned data tests', () => {
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
+            updateUsersMany: z
+              .object({
+                args: z
+                  .object({
+                    updates: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
             updateUsers: z
               .object({
                 args: z
@@ -2870,6 +2888,23 @@ describe.sequential('Returned data tests', () => {
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
+            updatePostsMany: z
+              .object({
+                args: z
+                  .object({
+                    updates: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
             updatePosts: z
               .object({
                 args: z
@@ -2941,6 +2976,23 @@ describe.sequential('Returned data tests', () => {
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
                 type: z.instanceof(GraphQLObjectType),
+              })
+              .strict(),
+            updateCustomersMany: z
+              .object({
+                args: z
+                  .object({
+                    updates: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
             updateCustomers: z
@@ -3080,16 +3132,19 @@ describe.sequential('Returned data tests', () => {
             UsersOrderBy: z.instanceof(GraphQLInputObjectType),
             CreateUsersInput: z.instanceof(GraphQLInputObjectType),
             UpdateUsersInput: z.instanceof(GraphQLInputObjectType),
+            UpdateUsersManyInput: z.instanceof(GraphQLInputObjectType),
             PostsFilters: z.instanceof(GraphQLInputObjectType),
             PostsHaving: z.instanceof(GraphQLInputObjectType),
             PostsOrderBy: z.instanceof(GraphQLInputObjectType),
             CreatePostsInput: z.instanceof(GraphQLInputObjectType),
             UpdatePostsInput: z.instanceof(GraphQLInputObjectType),
+            UpdatePostsManyInput: z.instanceof(GraphQLInputObjectType),
             CustomersFilters: z.instanceof(GraphQLInputObjectType),
             CustomersHaving: z.instanceof(GraphQLInputObjectType),
             CustomersOrderBy: z.instanceof(GraphQLInputObjectType),
             CreateCustomersInput: z.instanceof(GraphQLInputObjectType),
             UpdateCustomersInput: z.instanceof(GraphQLInputObjectType),
+            UpdateCustomersManyInput: z.instanceof(GraphQLInputObjectType),
             TagsFilters: z.instanceof(GraphQLInputObjectType),
             TagsHaving: z.instanceof(GraphQLInputObjectType),
             TagsOrderBy: z.instanceof(GraphQLInputObjectType),
@@ -3295,6 +3350,34 @@ describe.sequential('Type tests', () => {
           resolve: UpdateResolver<typeof schema.Users, false>;
         };
       } & {
+        readonly updateCustomersMany: {
+          type: GraphQLNonNull<GraphQLList<GraphQLObjectType>>;
+          args: {
+            updates: {
+              type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLInputObjectType>>>;
+            };
+          };
+          resolve: UpdateManyResolver<typeof schema.Customers, false>;
+        };
+        readonly updatePostsMany: {
+          type: GraphQLNonNull<GraphQLList<GraphQLObjectType>>;
+          args: {
+            updates: {
+              type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLInputObjectType>>>;
+            };
+          };
+          resolve: UpdateManyResolver<typeof schema.Posts, false>;
+        };
+        readonly updateUsersMany: {
+          type: GraphQLNonNull<GraphQLList<GraphQLObjectType>>;
+          args: {
+            updates: {
+              type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLInputObjectType>>>;
+            };
+          };
+          resolve: UpdateManyResolver<typeof schema.Users, false>;
+        };
+      } & {
         readonly deleteCustomers: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
@@ -3352,6 +3435,10 @@ describe.sequential('Type tests', () => {
         readonly UpdateUsersInput: GraphQLInputObjectType;
         readonly UpdateCustomersInput: GraphQLInputObjectType;
         readonly UpdatePostsInput: GraphQLInputObjectType;
+      } & {
+        readonly UpdateUsersManyInput: GraphQLInputObjectType;
+        readonly UpdateCustomersManyInput: GraphQLInputObjectType;
+        readonly UpdatePostsManyInput: GraphQLInputObjectType;
       }
     >();
   });

--- a/tests/pglite/returned-data.test.ts
+++ b/tests/pglite/returned-data.test.ts
@@ -515,6 +515,23 @@ describe.sequential('Returned data tests', () => {
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
+            updateUsersMany: z
+              .object({
+                args: z
+                  .object({
+                    updates: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
             updateUser: z
               .object({
                 args: z
@@ -586,6 +603,23 @@ describe.sequential('Returned data tests', () => {
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
                 type: z.instanceof(GraphQLObjectType),
+              })
+              .strict(),
+            updatePostsMany: z
+              .object({
+                args: z
+                  .object({
+                    updates: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
             updatePost: z
@@ -661,6 +695,23 @@ describe.sequential('Returned data tests', () => {
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
+            updateCustomersMany: z
+              .object({
+                args: z
+                  .object({
+                    updates: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
             updateCustomer: z
               .object({
                 args: z
@@ -734,6 +785,23 @@ describe.sequential('Returned data tests', () => {
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
+            updateTagsMany: z
+              .object({
+                args: z
+                  .object({
+                    updates: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
             updateTag: z
               .object({
                 args: z
@@ -802,21 +870,25 @@ describe.sequential('Returned data tests', () => {
             UserOrderBy: z.instanceof(GraphQLInputObjectType),
             CreateUserInput: z.instanceof(GraphQLInputObjectType),
             UpdateUserInput: z.instanceof(GraphQLInputObjectType),
+            UpdateUserManyInput: z.instanceof(GraphQLInputObjectType),
             PostFilters: z.instanceof(GraphQLInputObjectType),
             PostHaving: z.instanceof(GraphQLInputObjectType),
             PostOrderBy: z.instanceof(GraphQLInputObjectType),
             CreatePostInput: z.instanceof(GraphQLInputObjectType),
             UpdatePostInput: z.instanceof(GraphQLInputObjectType),
+            UpdatePostManyInput: z.instanceof(GraphQLInputObjectType),
             CustomerFilters: z.instanceof(GraphQLInputObjectType),
             CustomerHaving: z.instanceof(GraphQLInputObjectType),
             CustomerOrderBy: z.instanceof(GraphQLInputObjectType),
             CreateCustomerInput: z.instanceof(GraphQLInputObjectType),
             UpdateCustomerInput: z.instanceof(GraphQLInputObjectType),
+            UpdateCustomerManyInput: z.instanceof(GraphQLInputObjectType),
             TagFilters: z.instanceof(GraphQLInputObjectType),
             TagHaving: z.instanceof(GraphQLInputObjectType),
             TagOrderBy: z.instanceof(GraphQLInputObjectType),
             CreateTagInput: z.instanceof(GraphQLInputObjectType),
             UpdateTagInput: z.instanceof(GraphQLInputObjectType),
+            UpdateTagManyInput: z.instanceof(GraphQLInputObjectType),
           })
           .strict(),
         fieldResolvers: z.record(z.string(), z.record(z.string(), z.function())).optional(),

--- a/tests/pglite/update-many.test.ts
+++ b/tests/pglite/update-many.test.ts
@@ -1,0 +1,246 @@
+import { PGlite } from '@electric-sql/pglite';
+import { buildRelations, sql } from 'drizzle-orm';
+import { integer, pgTable, text } from 'drizzle-orm/pg-core';
+import { drizzle } from 'drizzle-orm/pglite';
+import { type GraphQLInputObjectType, type GraphQLSchema, graphql } from 'graphql';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { buildSchema, drizzleExecutorKey } from '@/index';
+
+// `name` is NOT NULL so a `set: { name: null }` entry can force a mid-batch failure.
+const Items = pgTable('items', {
+  id: integer('id').primaryKey(),
+  name: text('name').notNull(),
+  qty: integer('qty'),
+  category: text('category'),
+});
+
+const relations = buildRelations({ Items }, { Items: {} });
+const schema = { Items, relations };
+
+const DATA_DIR = `./tests/.temp/pgdata-update-many-${Date.now()}`;
+let pglite: PGlite;
+let db: any;
+let gqlSchema: GraphQLSchema;
+
+const run = (source: string, variableValues?: Record<string, any>) =>
+  graphql({ schema: gqlSchema, source, variableValues, contextValue: {} });
+
+const items = () => db.select().from(Items).orderBy(Items.id);
+
+const UPDATE_MANY = /* GraphQL */ `
+  mutation ($updates: [UpdateItemsManyInput!]!) {
+    updateItemsMany(updates: $updates) {
+      id
+      name
+      qty
+      category
+    }
+  }
+`;
+
+beforeAll(async () => {
+  const { mkdir } = await import('node:fs/promises');
+  await mkdir(DATA_DIR, { recursive: true });
+  pglite = new PGlite(DATA_DIR);
+  await pglite.waitReady;
+  db = (drizzle as any)({ client: pglite, schema, relations, logger: !!process.env['LOG_SQL'] });
+
+  await db.execute(sql`CREATE TABLE "items" (
+		"id" integer PRIMARY KEY NOT NULL,
+		"name" text NOT NULL,
+		"qty" integer,
+		"category" text
+	);`);
+
+  gqlSchema = buildSchema(db).schema;
+});
+
+afterAll(async () => {
+  await pglite?.close().catch(console.error);
+  const { rm } = await import('node:fs/promises');
+  await rm(DATA_DIR, { recursive: true, force: true }).catch(console.error);
+});
+
+beforeEach(async () => {
+  await db.execute(sql`DELETE FROM "items"`);
+  await db.insert(Items).values([
+    { id: 1, name: 'One', qty: 1, category: 'a' },
+    { id: 2, name: 'Two', qty: 2, category: 'a' },
+    { id: 3, name: 'Three', qty: 3, category: 'b' },
+  ]);
+});
+
+describe.sequential('updateMany: generated surface', () => {
+  it('generates the mutation with the expected SDL shape', () => {
+    const field = gqlSchema.getMutationType()!.getFields()['updateItemsMany']!;
+
+    expect(field).toBeDefined();
+    expect(field.args.map((a) => a.name)).toEqual(['updates']);
+    expect(String(field.args[0]!.type)).toBe('[UpdateItemsManyInput!]!');
+    // Nullable items: an entry whose `where` matched nothing yields `null` in its slot.
+    expect(String(field.type)).toBe('[Items]!');
+  });
+
+  it('generates the entry input from the update set input and the table filters', () => {
+    const input = gqlSchema.getType('UpdateItemsManyInput') as GraphQLInputObjectType;
+    const fields = input.getFields();
+
+    expect(Object.keys(fields).sort()).toEqual(['set', 'where']);
+    expect(String(fields['set']!.type)).toBe('UpdateItemsInput!');
+    expect(String(fields['where']!.type)).toBe('ItemsFilters');
+  });
+
+  it('is switched off by its own feature flag, and off with update itself', () => {
+    const noMany = buildSchema(db, { features: { updateMany: false } }).schema;
+    expect(noMany.getMutationType()!.getFields()['updateItemsMany']).toBeUndefined();
+    expect(noMany.getType('UpdateItemsManyInput')).toBeUndefined();
+    // The single-set update is untouched.
+    expect(noMany.getMutationType()!.getFields()['updateItems']).toBeDefined();
+
+    // The batch update reuses the update set input, so update: false removes it too.
+    const noUpdate = buildSchema(db, { features: { update: false } }).schema;
+    expect(noUpdate.getMutationType()!.getFields()['updateItemsMany']).toBeUndefined();
+    expect(noUpdate.getType('UpdateItemsManyInput')).toBeUndefined();
+  });
+});
+
+describe.sequential('updateMany: behavior', () => {
+  it('applies a distinct set per entry and returns the rows in input order', async () => {
+    const result = await run(UPDATE_MANY, {
+      updates: [
+        { where: { id: { eq: 3 } }, set: { qty: 30 } },
+        { where: { id: { eq: 1 } }, set: { qty: 10, name: 'OneEdited' } },
+        { where: { id: { eq: 2 } }, set: { qty: 20 } },
+      ],
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.['updateItemsMany']).toEqual([
+      { id: 3, name: 'Three', qty: 30, category: 'b' },
+      { id: 1, name: 'OneEdited', qty: 10, category: 'a' },
+      { id: 2, name: 'Two', qty: 20, category: 'a' },
+    ]);
+
+    expect(await items()).toEqual([
+      { id: 1, name: 'OneEdited', qty: 10, category: 'a' },
+      { id: 2, name: 'Two', qty: 20, category: 'a' },
+      { id: 3, name: 'Three', qty: 30, category: 'b' },
+    ]);
+  });
+
+  it('returns null in the slot of an entry whose where matched no rows', async () => {
+    const result = await run(UPDATE_MANY, {
+      updates: [
+        { where: { id: { eq: 1 } }, set: { qty: 10 } },
+        { where: { id: { eq: 999 } }, set: { qty: 990 } },
+        { where: { id: { eq: 2 } }, set: { qty: 20 } },
+      ],
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.['updateItemsMany']).toEqual([
+      { id: 1, name: 'One', qty: 10, category: 'a' },
+      null,
+      { id: 2, name: 'Two', qty: 20, category: 'a' },
+    ]);
+  });
+
+  it('lets one entry update several rows, contributing each of them', async () => {
+    const result = await run(UPDATE_MANY, {
+      updates: [
+        { where: { category: { eq: 'a' } }, set: { qty: 100 } },
+        { where: { id: { eq: 3 } }, set: { qty: 30 } },
+      ],
+    });
+
+    expect(result.errors).toBeUndefined();
+    const rows = result.data?.['updateItemsMany'] as any[];
+    expect(rows).toHaveLength(3);
+    // The first entry's rows come first; their order within the entry is the database's.
+    expect(
+      rows
+        .slice(0, 2)
+        .map((r) => r.id)
+        .sort(),
+    ).toEqual([1, 2]);
+    expect(rows.slice(0, 2).every((r) => r.qty === 100)).toBe(true);
+    expect(rows[2]).toEqual({ id: 3, name: 'Three', qty: 30, category: 'b' });
+  });
+
+  it('applies entries matching the same row in input order', async () => {
+    const result = await run(UPDATE_MANY, {
+      updates: [
+        { where: { id: { eq: 1 } }, set: { qty: 10 } },
+        { where: { id: { eq: 1 } }, set: { name: 'OneEdited' } },
+      ],
+    });
+
+    expect(result.errors).toBeUndefined();
+    // Each slot returns the row as of its own statement, so the second slot sees the first's set.
+    expect(result.data?.['updateItemsMany']).toEqual([
+      { id: 1, name: 'One', qty: 10, category: 'a' },
+      { id: 1, name: 'OneEdited', qty: 10, category: 'a' },
+    ]);
+    expect((await items())[0]).toEqual({ id: 1, name: 'OneEdited', qty: 10, category: 'a' });
+  });
+
+  it('rolls back every entry when one of them fails', async () => {
+    const result = await run(UPDATE_MANY, {
+      updates: [
+        { where: { id: { eq: 1 } }, set: { qty: 100 } },
+        // Violates NOT NULL on name — the whole batch must fail.
+        { where: { id: { eq: 2 } }, set: { name: null } },
+      ],
+    });
+
+    expect(result.errors).toBeDefined();
+    // The first entry's update was rolled back with the failing one.
+    expect(await items()).toEqual([
+      { id: 1, name: 'One', qty: 1, category: 'a' },
+      { id: 2, name: 'Two', qty: 2, category: 'a' },
+      { id: 3, name: 'Three', qty: 3, category: 'b' },
+    ]);
+  });
+
+  it('rejects an empty batch and an entry with an empty set before touching the database', async () => {
+    const empty = await run(UPDATE_MANY, { updates: [] });
+    expect(empty.errors?.[0]?.message).toBe('No updates were provided!');
+
+    const emptySet = await run(UPDATE_MANY, {
+      updates: [
+        { where: { id: { eq: 1 } }, set: { qty: 10 } },
+        { where: { id: { eq: 2 } }, set: {} },
+      ],
+    });
+    expect(emptySet.errors?.[0]?.message).toBe('Unable to update with no values specified!');
+    // The malformed entry rejected the request before any update ran.
+    expect((await items())[0]?.qty).toBe(1);
+  });
+
+  it('runs on a caller-supplied transaction from the context', async () => {
+    await db
+      .transaction(async (tx: any) => {
+        const result = await graphql({
+          schema: gqlSchema,
+          source: UPDATE_MANY,
+          variableValues: { updates: [{ where: { id: { eq: 1 } }, set: { qty: 10 } }] },
+          contextValue: { [drizzleExecutorKey]: tx },
+        });
+
+        expect(result.errors).toBeUndefined();
+        expect((result.data?.['updateItemsMany'] as any[])[0].qty).toBe(10);
+
+        // The write is visible inside the caller's transaction...
+        const inside = await tx.select().from(Items).orderBy(Items.id);
+        expect(inside[0].qty).toBe(10);
+
+        tx.rollback();
+      })
+      .catch(() => {
+        // db.transaction rethrows the rollback — expected.
+      });
+
+    // ...and gone once the caller rolls it back: the batch's savepoint nested correctly.
+    expect((await items())[0]?.qty).toBe(1);
+  });
+});

--- a/tests/sqlite-custom.test.ts
+++ b/tests/sqlite-custom.test.ts
@@ -75,6 +75,7 @@ beforeAll(async () => {
         deleteFromCustomCustomers: entities.mutations.deleteCustomers,
         deleteFromCustomPosts: entities.mutations.deletePosts,
         updateCustomUsers: entities.mutations.updateUsers,
+        updateCustomUsersMany: entities.mutations.updateUsersMany,
         updateCustomCustomers: entities.mutations.updateCustomers,
         updateCustomPosts: entities.mutations.updatePosts,
         insertIntoCustomUsers: entities.mutations.createUsers,
@@ -1466,6 +1467,32 @@ describe.sequential('Query tests', async () => {
         ],
       },
     });
+  });
+
+  it(`Update many`, async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			mutation {
+				updateCustomUsersMany(
+					updates: [
+						{ where: { id: { eq: 2 } }, set: { name: "SecondEdited" } }
+						{ where: { id: { eq: 999 } }, set: { name: "Nobody" } }
+						{ where: { id: { eq: 5 } }, set: { name: "FifthEdited" } }
+					]
+				) {
+					id
+					name
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        updateCustomUsersMany: [{ id: 2, name: 'SecondEdited' }, null, { id: 5, name: 'FifthEdited' }],
+      },
+    });
+
+    const untouched = await ctx.db.query.Users.findFirst({ where: { id: 1 } });
+    expect(untouched?.name).toBe('FirstUser');
   });
 
   it(`Delete`, async () => {

--- a/tests/sqlite.test.ts
+++ b/tests/sqlite.test.ts
@@ -26,6 +26,7 @@ import {
   type InsertResolver,
   type SelectResolver,
   type SelectSingleResolver,
+  type UpdateManyResolver,
   type UpdateResolver,
 } from '@/index';
 import * as schema from './schema/sqlite';
@@ -2848,6 +2849,23 @@ describe.sequential('Returned data tests', () => {
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
+            updateUsersMany: z
+              .object({
+                args: z
+                  .object({
+                    updates: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
             updateUsers: z
               .object({
                 args: z
@@ -2919,6 +2937,23 @@ describe.sequential('Returned data tests', () => {
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
                 type: z.instanceof(GraphQLObjectType),
+              })
+              .strict(),
+            updatePostsMany: z
+              .object({
+                args: z
+                  .object({
+                    updates: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
             updatePosts: z
@@ -2994,6 +3029,23 @@ describe.sequential('Returned data tests', () => {
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
+            updateCustomersMany: z
+              .object({
+                args: z
+                  .object({
+                    updates: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
             updateCustomers: z
               .object({
                 args: z
@@ -3055,16 +3107,19 @@ describe.sequential('Returned data tests', () => {
             UsersOrderBy: z.instanceof(GraphQLInputObjectType),
             CreateUsersInput: z.instanceof(GraphQLInputObjectType),
             UpdateUsersInput: z.instanceof(GraphQLInputObjectType),
+            UpdateUsersManyInput: z.instanceof(GraphQLInputObjectType),
             PostsFilters: z.instanceof(GraphQLInputObjectType),
             PostsHaving: z.instanceof(GraphQLInputObjectType),
             PostsOrderBy: z.instanceof(GraphQLInputObjectType),
             CreatePostsInput: z.instanceof(GraphQLInputObjectType),
             UpdatePostsInput: z.instanceof(GraphQLInputObjectType),
+            UpdatePostsManyInput: z.instanceof(GraphQLInputObjectType),
             CustomersFilters: z.instanceof(GraphQLInputObjectType),
             CustomersHaving: z.instanceof(GraphQLInputObjectType),
             CustomersOrderBy: z.instanceof(GraphQLInputObjectType),
             CreateCustomersInput: z.instanceof(GraphQLInputObjectType),
             UpdateCustomersInput: z.instanceof(GraphQLInputObjectType),
+            UpdateCustomersManyInput: z.instanceof(GraphQLInputObjectType),
           })
           .strict(),
         fieldResolvers: z.record(z.string(), z.record(z.string(), z.function())).optional(),
@@ -3290,6 +3345,34 @@ describe.sequential('Type tests', () => {
           resolve: UpdateResolver<typeof schema.Users, false>;
         };
       } & {
+        readonly updateCustomersMany: {
+          type: GraphQLNonNull<GraphQLList<GraphQLObjectType>>;
+          args: {
+            updates: {
+              type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLInputObjectType>>>;
+            };
+          };
+          resolve: UpdateManyResolver<typeof schema.Customers, false>;
+        };
+        readonly updatePostsMany: {
+          type: GraphQLNonNull<GraphQLList<GraphQLObjectType>>;
+          args: {
+            updates: {
+              type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLInputObjectType>>>;
+            };
+          };
+          resolve: UpdateManyResolver<typeof schema.Posts, false>;
+        };
+        readonly updateUsersMany: {
+          type: GraphQLNonNull<GraphQLList<GraphQLObjectType>>;
+          args: {
+            updates: {
+              type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLInputObjectType>>>;
+            };
+          };
+          resolve: UpdateManyResolver<typeof schema.Users, false>;
+        };
+      } & {
         readonly deleteCustomers: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
@@ -3351,6 +3434,10 @@ describe.sequential('Type tests', () => {
         readonly UpdateUsersInput: GraphQLInputObjectType;
         readonly UpdateCustomersInput: GraphQLInputObjectType;
         readonly UpdatePostsInput: GraphQLInputObjectType;
+      } & {
+        readonly UpdateUsersManyInput: GraphQLInputObjectType;
+        readonly UpdateCustomersManyInput: GraphQLInputObjectType;
+        readonly UpdatePostsManyInput: GraphQLInputObjectType;
       }
     >();
   });


### PR DESCRIPTION
## Summary

Adds a batch update mutation `update<Table>Many(updates: [{ where, set }!]!)` to all three dialect builders (pg, mysql, sqlite), per #26.

```graphql
mutation {
  updateUsersMany(updates: [
    { where: { id: { eq: 1 } }, set: { name: "A" } }
    { where: { id: { eq: 2 } }, set: { name: "B" } }
  ]) { id name }
}
```

## Design

- **One transaction, N statements.** A single-statement `UPDATE ... FROM (VALUES ...)` was considered for Postgres, but drizzle's query builder has no good way to express it with heterogeneous per-entry `set` columns and arbitrary per-entry `where` filters, so the implementation uses the issue's stated acceptable minimum: one `UPDATE` per entry, in input order, inside one transaction via the dialect's transaction API.
- **Caller-supplied transactions still work.** The resolver goes through `resolveExecutor(db, context)`; when the context carries a transaction via `drizzleExecutorKey`, calling `.transaction()` on it opens a savepoint, so the batch stays atomic without breaking the outer transaction (covered by a test).
- **Input type.** A new per-entry input `Update<Type>ManyInput { where: <Type>Filters, set: Update<Type>Input! }` reuses the existing update `set` input and table filters. Because of that reuse, the feature is gated on both the new `features.updateMany` flag and `features.update` (both default `true`).
- **Field naming** follows the array-insert convention (plural when a `typeNameMapper` is present) plus an explicit `Many` suffix: `updateUsersMany`, or `update<mapped plural>Many`.
- **MySQL** stays returnless like its other mutations (`{ isSuccess: true }` / `MutationReturn`), since MySQL has no `RETURNING`.
- **sqlite sync drivers** (better-sqlite3): an async transaction callback would commit before awaited statements run, so the resolver executes each statement with `.all()` and probes the first result for a thenable to pick the sync or sequential-async path — same trick for both driver kinds, entries still applied in order.

## Semantics (consistent across dialects)

- Result type is `[Item]!` (nullable items): an entry whose `where` matched **no rows contributes `null` in its slot** (skip-and-null rather than throw), so the common one-row-per-entry case stays aligned with the input. An entry whose `where` matches several rows contributes each of its rows, in place.
- Entries execute **in input order**; a row matched by multiple entries sees them applied in order within the transaction (later sets see earlier ones).
- **Atomicity:** a failing entry rolls back the entire batch.
- Malformed requests (`updates: []`, or an entry with an empty `set`) are rejected **before** the transaction opens.
- An omitted `where` on an entry updates every row, matching the existing `update` mutation.

## Tests

- New `tests/pglite/update-many.test.ts` (serverless, direct `graphql()` calls): SDL shape of the mutation and its input, feature-flag gating, per-row sets returned in input order, null slot for no-match entries, multi-row entries, same-row-in-order application, rollback on a failing entry, pre-transaction validation errors, and caller-supplied transaction/savepoint nesting.
- `tests/sqlite-custom.test.ts`: exposes `entities.mutations.updateUsersMany` in a hand-built schema and exercises it (covers the entities/custom-resolver surface and the async sqlite path).
- Updated the strict entity-shape validations (zod + `expectTypeOf`) in `tests/sqlite.test.ts`, `tests/pg.test.ts`, `tests/mysql.test.ts`, and `tests/pglite/returned-data.test.ts` for the new mutations and inputs.

## Verification

- `npx tsc --noEmit` — clean
- `npx biome check --write .` — no new errors (remaining diagnostics pre-exist on main)
- `npx vitest run tests/pglite/ tests/sqlite.test.ts tests/sqlite-custom.test.ts` — 31 files, 409/409 passed (Docker-based pg/mysql suites not run, per instructions)

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)
