### PR TITLE
feat(query): add JSON and array column filter operators

### DIFF
--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -17,6 +17,8 @@ import type { Column, Relation, Table } from 'drizzle-orm';
 import {
   aliasedTable,
   and,
+  arrayContains,
+  arrayOverlaps,
   asc,
   desc,
   eq,
@@ -59,6 +61,7 @@ import type { ResolveTree } from 'graphql-parse-resolve-info';
 import { getOrCreateLoader } from '../batch-loader/index.ts';
 import { capitalize, uncapitalize } from '../case-ops/index.ts';
 import { remapFromGraphQLCore, remapToGraphQLArrayOutput, remapToGraphQLSingleOutput } from '../data-mappers/index.ts';
+import { GraphQLJSON } from '../scalars/index.ts';
 import { drizzleColumnToGraphQLType } from '../type-converter/index.ts';
 import type {
   ConvertedColumn,
@@ -701,46 +704,126 @@ export const innerOrder = new GraphQLInputObjectType({
   } as const,
 });
 
+/** The dialect a column belongs to, inferred from its drizzle columnType string (e.g. 'PgJsonb'). */
+const columnDialect = (column: Column): 'pg' | 'mysql' | 'sqlite' | undefined => {
+  const ct: string = (column as any).columnType ?? '';
+  if (ct.startsWith('Pg')) {
+    return 'pg';
+  }
+  if (ct.startsWith('MySql')) {
+    return 'mysql';
+  }
+  if (ct.startsWith('SQLite')) {
+    return 'sqlite';
+  }
+  return undefined;
+};
+
+/** How a column's generic filter input should be shaped, alongside the cache key to store it under. */
+interface GenericFilterDescriptor {
+  name: string;
+  kind: 'scalar' | 'json' | 'array';
+}
+
 /**
- * Maps a Drizzle column to the generic filter type name to use.
- * - "Id"          → uuid PK/FK columns (no like/ilike operators)
- * - "DateTime"    → timestamp and date columns
- * - "Boolean"     → boolean columns
+ * Maps a Drizzle column to the generic filter type to use.
+ * - "JSON"           → json/jsonb columns (eq/ne + containment, no scalar comparison ops)
+ * - `${Element}Array` → array columns, keyed per element type (IntArray, StringArray, …) so
+ *                      arrays with different element types never share one filter input
+ * - "Id"             → uuid PK/FK columns (no like/ilike operators)
+ * - "DateTime"       → timestamp and date columns
+ * - "Boolean"        → boolean columns
  * - the enum GraphQL type name → enum columns (still unique per enum)
- * - "IntArray"    → integer[]/serial[] array columns
- * - "FloatArray"  → float[]/numeric[] array columns
- * - "String"      → all other text/varchar columns
+ * - "String"         → all other text/varchar columns
  */
-const resolveGenericFilterName = (
+const resolveGenericFilterDescriptor = (
   column: Column,
   columnName: string,
   columnGraphQLType: ReturnType<typeof drizzleColumnToGraphQLType>,
-): string => {
+): GenericFilterDescriptor => {
+  // JSON / JSONB columns — structural, so they must win over the name-based Id check.
+  if (columnGraphQLType.type === GraphQLJSON) {
+    return { name: 'JSON', kind: 'json' };
+  }
+  // Array columns — keyed per element type so an int[] and a text[] column never share
+  // one cached filter input (they previously all collapsed into IntArray/FloatArray).
+  if (columnGraphQLType.type instanceof GraphQLList) {
+    let element = columnGraphQLType.type.ofType;
+    if (element instanceof GraphQLNonNull) {
+      element = element.ofType;
+    }
+    return { name: `${element.name}Array`, kind: 'array' };
+  }
   // ID / foreign-key columns
   if (columnName === 'id' || columnName.endsWith('Id')) {
-    return 'Id';
+    return { name: 'Id', kind: 'scalar' };
   }
   // Boolean scalar
   if (columnGraphQLType.type === GraphQLBoolean) {
-    return 'Boolean';
+    return { name: 'Boolean', kind: 'scalar' };
   }
   // Enum type — keep unique per enum since values differ
   if (columnGraphQLType.type instanceof GraphQLEnumType) {
-    return columnGraphQLType.type.name;
-  }
-  // Array columns — give them a distinct name so they never collide with StringFilter.
-  // integer().array() columns have a `dimensions` property set on them.
-  if (columnGraphQLType.type instanceof GraphQLList) {
-    const desc = (columnGraphQLType as any).description ?? '';
-    return desc.includes('Integer') ? 'IntArray' : 'FloatArray';
+    return { name: columnGraphQLType.type.name, kind: 'scalar' };
   }
   // Date / timestamp columns (check Drizzle internal columnType string)
   const ct: string = (column as any).columnType ?? '';
   if (ct === 'PgTimestamp' || ct === 'PgTimestampString' || ct === 'PgDate') {
-    return 'DateTime';
+    return { name: 'DateTime', kind: 'scalar' };
   }
   // Default: plain text/varchar
-  return 'String';
+  return { name: 'String', kind: 'scalar' };
+};
+
+/**
+ * Filter fields for a json/jsonb column. `eq`/`ne` compare the whole document (jsonb equality
+ * on Postgres, driver-level comparison elsewhere); `contains` is structural containment —
+ * Postgres `@>` / MySQL `JSON_CONTAINS`. SQLite stores json as text and has no containment
+ * operator, so `contains` is omitted there (same precedent as dialect-specific ops like ilike).
+ */
+const jsonFilterFields = (column: Column, colType: ReturnType<typeof drizzleColumnToGraphQLType>['type']) => {
+  const dialect = columnDialect(column);
+  return {
+    eq: { type: colType, description: 'JSON equality on the whole value' },
+    ne: { type: colType, description: 'JSON inequality on the whole value' },
+    ...(dialect === 'pg' || dialect === 'mysql'
+      ? {
+          contains: {
+            type: colType,
+            description: 'Value structurally contains this JSON (Postgres `@>` / MySQL JSON_CONTAINS)',
+          },
+        }
+      : {}),
+    isNull: { type: GraphQLBoolean },
+    isNotNull: { type: GraphQLBoolean },
+  };
+};
+
+/**
+ * Filter fields for an array column (Postgres-only in drizzle). Membership operators replace
+ * the scalar comparison set: `has` checks a single element (`@>` with a one-element array),
+ * `hasSome` is overlap (`&&`), `hasEvery` is containment (`@>`), `isEmpty` matches arrays with
+ * no elements. `eq`/`ne` still compare the whole array. The scalar filter's `inArray` operator
+ * (SQL `IN` against a list of whole-array values) was type-confused on array columns and is
+ * intentionally dropped.
+ */
+const arrayFilterFields = (colType: GraphQLList<any>, colDesc: string | undefined) => {
+  let element = colType.ofType;
+  if (element instanceof GraphQLNonNull) {
+    element = element.ofType;
+  }
+  const elementList = new GraphQLList(new GraphQLNonNull(element));
+
+  return {
+    eq: { type: colType, description: colDesc },
+    ne: { type: colType, description: colDesc },
+    has: { type: element, description: 'Array contains this element' },
+    hasSome: { type: elementList, description: 'Array contains at least one of these elements (overlap, `&&`)' },
+    hasEvery: { type: elementList, description: 'Array contains every one of these elements (containment, `@>`)' },
+    isEmpty: { type: GraphQLBoolean, description: 'When true, matches arrays with no elements' },
+    isNull: { type: GraphQLBoolean },
+    isNotNull: { type: GraphQLBoolean },
+  };
 };
 
 const generateColumnFilterValues = (
@@ -751,7 +834,7 @@ const generateColumnFilterValues = (
 ): GraphQLInputObjectType => {
   const columnGraphQLType = drizzleColumnToGraphQLType(column, columnName, tableName, true, false, true);
 
-  const genericName = resolveGenericFilterName(column, columnName, columnGraphQLType);
+  const { name: genericName, kind } = resolveGenericFilterDescriptor(column, columnName, columnGraphQLType);
   const cached = cacheCtx.genericFilterCache.get(genericName);
   if (cached) {
     return cached.main;
@@ -764,26 +847,31 @@ const generateColumnFilterValues = (
   // IdFilter omits like/notLike/ilike/notIlike — they are nonsensical on UUIDs.
   const isId = genericName === 'Id';
 
-  const baseFields = {
-    eq: { type: colType, description: colDesc },
-    ne: { type: colType, description: colDesc },
-    lt: { type: colType, description: colDesc },
-    lte: { type: colType, description: colDesc },
-    gt: { type: colType, description: colDesc },
-    gte: { type: colType, description: colDesc },
-    ...(isId
-      ? {}
-      : {
-          like: { type: GraphQLString },
-          notLike: { type: GraphQLString },
-          ilike: { type: GraphQLString },
-          notIlike: { type: GraphQLString },
-        }),
-    inArray: { type: colArr, description: `Array<${colDesc}>` },
-    notInArray: { type: colArr, description: `Array<${colDesc}>` },
-    isNull: { type: GraphQLBoolean },
-    isNotNull: { type: GraphQLBoolean },
-  };
+  const baseFields =
+    kind === 'json'
+      ? jsonFilterFields(column, colType)
+      : kind === 'array'
+        ? arrayFilterFields(colType as GraphQLList<any>, colDesc)
+        : {
+            eq: { type: colType, description: colDesc },
+            ne: { type: colType, description: colDesc },
+            lt: { type: colType, description: colDesc },
+            lte: { type: colType, description: colDesc },
+            gt: { type: colType, description: colDesc },
+            gte: { type: colType, description: colDesc },
+            ...(isId
+              ? {}
+              : {
+                  like: { type: GraphQLString },
+                  notLike: { type: GraphQLString },
+                  ilike: { type: GraphQLString },
+                  notIlike: { type: GraphQLString },
+                }),
+            inArray: { type: colArr, description: `Array<${colDesc}>` },
+            notInArray: { type: colArr, description: `Array<${colDesc}>` },
+            isNull: { type: GraphQLBoolean },
+            isNotNull: { type: GraphQLBoolean },
+          };
 
   const orType = new GraphQLInputObjectType({
     name: `${genericName}FilterOr`,
@@ -1414,6 +1502,30 @@ export const extractOrderBy = <TTable extends Table, TArgs extends OrderByArgs<a
     direction === 'asc' ? asc(getColumns(table)[column]!) : desc(getColumns(table)[column]!),
   );
 
+/**
+ * Structural JSON containment for the `contains` operator on json/jsonb columns.
+ * The value is serialized and bound as a parameter (never interpolated into the SQL text):
+ * - Postgres: `col @> $1::jsonb` (a plain `json` column is cast through jsonb — `json` has
+ *   no containment operator of its own)
+ * - MySQL: `JSON_CONTAINS(col, ?)`
+ * SQLite has no containment operator, so the filter input never exposes `contains` there;
+ * reaching this with an unsupported dialect is a programming error surfaced as a GraphQLError.
+ */
+const jsonContains = (column: Column, columnName: string, value: any): SQL => {
+  const serialized = JSON.stringify(value);
+
+  switch (columnDialect(column)) {
+    case 'pg':
+      return (column as any).columnType === 'PgJson'
+        ? sql`${column}::jsonb @> ${serialized}::jsonb`
+        : sql`${column} @> ${serialized}::jsonb`;
+    case 'mysql':
+      return sql`json_contains(${column}, ${serialized})`;
+    default:
+      throw new GraphQLError(`WHERE ${columnName}: Operator 'contains' is not supported for this dialect!`);
+  }
+};
+
 export const extractFiltersColumn = <TColumn extends Column>(
   column: TColumn,
   columnName: string,
@@ -1446,6 +1558,11 @@ export const extractFiltersColumn = <TColumn extends Column>(
   const singleValueOps: Record<string, (...args: any[]) => SQL> = { eq, ne, gt, gte, lt, lte };
   const stringValueOps: Record<string, (...args: any[]) => SQL> = { like, notLike, ilike, notIlike };
   const arrayValueOps: Record<string, (...args: any[]) => SQL> = { inArray, notInArray };
+  // Membership operators for array columns: element list → SQL. Empty lists are rejected below.
+  const arrayMembershipOps: Record<string, (...args: any[]) => SQL> = {
+    hasSome: arrayOverlaps,
+    hasEvery: arrayContains,
+  };
   const nullableOps: Record<string, (...args: any[]) => SQL> = { isNull, isNotNull };
 
   const variants = [] as SQL[];
@@ -1465,6 +1582,18 @@ export const extractFiltersColumn = <TColumn extends Column>(
       }
       const arrayValue = (operatorValue as any[]).map((val) => remapFromGraphQLCore(val, column, columnName));
       variants.push(arrayValueOps[operatorName]!(column, arrayValue));
+    } else if (operatorName === 'has') {
+      // Single-element membership: containment with a one-element array (`col @> ARRAY[value]`).
+      variants.push(arrayContains(column, [operatorValue]));
+    } else if (operatorName in arrayMembershipOps) {
+      if (!(operatorValue as any[]).length) {
+        throw new GraphQLError(`WHERE ${columnName}: Unable to use operator ${operatorName} with an empty array!`);
+      }
+      variants.push(arrayMembershipOps[operatorName]!(column, operatorValue as any[]));
+    } else if (operatorName === 'isEmpty') {
+      variants.push(sql`cardinality(${column}) = 0`);
+    } else if (operatorName === 'contains') {
+      variants.push(jsonContains(column, columnName, operatorValue));
     } else if (operatorName in nullableOps) {
       variants.push(nullableOps[operatorName]!(column));
     }

--- a/src/util/builders/types.ts
+++ b/src/util/builders/types.ts
@@ -258,6 +258,16 @@ export type FilterColumnOperatorsCore<TColumn extends Column, TColType = GetColu
   notIlike: string;
   inArray: Array<TColType>;
   notInArray: Array<TColType>;
+  /** JSON columns only: structural containment (Postgres `@>` / MySQL JSON_CONTAINS). */
+  contains: TColType;
+  /** Array columns only: the array contains this element. */
+  has: TColType extends Array<infer TElement> ? TElement : never;
+  /** Array columns only: the array overlaps these elements (`&&`). */
+  hasSome: TColType extends Array<infer TElement> ? Array<TElement> : never;
+  /** Array columns only: the array contains all of these elements (`@>`). */
+  hasEvery: TColType extends Array<infer TElement> ? Array<TElement> : never;
+  /** Array columns only: when true, matches arrays with no elements. */
+  isEmpty: boolean;
   isNull: boolean;
   isNotNull: boolean;
 }>;

--- a/src/util/type-converter/index.ts
+++ b/src/util/type-converter/index.ts
@@ -67,6 +67,34 @@ const columnToGraphQLCore = (
   tableName: string,
   isInput: boolean,
 ): ConvertedColumn<boolean> => {
+  // drizzle-orm v1 models `.array()` columns as their base column plus a `dimensions` count
+  // (e.g. text().array() keeps columnType=PgText with dimensions=1), so the element type is
+  // whatever the base column maps to. PgVector/PgGeometry report dimensions of 0 and keep
+  // their dedicated handling below.
+  const dimensions = (column as any).dimensions as number | undefined;
+  if (dimensions !== undefined && dimensions > 0) {
+    const inner = columnBaseToGraphQLCore(column, columnName, tableName, isInput);
+    const innerDesc = inner.description ?? (inner.type as GraphQLScalarType).name;
+
+    let type: ConvertedColumn<boolean>['type'] = inner.type;
+    let description = innerDesc;
+    for (let i = 0; i < dimensions; i++) {
+      type = new GraphQLList(new GraphQLNonNull(type as GraphQLScalarType));
+      description = `Array<${description}>`;
+    }
+
+    return { type, description };
+  }
+
+  return columnBaseToGraphQLCore(column, columnName, tableName, isInput);
+};
+
+const columnBaseToGraphQLCore = (
+  column: Column,
+  columnName: string,
+  tableName: string,
+  isInput: boolean,
+): ConvertedColumn<boolean> => {
   const { type: baseType } = extractExtendedColumnType(column);
   switch (baseType) {
     case 'boolean':
@@ -107,18 +135,6 @@ const columnToGraphQLCore = (
     case 'bigint':
       return { type: GraphQLBigIntString, description: 'BigInt' };
     case 'number': {
-      // integer().array() columns keep columnType=PgInteger but gain a `dimensions` property.
-      // drizzle-orm's extractExtendedColumnType still returns 'number' for them, so we
-      // detect the array wrapper here and recurse with a synthetic base-int scalar.
-      const dims = (column as any).dimensions as number | undefined;
-      if (dims !== undefined && dims > 0) {
-        const baseDesc = is(column, PgInteger) || is(column, PgSerial) ? 'Integer' : 'Float';
-        const baseType = baseDesc === 'Integer' ? GraphQLInt : GraphQLFloat;
-        return {
-          type: new GraphQLList(new GraphQLNonNull(baseType)),
-          description: `Array<${baseDesc}>`,
-        };
-      }
       return is(column, PgInteger) ||
         is(column, PgSerial) ||
         is(column, MySqlInt) ||

--- a/tests/pglite/json-array-filters.test.ts
+++ b/tests/pglite/json-array-filters.test.ts
@@ -1,0 +1,200 @@
+import { mkdir, rm } from 'node:fs/promises';
+import { PGlite } from '@electric-sql/pglite';
+import { buildRelations, sql } from 'drizzle-orm';
+import { integer, jsonb, pgTable, serial, text } from 'drizzle-orm/pg-core';
+import { drizzle } from 'drizzle-orm/pglite';
+import { type GraphQLInputObjectType, type GraphQLSchema, graphql } from 'graphql';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildSchema } from '@/index';
+
+// ── Schema covering json + int/text array columns ────────────────────────────
+const Items = pgTable('items', {
+  id: serial('id').primaryKey(),
+  meta: jsonb('meta'),
+  nums: integer('nums').array(),
+  labels: text('labels').array(),
+});
+const relations = buildRelations({ Items }, {});
+const schema = { Items, relations };
+
+const DATA_DIR = `./tests/.temp/pgdata-json-array-filters-${Date.now()}`;
+
+let pglite: PGlite;
+let db: any;
+let gqlSchema: GraphQLSchema;
+
+const run = (source: string, variableValues?: Record<string, any>) =>
+  graphql({ schema: gqlSchema, source, contextValue: {}, variableValues });
+
+const filterFieldNames = (typeName: string): string[] =>
+  Object.keys((gqlSchema.getType(typeName) as GraphQLInputObjectType).getFields()).sort();
+
+const filterFieldType = (typeName: string, fieldName: string): string =>
+  String((gqlSchema.getType(typeName) as GraphQLInputObjectType).getFields()[fieldName]!.type);
+
+const ids = async (where: string): Promise<number[]> => {
+  const res = await run(`{ items(where: ${where}, orderBy: { id: { direction: asc, priority: 1 } }) { id } }`);
+  expect(res.errors).toBeUndefined();
+  return (res.data as any).items.map((row: any) => row.id);
+};
+
+beforeAll(async () => {
+  await mkdir(DATA_DIR, { recursive: true });
+  pglite = new PGlite(DATA_DIR);
+  await pglite.waitReady;
+  db = (drizzle as any)({ client: pglite, schema, relations, logger: !!process.env['LOG_SQL'] });
+
+  await db.execute(
+    sql`CREATE TABLE "items" (
+      "id" serial PRIMARY KEY NOT NULL,
+      "meta" jsonb,
+      "nums" integer[],
+      "labels" text[]
+    );`,
+  );
+
+  await db.insert(Items).values([
+    {
+      id: 1,
+      meta: { tags: ['a'], profile: { role: 'admin', level: 3 } },
+      nums: [1, 2, 3],
+      labels: ['red', 'blue'],
+    },
+    { id: 2, meta: { profile: { role: 'user' } }, nums: [3, 4, 5], labels: ['blue', 'green'] },
+    { id: 3, meta: null, nums: [], labels: [] },
+    { id: 4, meta: { plain: true }, nums: null, labels: null },
+  ]);
+
+  gqlSchema = buildSchema(db).schema;
+});
+
+afterAll(async () => {
+  await pglite?.close().catch(() => {});
+  await rm(DATA_DIR, { recursive: true, force: true }).catch(() => {});
+});
+
+describe.sequential('filter input shape', () => {
+  it('gives json columns a JSONFilter with eq/ne/contains and no scalar string ops', () => {
+    expect(filterFieldNames('JSONFilter')).toStrictEqual(['OR', 'contains', 'eq', 'isNotNull', 'isNull', 'ne']);
+    expect(filterFieldType('JSONFilter', 'eq')).toBe('JSON');
+    expect(filterFieldType('JSONFilter', 'contains')).toBe('JSON');
+  });
+
+  it('gives int array columns membership operators instead of scalar operators', () => {
+    expect(filterFieldNames('IntArrayFilter')).toStrictEqual([
+      'OR',
+      'eq',
+      'has',
+      'hasEvery',
+      'hasSome',
+      'isEmpty',
+      'isNotNull',
+      'isNull',
+      'ne',
+    ]);
+    expect(filterFieldType('IntArrayFilter', 'eq')).toBe('[Int!]');
+    expect(filterFieldType('IntArrayFilter', 'has')).toBe('Int');
+    expect(filterFieldType('IntArrayFilter', 'hasSome')).toBe('[Int!]');
+    expect(filterFieldType('IntArrayFilter', 'hasEvery')).toBe('[Int!]');
+    expect(filterFieldType('IntArrayFilter', 'isEmpty')).toBe('Boolean');
+  });
+
+  it('keys array filters per element type — text arrays get their own StringArrayFilter', () => {
+    expect(filterFieldType('StringArrayFilter', 'has')).toBe('String');
+    expect(filterFieldType('StringArrayFilter', 'hasSome')).toBe('[String!]');
+
+    const itemsFilters = (gqlSchema.getType('ItemsFilters') as GraphQLInputObjectType).getFields();
+    expect(String(itemsFilters['nums']!.type)).toBe('IntArrayFilter');
+    expect(String(itemsFilters['labels']!.type)).toBe('StringArrayFilter');
+    expect(String(itemsFilters['meta']!.type)).toBe('JSONFilter');
+  });
+
+  it('rejects the removed type-confused operators on json and array columns', async () => {
+    for (const where of ['{ meta: { like: "x" } }', '{ nums: { inArray: [1] } }', '{ nums: { lt: [1] } }']) {
+      const res = await run(`{ items(where: ${where}) { id } }`);
+      expect(res.errors?.[0]?.message).toMatch(/is not defined by type/);
+    }
+  });
+});
+
+describe.sequential('JSON filters', () => {
+  it('eq matches the whole document with jsonb semantics (key order does not matter)', async () => {
+    await expect(ids(`{ meta: { eq: { profile: { level: 3, role: "admin" }, tags: ["a"] } } }`)).resolves.toStrictEqual(
+      [1],
+    );
+  });
+
+  it('eq does not match a partial document', async () => {
+    await expect(ids(`{ meta: { eq: { profile: { role: "admin" } } } }`)).resolves.toStrictEqual([]);
+  });
+
+  it('contains matches nested containment', async () => {
+    await expect(ids(`{ meta: { contains: { profile: { role: "admin" } } } }`)).resolves.toStrictEqual([1]);
+    await expect(ids(`{ meta: { contains: { profile: {} } } }`)).resolves.toStrictEqual([1, 2]);
+  });
+
+  it('contains matches a top-level key/value pair', async () => {
+    await expect(ids(`{ meta: { contains: { plain: true } } }`)).resolves.toStrictEqual([4]);
+  });
+
+  it('contains accepts the value through a variable', async () => {
+    const res = await run(
+      `query ($where: ItemsFilters) {
+        items(where: $where, orderBy: { id: { direction: asc, priority: 1 } }) { id }
+      }`,
+      { where: { meta: { contains: { tags: ['a'] } } } },
+    );
+    expect(res.errors).toBeUndefined();
+    expect((res.data as any).items.map((row: any) => row.id)).toStrictEqual([1]);
+  });
+
+  it('isNull / isNotNull still work on json columns', async () => {
+    await expect(ids(`{ meta: { isNull: true } }`)).resolves.toStrictEqual([3]);
+    await expect(ids(`{ meta: { isNotNull: true } }`)).resolves.toStrictEqual([1, 2, 4]);
+  });
+});
+
+describe.sequential('array filters', () => {
+  it('has matches single-element membership on int and text arrays', async () => {
+    await expect(ids(`{ nums: { has: 3 } }`)).resolves.toStrictEqual([1, 2]);
+    await expect(ids(`{ nums: { has: 1 } }`)).resolves.toStrictEqual([1]);
+    await expect(ids(`{ labels: { has: "blue" } }`)).resolves.toStrictEqual([1, 2]);
+    await expect(ids(`{ labels: { has: "purple" } }`)).resolves.toStrictEqual([]);
+  });
+
+  it('hasSome matches overlap', async () => {
+    await expect(ids(`{ nums: { hasSome: [1, 5] } }`)).resolves.toStrictEqual([1, 2]);
+    await expect(ids(`{ labels: { hasSome: ["green", "purple"] } }`)).resolves.toStrictEqual([2]);
+  });
+
+  it('hasEvery matches containment of all elements', async () => {
+    await expect(ids(`{ nums: { hasEvery: [1, 2] } }`)).resolves.toStrictEqual([1]);
+    await expect(ids(`{ nums: { hasEvery: [3] } }`)).resolves.toStrictEqual([1, 2]);
+    await expect(ids(`{ labels: { hasEvery: ["blue", "green"] } }`)).resolves.toStrictEqual([2]);
+  });
+
+  it('isEmpty matches empty (but not null) arrays', async () => {
+    await expect(ids(`{ nums: { isEmpty: true } }`)).resolves.toStrictEqual([3]);
+    await expect(ids(`{ labels: { isEmpty: true } }`)).resolves.toStrictEqual([3]);
+  });
+
+  it('eq still compares the whole array', async () => {
+    await expect(ids(`{ nums: { eq: [1, 2, 3] } }`)).resolves.toStrictEqual([1]);
+    await expect(ids(`{ nums: { eq: [3, 2, 1] } }`)).resolves.toStrictEqual([]);
+  });
+
+  it('isNull matches missing arrays', async () => {
+    await expect(ids(`{ nums: { isNull: true } }`)).resolves.toStrictEqual([4]);
+  });
+
+  it('membership operators combine with other filters', async () => {
+    await expect(ids(`{ nums: { has: 3 }, labels: { has: "green" } }`)).resolves.toStrictEqual([2]);
+  });
+
+  it('rejects hasSome / hasEvery with an empty list', async () => {
+    for (const op of ['hasSome', 'hasEvery']) {
+      const res = await run(`{ items(where: { nums: { ${op}: [] } }) { id } }`);
+      expect(res.errors?.[0]?.message).toMatch(/empty array/);
+    }
+  });
+});


### PR DESCRIPTION
Closes #27

## What

Two column families were getting filter surfaces that didn't match their semantics. This PR gives each its own generic filter input and wires up the runtime operators.

### JSON / JSONB columns → new `JSONFilter`

`resolveGenericFilterName` had no branch for json columns, so they fell through to the generic `String` filter — `eq`/`like`/etc. typed as `String` against jsonb. They now get a dedicated `JSON` generic filter, typed with the `JSON` scalar the column value already uses:

- `eq` / `ne` — whole-document equality (jsonb semantic equality on Postgres: key order insensitive)
- `contains` — structural containment, parameter-bound: Postgres `col @> $1::jsonb` (a plain `json` column is cast through `jsonb`, since `json` has no containment operator), MySQL `JSON_CONTAINS(col, ?)`
- `isNull` / `isNotNull`

**Dialect decisions:** SQLite stores json as text and has no containment operator, so `contains` is omitted from the filter input there (a missing field is a clean GraphQL validation error — same precedent as other dialect-specific operator differences). SQLite keeps `eq`/`ne`, which compare the serialized text. The scalar string/comparison operators (`like`, `lt`, `inArray`, …) are gone from json filters on every dialect.

### Array columns → membership operators, keyed per element type

Array columns (Postgres-only in drizzle) previously got the scalar operator set. The array generic filters now contain:

- `has: T` — element membership, `col @> ARRAY[value]` via drizzle's `arrayContains` with a one-element array
- `hasSome: [T!]` — overlap, `&&` via `arrayOverlaps`
- `hasEvery: [T!]` — containment, `@>` via `arrayContains`
- `isEmpty: Boolean` — `cardinality(col) = 0` when `true`
- `eq` / `ne` on the whole array, plus `isNull` / `isNotNull`

All values are bound as parameters (drizzle operators / sql templates) — no string interpolation. Empty `hasSome`/`hasEvery` lists are rejected with a `GraphQLError`, matching the existing `inArray` behavior.

**Removed:** `inArray`/`notInArray` on array columns (SQL `IN` over a list of whole-array values — the type-confused no-op flagged in the issue) and the scalar comparison/string operators (`lt`, `like`, `ilike`, …).

### Generic filter cache keying (and the type-converter fix it needed)

Array filters are now cached per element type — `IntArrayFilter`, `StringArrayFilter`, `BooleanArrayFilter`, … — instead of every non-int array collapsing into `FloatArray` (the separately-filed naming bug). Getting this right surfaced a type-converter gap: drizzle-orm v1 models `.array()` columns as their **base** column plus a `dimensions` count, and only the `number` case handled it — `text().array()`, `boolean().array()`, `uuid().array()` were typed as bare scalars everywhere (output, inputs, and filters). The `dimensions` wrapper is now applied for every base type, once per dimension, with `PgVector`/`PgGeometry` (which report `dimensions: 0`) keeping their dedicated handling.

## Tests

New PGlite suite `tests/pglite/json-array-filters.test.ts` (no server/port needed — direct `graphql()` execution): SDL shape of `JSONFilter`/`IntArrayFilter`/`StringArrayFilter` (including that removed operators fail validation), jsonb `eq` semantic equality and nested `contains`, `has`/`hasSome`/`hasEvery`/`isEmpty` on int and text arrays, null/empty-array distinctions, and empty-list rejection.

- `npx tsc --noEmit` — clean
- `npx biome check` — no new findings on touched files
- `npx vitest run tests/pglite/ tests/sqlite.test.ts tests/sqlite-custom.test.ts` — 416 passed (31 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)