### PR TITLE
feat(mutations): add updateSingle/deleteSingle variants and requireWhere option

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,10 @@ const { schema } = buildSchema(db, {
         relationAggregates: false, // <relation>Aggregate fields on object types
         distinct: false,          // the `distinct` argument on list queries
         insert: false,            // create<Table> / create<Table>Single mutations
-        update: false,            // update<Table> mutations
-        delete: false,            // delete<Table> mutations
+        update: false,            // update<Table> / update<Table>Single mutations
+        delete: false,            // delete<Table> / delete<Table>Single mutations
         upsert: true,             // upsert<Table> / upsert<Table>Single mutations (off by default)
+        requireWhere: true,       // make `where` non-null on plural update/delete (off by default)
     },
 })
 ```
@@ -464,6 +465,37 @@ Dialect differences:
 The build-wide `conflictDoNothing` option is deprecated in favour of this: it applies to every
 `create*` mutation with no way for a request to opt out. `onConflict: { action: NOTHING }` is
 the per-request replacement.
+
+## Single-row update & delete
+
+Alongside the plural `update<Table>` / `delete<Table>` mutations, every table gets an
+`update<Table>Single` / `delete<Table>Single` variant that targets exactly one row:
+
+```graphql
+mutation {
+    updateUsersSingle(where: { id: { eq: 1 } }, set: { name: "Dan" }) {
+        id
+        name
+    }
+}
+```
+
+-   `where` is **non-null** and must contain at least one filter — `where: {}` is rejected at
+    resolve time, so a Single write can never become an unbounded one
+-   The return type is the single (nullable) row type, not a list: the affected row comes back
+    directly, and **no match returns `null`** instead of an empty list
+-   If `where` matches **more than one row**, the mutation throws a `GraphQLError` and writes
+    nothing — the match is checked (`LIMIT 2`) before the write runs
+-   **MySQL** cannot return the affected row (no `RETURNING`), so its Single variants keep the
+    single-match and non-empty-`where` guarantees but return `MutationReturn` like every other
+    MySQL mutation
+-   The variants are generated under `features.update` / `features.delete`, share the plural
+    mutations' input types, and appear in `entities.mutations` for custom schemas
+
+The plural mutations still accept a missing `where` (a full-table write) by default. To rule
+that out at the type level, `features: { requireWhere: true }` makes `where` non-null on
+`update<Table>` / `delete<Table>` and rejects a `where` with no filters, exactly like the
+Single variants. It defaults to `false` for backwards compatibility.
 
 ## Query cost
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export type {
   BuildSchemaConfig,
   ComplexityConfig,
   DeleteResolver,
+  DeleteSingleResolver,
   ExtractRelations,
   ExtractTableByName,
   ExtractTableRelations,
@@ -37,6 +38,7 @@ export type {
   SelectResolver,
   SelectSingleResolver,
   UpdateResolver,
+  UpdateSingleResolver,
   UpsertArgs,
   UpsertArrResolver,
   UpsertConflictArgs,
@@ -110,6 +112,7 @@ export const buildSchema = <TDbClient extends AnyDrizzleDB<any>>(
     update: config?.features?.update ?? true,
     delete: config?.features?.delete ?? true,
     upsert: config?.features?.upsert ?? false,
+    requireWhere: config?.features?.requireWhere ?? false,
   };
 
   // Cost hints are inert without a complexity rule installed, so they are generated unless the

--- a/src/types.ts
+++ b/src/types.ts
@@ -121,6 +121,17 @@ export type DeleteArgs<TTable extends Table> = {
   where?: Filters<TTable>;
 };
 
+/** Arguments of `update<Table>Single` — unlike the plural variant, `where` is required. */
+export type UpdateSingleArgs<TTable extends Table> = {
+  set: GetRemappedTableUpdateDataType<TTable>;
+  where: Filters<TTable>;
+};
+
+/** Arguments of `delete<Table>Single` — unlike the plural variant, `where` is required. */
+export type DeleteSingleArgs<TTable extends Table> = {
+  where: Filters<TTable>;
+};
+
 export type SelectResolver<
   TTable extends Table,
   TTables extends Record<string, Table>,
@@ -209,6 +220,17 @@ export type UpdateResolver<TTable extends Table, IsReturnless extends boolean> =
   info: GraphQLResolveInfo,
 ) => Promise<IsReturnless extends false ? GetRemappedTableDataType<TTable> | undefined : MutationReturnlessResult>;
 
+/**
+ * Resolver for `update<Table>Single`: `where` required, the single (nullable) affected row
+ * out. Throws before writing anything when `where` matches more than one row.
+ */
+export type UpdateSingleResolver<TTable extends Table, IsReturnless extends boolean> = (
+  source: any,
+  args: UpdateSingleArgs<TTable>,
+  context: any,
+  info: GraphQLResolveInfo,
+) => Promise<IsReturnless extends false ? GetRemappedTableDataType<TTable> | undefined : MutationReturnlessResult>;
+
 /** Resolver for `upsert<Table>Single`. */
 export type UpsertResolver<TTable extends Table, IsReturnless extends boolean> = (
   source: any,
@@ -240,6 +262,17 @@ export type AggregateResolver<TTable extends Table> = (
 export type DeleteResolver<TTable extends Table, IsReturnless extends boolean> = (
   source: any,
   args: DeleteArgs<TTable>,
+  context: any,
+  info: GraphQLResolveInfo,
+) => Promise<IsReturnless extends false ? GetRemappedTableDataType<TTable> | undefined : MutationReturnlessResult>;
+
+/**
+ * Resolver for `delete<Table>Single`: `where` required, the single (nullable) deleted row
+ * out. Throws before writing anything when `where` matches more than one row.
+ */
+export type DeleteSingleResolver<TTable extends Table, IsReturnless extends boolean> = (
+  source: any,
+  args: DeleteSingleArgs<TTable>,
   context: any,
   info: GraphQLResolveInfo,
 ) => Promise<IsReturnless extends false ? GetRemappedTableDataType<TTable> | undefined : MutationReturnlessResult>;
@@ -433,6 +466,31 @@ export type MutationsCore<
       }
     : never;
 } & {
+  [TName in keyof TSchemaTables as TName extends string
+    ? `update${Capitalize<TName>}Single`
+    : never]: TName extends string
+    ? {
+        type: IsReturnless extends true
+          ? TOutputs['MutationReturn'] extends GraphQLObjectType
+            ? TOutputs['MutationReturn']
+            : never
+          : TOutputs[`${Capitalize<TName>}Item`];
+        args: {
+          set: {
+            type: GraphQLNonNull<TInputs[`${Capitalize<TName>}UpdateInput`]>;
+          };
+          where: {
+            type: GraphQLNonNull<
+              TInputs[`${Capitalize<TName>}Filters`] extends GraphQLInputObjectType
+                ? TInputs[`${Capitalize<TName>}Filters`]
+                : never
+            >;
+          };
+        };
+        resolve: UpdateSingleResolver<TSchemaTables[TName], IsReturnless>;
+      }
+    : never;
+} & {
   [TName in keyof TSchemaTables as TName extends string ? `delete${Capitalize<TName>}` : never]: TName extends string
     ? {
         type: IsReturnless extends true
@@ -448,6 +506,28 @@ export type MutationsCore<
           };
         };
         resolve: DeleteResolver<TSchemaTables[TName], IsReturnless>;
+      }
+    : never;
+} & {
+  [TName in keyof TSchemaTables as TName extends string
+    ? `delete${Capitalize<TName>}Single`
+    : never]: TName extends string
+    ? {
+        type: IsReturnless extends true
+          ? TOutputs['MutationReturn'] extends GraphQLObjectType
+            ? TOutputs['MutationReturn']
+            : never
+          : TOutputs[`${Capitalize<TName>}Item`];
+        args: {
+          where: {
+            type: GraphQLNonNull<
+              TInputs[`${Capitalize<TName>}Filters`] extends GraphQLInputObjectType
+                ? TInputs[`${Capitalize<TName>}Filters`]
+                : never
+            >;
+          };
+        };
+        resolve: DeleteSingleResolver<TSchemaTables[TName], IsReturnless>;
       }
     : never;
 };
@@ -533,9 +613,9 @@ export type SchemaFeatures = {
   distinct?: boolean;
   /** `create<Table>` / `create<Table>Single` mutations. @default true */
   insert?: boolean;
-  /** `update<Table>` mutations. @default true */
+  /** `update<Table>` / `update<Table>Single` mutations. @default true */
   update?: boolean;
-  /** `delete<Table>` mutations. @default true */
+  /** `delete<Table>` / `delete<Table>Single` mutations. @default true */
   delete?: boolean;
   /**
    * `upsert<Table>` / `upsert<Table>Single` mutations — insert, or update the row that
@@ -545,6 +625,17 @@ export type SchemaFeatures = {
    * @default false
    */
   upsert?: boolean;
+  /**
+   * Makes `where` non-null on the plural `update<Table>` / `delete<Table>` mutations, and
+   * rejects a `where` that collapses to no filters (e.g. `where: {}`), so a schema can rule
+   * out unbounded writes at the type level. Off by default for backwards compatibility.
+   *
+   * The `Single` variants (`update<Table>Single` / `delete<Table>Single`) require a
+   * non-empty `where` regardless of this flag.
+   *
+   * @default false
+   */
+  requireWhere?: boolean;
 };
 
 /**

--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -2449,7 +2449,9 @@ export const computeResolverFieldNames = (
   upsertArrayFieldName: string;
   upsertSingleFieldName: string;
   updateFieldName: string;
+  updateSingleFieldName: string;
   deleteFieldName: string;
+  deleteSingleFieldName: string;
 } => {
   const mapped = typeNameMapper?.(tableName);
   const typeName = mapped ? capitalize(mapped.singular) : capitalize(tableName);
@@ -2468,6 +2470,13 @@ export const computeResolverFieldNames = (
     : `${upsertPrefix}${capitalize(tableName)}${suffixes.single}`;
   const updateFieldName = `${prefixes.update}${mapped ? capitalize(mapped.singular) : capitalize(tableName)}`;
   const deleteFieldName = `${prefixes.delete}${mapped ? capitalize(mapped.singular) : capitalize(tableName)}`;
+  // The plural update/delete mutations already use the singular noun when a mapper is
+  // present, so — unlike create — the Single variants can't rely on singular vs plural to
+  // stay distinct. They always carry a suffix, falling back to 'Single' when the configured
+  // suffix is empty (a mapper config may set it to '' for the query side).
+  const writeSingleSuffix = suffixes.single === '' ? 'Single' : suffixes.single;
+  const updateSingleFieldName = `${updateFieldName}${writeSingleSuffix}`;
+  const deleteSingleFieldName = `${deleteFieldName}${writeSingleSuffix}`;
   return {
     typeName,
     listFieldName,
@@ -2479,8 +2488,47 @@ export const computeResolverFieldNames = (
     upsertArrayFieldName,
     upsertSingleFieldName,
     updateFieldName,
+    updateSingleFieldName,
     deleteFieldName,
+    deleteSingleFieldName,
   };
+};
+
+/**
+ * Extracts a `where` argument that a mutation refuses to run without: missing, or present
+ * but matching every row (e.g. `where: {}` or filters that all collapse to nothing), both
+ * throw instead of becoming an unbounded write. Used by the `Single` write variants always
+ * and by the plural update/delete mutations when `features.requireWhere` is on.
+ */
+export const extractRequiredFilters = <TTable extends Table>(
+  table: TTable,
+  tableName: string,
+  where: Filters<TTable> | undefined,
+  fieldName: string,
+  relationCtx?: RelationFilterContext,
+): SQL => {
+  const filters = where ? extractFilters(table, tableName, where, relationCtx) : undefined;
+  if (!filters) {
+    throw new GraphQLError(`${fieldName} requires a 'where' argument with at least one filter!`);
+  }
+  return filters;
+};
+
+/**
+ * Guard for the `Single` write variants: throws before anything is written when `where`
+ * matches more than one row, so a multi-row update/delete never executes. Probed with a
+ * `LIMIT 2` select rather than a count so the check stays cheap on large matches.
+ */
+export const assertSingleMatch = async (
+  executor: any,
+  table: Table,
+  filters: SQL,
+  fieldName: string,
+): Promise<void> => {
+  const matched = await executor.select({ found: sql`1` }).from(table).where(filters).limit(2);
+  if (matched.length > 1) {
+    throw new GraphQLError(`${fieldName}: 'where' matched more than one row — nothing was written!`);
+  }
 };
 
 /** GraphQL argument map for a list/array select field. */

--- a/src/util/builders/mysql.ts
+++ b/src/util/builders/mysql.ts
@@ -17,11 +17,13 @@ import { parseResolveInfo } from 'graphql-parse-resolve-info';
 import type { GeneratedEntities } from '../../types.ts';
 import {
   aggregateFieldComplexity,
+  assertSingleMatch,
   attachTargetPrimaryKeys,
   buildNamedRelations,
   computeResolverFieldNames,
   createRelationResolverFactory,
   extractFilters,
+  extractRequiredFilters,
   generateDistinctEnum,
   generateOnConflictInput,
   generateTableTypes,
@@ -312,6 +314,8 @@ const generateUpdate = (
   setArgs: GraphQLInputObjectType,
   filterArgs: GraphQLInputObjectType,
   fieldName: string,
+  single: boolean,
+  requireWhere: boolean,
   filterCtx?: RelationFilterBase,
 ): CreatedResolver => {
   const queryArgs = {
@@ -319,7 +323,7 @@ const generateUpdate = (
       type: new GraphQLNonNull(setArgs),
     },
     where: {
-      type: filterArgs,
+      type: single || requireWhere ? new GraphQLNonNull(filterArgs) : filterArgs,
     },
   } as const satisfies GraphQLFieldConfigArgumentMap;
 
@@ -334,10 +338,21 @@ const generateUpdate = (
           throw new GraphQLError('Unable to update with no values specified!');
         }
 
+        const relationCtx = relationFilterCtx(filterCtx, tableName);
+        const filters =
+          single || requireWhere
+            ? extractRequiredFilters(table, tableName, where, fieldName, relationCtx)
+            : where
+              ? extractFilters(table, tableName, where, relationCtx)
+              : undefined;
+
         const executor = resolveExecutor(db, context);
+        if (single) {
+          await assertSingleMatch(executor, table, filters!, fieldName);
+        }
+
         let query = executor.update(table).set(input);
-        if (where) {
-          const filters = extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName));
+        if (filters) {
           query = query.where(filters) as any;
         }
 
@@ -358,11 +373,13 @@ const generateDelete = (
   table: MySqlTable,
   filterArgs: GraphQLInputObjectType,
   fieldName: string,
+  single: boolean,
+  requireWhere: boolean,
   filterCtx?: RelationFilterBase,
 ): CreatedResolver => {
   const queryArgs = {
     where: {
-      type: filterArgs,
+      type: single || requireWhere ? new GraphQLNonNull(filterArgs) : filterArgs,
     },
   } as const satisfies GraphQLFieldConfigArgumentMap;
 
@@ -372,10 +389,21 @@ const generateDelete = (
       try {
         const { where } = args;
 
+        const relationCtx = relationFilterCtx(filterCtx, tableName);
+        const filters =
+          single || requireWhere
+            ? extractRequiredFilters(table, tableName, where, fieldName, relationCtx)
+            : where
+              ? extractFilters(table, tableName, where, relationCtx)
+              : undefined;
+
         const executor = resolveExecutor(db, context);
+        if (single) {
+          await assertSingleMatch(executor, table, filters!, fieldName);
+        }
+
         let query = executor.delete(table);
-        if (where) {
-          const filters = extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName));
+        if (filters) {
           query = query.where(filters) as any;
         }
 
@@ -503,7 +531,9 @@ export const generateSchemaData = <
       upsertArrayFieldName,
       upsertSingleFieldName,
       updateFieldName,
+      updateSingleFieldName,
       deleteFieldName,
+      deleteSingleFieldName,
     } = computeResolverFieldNames(tableName, typeNameMapper, prefixes, suffixes);
 
     const selectArrGenerated = generateSelectArray(
@@ -562,11 +592,47 @@ export const generateSchemaData = <
           updateInput,
           tableFilters,
           updateFieldName,
+          false,
+          features.requireWhere,
+          filterCtx,
+        )
+      : undefined;
+    const updateSingleGenerated = features.update
+      ? generateUpdate(
+          db,
+          tableName,
+          schema[tableName] as MySqlTable,
+          updateInput,
+          tableFilters,
+          updateSingleFieldName,
+          true,
+          features.requireWhere,
           filterCtx,
         )
       : undefined;
     const deleteGenerated = features.delete
-      ? generateDelete(db, tableName, schema[tableName] as MySqlTable, tableFilters, deleteFieldName, filterCtx)
+      ? generateDelete(
+          db,
+          tableName,
+          schema[tableName] as MySqlTable,
+          tableFilters,
+          deleteFieldName,
+          false,
+          features.requireWhere,
+          filterCtx,
+        )
+      : undefined;
+    const deleteSingleGenerated = features.delete
+      ? generateDelete(
+          db,
+          tableName,
+          schema[tableName] as MySqlTable,
+          tableFilters,
+          deleteSingleFieldName,
+          true,
+          features.requireWhere,
+          filterCtx,
+        )
       : undefined;
     const aggregateType = features.aggregates
       ? generateAggregateTypes(schema[tableName] as MySqlTable, tableName, typeName, cacheCtx)
@@ -642,7 +708,9 @@ export const generateSchemaData = <
       upsertArrGenerated,
       upsertSingleGenerated,
       updateGenerated,
+      updateSingleGenerated,
       deleteGenerated,
+      deleteSingleGenerated,
     ]) {
       if (generated) {
         mutations[generated.name] = {

--- a/src/util/builders/pg.ts
+++ b/src/util/builders/pg.ts
@@ -15,6 +15,7 @@ import { parseResolveInfo } from 'graphql-parse-resolve-info';
 import type { GeneratedEntities } from '../../types.ts';
 import {
   aggregateFieldComplexity,
+  assertSingleMatch,
   attachTargetPrimaryKeys,
   buildNamedRelations,
   computeResolverFieldNames,
@@ -23,6 +24,7 @@ import {
   excludedColumnRef,
   extractFilters,
   extractOrderBy,
+  extractRequiredFilters,
   extractSelectedColumnsFromTreeSQLFormat,
   generateDistinctEnum,
   generateOnConflictInput,
@@ -514,6 +516,8 @@ const generateUpdate = (
   filterArgs: GraphQLInputObjectType,
   fieldName: string,
   typeName: string,
+  single: boolean,
+  requireWhere: boolean,
   typeNameMapper?: TypeNameMapper,
   filterCtx?: RelationFilterBase,
 ): CreatedResolver => {
@@ -522,7 +526,7 @@ const generateUpdate = (
       type: new GraphQLNonNull(setArgs),
     },
     where: {
-      type: filterArgs,
+      type: single || requireWhere ? new GraphQLNonNull(filterArgs) : filterArgs,
     },
   } as const satisfies GraphQLFieldConfigArgumentMap;
 
@@ -555,10 +559,21 @@ const generateUpdate = (
           throw new GraphQLError('Unable to update with no values specified!');
         }
 
+        const relationCtx = relationFilterCtx(filterCtx, tableName);
+        const filters =
+          single || requireWhere
+            ? extractRequiredFilters(table, tableName, where, fieldName, relationCtx)
+            : where
+              ? extractFilters(table, tableName, where, relationCtx)
+              : undefined;
+
         const executor = resolveExecutor(db, context);
+        if (single) {
+          await assertSingleMatch(executor, table, filters!, fieldName);
+        }
+
         let query = executor.update(table).set(input);
-        if (where) {
-          const filters = extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName));
+        if (filters) {
           query = query.where(filters) as any;
         }
 
@@ -566,11 +581,22 @@ const generateUpdate = (
 
         const result = await query;
 
+        if (single && result.length > 1) {
+          // A row started matching between the pre-check and the write.
+          throw new GraphQLError(`${fieldName}: 'where' matched more than one row!`);
+        }
+
+        if (single && !result[0]) {
+          return undefined;
+        }
+
         const enriched = hasRelations
           ? await eagerLoadMutationRelations(executor, tableName, result, pkNames, withParams)
           : result;
 
-        return remapToGraphQLArrayOutput(enriched, tableName, table, relationMap);
+        return single
+          ? remapToGraphQLSingleOutput(enriched[0], tableName, table, relationMap)
+          : remapToGraphQLArrayOutput(enriched, tableName, table, relationMap);
       } catch (e) {
         throw toGraphQLError(e);
       }
@@ -586,12 +612,14 @@ const generateDelete = (
   filterArgs: GraphQLInputObjectType,
   fieldName: string,
   typeName: string,
+  single: boolean,
+  requireWhere: boolean,
   filterCtx?: RelationFilterBase,
   selectionCtx?: SelectionCtx,
 ): CreatedResolver => {
   const queryArgs = {
     where: {
-      type: filterArgs,
+      type: single || requireWhere ? new GraphQLNonNull(filterArgs) : filterArgs,
     },
   } as const satisfies GraphQLFieldConfigArgumentMap;
 
@@ -611,16 +639,36 @@ const generateDelete = (
           selectionCtx,
         );
 
+        const relationCtx = relationFilterCtx(filterCtx, tableName);
+        const filters =
+          single || requireWhere
+            ? extractRequiredFilters(table, tableName, where, fieldName, relationCtx)
+            : where
+              ? extractFilters(table, tableName, where, relationCtx)
+              : undefined;
+
         const executor = resolveExecutor(db, context);
+        if (single) {
+          await assertSingleMatch(executor, table, filters!, fieldName);
+        }
+
         let query = executor.delete(table);
-        if (where) {
-          const filters = extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName));
+        if (filters) {
           query = query.where(filters) as any;
         }
 
         query = query.returning(columns) as any;
 
         const result = await query;
+
+        if (single && result.length > 1) {
+          // A row started matching between the pre-check and the write.
+          throw new GraphQLError(`${fieldName}: 'where' matched more than one row!`);
+        }
+
+        if (single) {
+          return result[0] ? remapToGraphQLSingleOutput(result[0], tableName, table) : undefined;
+        }
 
         return remapToGraphQLArrayOutput(result, tableName, table);
       } catch (e) {
@@ -741,7 +789,9 @@ export function generateSchemaData<
       upsertArrayFieldName,
       upsertSingleFieldName,
       updateFieldName,
+      updateSingleFieldName,
       deleteFieldName,
+      deleteSingleFieldName,
     } = computeResolverFieldNames(tableName, typeNameMapper, prefixes, suffixes);
 
     const selectArrGenerated = generateSelectArray(
@@ -854,6 +904,25 @@ export function generateSchemaData<
           tableFilters,
           updateFieldName,
           typeName,
+          false,
+          features.requireWhere,
+          typeNameMapper,
+          filterCtx,
+        )
+      : undefined;
+    const updateSingleGenerated = features.update
+      ? generateUpdate(
+          db,
+          tableName,
+          schema[tableName] as PgTable,
+          tables,
+          eagerRelations,
+          updateInput,
+          tableFilters,
+          updateSingleFieldName,
+          typeName,
+          true,
+          features.requireWhere,
           typeNameMapper,
           filterCtx,
         )
@@ -866,6 +935,22 @@ export function generateSchemaData<
           tableFilters,
           deleteFieldName,
           typeName,
+          false,
+          features.requireWhere,
+          filterCtx,
+          { tableName, relationMap: namedRelations, tables },
+        )
+      : undefined;
+    const deleteSingleGenerated = features.delete
+      ? generateDelete(
+          db,
+          tableName,
+          schema[tableName] as PgTable,
+          tableFilters,
+          deleteSingleFieldName,
+          typeName,
+          true,
+          features.requireWhere,
           filterCtx,
           { tableName, relationMap: namedRelations, tables },
         )
@@ -973,11 +1058,25 @@ export function generateSchemaData<
         resolve: updateGenerated.resolver,
       };
     }
+    if (updateSingleGenerated) {
+      mutations[updateSingleGenerated.name] = {
+        type: singleTableItemOutput,
+        args: updateSingleGenerated.args,
+        resolve: updateSingleGenerated.resolver,
+      };
+    }
     if (deleteGenerated) {
       mutations[deleteGenerated.name] = {
         type: arrTableItemOutput,
         args: deleteGenerated.args,
         resolve: deleteGenerated.resolver,
+      };
+    }
+    if (deleteSingleGenerated) {
+      mutations[deleteSingleGenerated.name] = {
+        type: singleTableItemOutput,
+        args: deleteSingleGenerated.args,
+        resolve: deleteSingleGenerated.resolver,
       };
     }
     // The insert/update inputs are still built (they type the mutations that survive) but

--- a/src/util/builders/sqlite.ts
+++ b/src/util/builders/sqlite.ts
@@ -16,6 +16,7 @@ import { parseResolveInfo } from 'graphql-parse-resolve-info';
 import type { GeneratedEntities } from '../../types.ts';
 import {
   aggregateFieldComplexity,
+  assertSingleMatch,
   attachTargetPrimaryKeys,
   buildNamedRelations,
   computeResolverFieldNames,
@@ -23,6 +24,7 @@ import {
   eagerLoadMutationRelations,
   excludedColumnRef,
   extractFilters,
+  extractRequiredFilters,
   extractSelectedColumnsFromTreeSQLFormat,
   generateDistinctEnum,
   generateOnConflictInput,
@@ -432,6 +434,8 @@ const generateUpdate = (
   filterArgs: GraphQLInputObjectType,
   fieldName: string,
   typeName: string,
+  single: boolean,
+  requireWhere: boolean,
   typeNameMapper?: TypeNameMapper,
   filterCtx?: RelationFilterBase,
 ): CreatedResolver => {
@@ -440,7 +444,7 @@ const generateUpdate = (
       type: new GraphQLNonNull(setArgs),
     },
     where: {
-      type: filterArgs,
+      type: single || requireWhere ? new GraphQLNonNull(filterArgs) : filterArgs,
     },
   } as const satisfies GraphQLFieldConfigArgumentMap;
 
@@ -473,10 +477,21 @@ const generateUpdate = (
           throw new GraphQLError('Unable to update with no values specified!');
         }
 
+        const relationCtx = relationFilterCtx(filterCtx, tableName);
+        const filters =
+          single || requireWhere
+            ? extractRequiredFilters(table, tableName, where, fieldName, relationCtx)
+            : where
+              ? extractFilters(table, tableName, where, relationCtx)
+              : undefined;
+
         const executor = resolveExecutor(db, context);
+        if (single) {
+          await assertSingleMatch(executor, table, filters!, fieldName);
+        }
+
         let query = executor.update(table).set(input);
-        if (where) {
-          const filters = extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName));
+        if (filters) {
           query = query.where(filters) as any;
         }
 
@@ -484,11 +499,22 @@ const generateUpdate = (
 
         const result = await query;
 
+        if (single && result.length > 1) {
+          // A row started matching between the pre-check and the write.
+          throw new GraphQLError(`${fieldName}: 'where' matched more than one row!`);
+        }
+
+        if (single && !result[0]) {
+          return undefined;
+        }
+
         const enriched = hasRelations
           ? await eagerLoadMutationRelations(executor, tableName, result, pkNames, withParams)
           : result;
 
-        return remapToGraphQLArrayOutput(enriched, tableName, table, relationMap);
+        return single
+          ? remapToGraphQLSingleOutput(enriched[0], tableName, table, relationMap)
+          : remapToGraphQLArrayOutput(enriched, tableName, table, relationMap);
       } catch (e) {
         throw toGraphQLError(e);
       }
@@ -504,12 +530,14 @@ const generateDelete = (
   filterArgs: GraphQLInputObjectType,
   fieldName: string,
   typeName: string,
+  single: boolean,
+  requireWhere: boolean,
   filterCtx?: RelationFilterBase,
   selectionCtx?: SelectionCtx,
 ): CreatedResolver => {
   const queryArgs = {
     where: {
-      type: filterArgs,
+      type: single || requireWhere ? new GraphQLNonNull(filterArgs) : filterArgs,
     },
   } as const satisfies GraphQLFieldConfigArgumentMap;
 
@@ -529,16 +557,36 @@ const generateDelete = (
           selectionCtx,
         );
 
+        const relationCtx = relationFilterCtx(filterCtx, tableName);
+        const filters =
+          single || requireWhere
+            ? extractRequiredFilters(table, tableName, where, fieldName, relationCtx)
+            : where
+              ? extractFilters(table, tableName, where, relationCtx)
+              : undefined;
+
         const executor = resolveExecutor(db, context);
+        if (single) {
+          await assertSingleMatch(executor, table, filters!, fieldName);
+        }
+
         let query = executor.delete(table);
-        if (where) {
-          const filters = extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName));
+        if (filters) {
           query = query.where(filters) as any;
         }
 
         query = query.returning(columns) as any;
 
         const result = await query;
+
+        if (single && result.length > 1) {
+          // A row started matching between the pre-check and the write.
+          throw new GraphQLError(`${fieldName}: 'where' matched more than one row!`);
+        }
+
+        if (single) {
+          return result[0] ? remapToGraphQLSingleOutput(result[0], tableName, table) : undefined;
+        }
 
         return remapToGraphQLArrayOutput(result, tableName, table);
       } catch (e) {
@@ -653,7 +701,9 @@ export const generateSchemaData = <
       upsertArrayFieldName,
       upsertSingleFieldName,
       updateFieldName,
+      updateSingleFieldName,
       deleteFieldName,
+      deleteSingleFieldName,
     } = computeResolverFieldNames(tableName, typeNameMapper, prefixes, suffixes);
 
     const selectArrGenerated = generateSelectArray(
@@ -766,6 +816,25 @@ export const generateSchemaData = <
           tableFilters,
           updateFieldName,
           typeName,
+          false,
+          features.requireWhere,
+          typeNameMapper,
+          filterCtx,
+        )
+      : undefined;
+    const updateSingleGenerated = features.update
+      ? generateUpdate(
+          db,
+          tableName,
+          schema[tableName] as SQLiteTable,
+          tables,
+          eagerRelations,
+          updateInput,
+          tableFilters,
+          updateSingleFieldName,
+          typeName,
+          true,
+          features.requireWhere,
           typeNameMapper,
           filterCtx,
         )
@@ -778,6 +847,22 @@ export const generateSchemaData = <
           tableFilters,
           deleteFieldName,
           typeName,
+          false,
+          features.requireWhere,
+          filterCtx,
+          { tableName, relationMap: namedRelations, tables },
+        )
+      : undefined;
+    const deleteSingleGenerated = features.delete
+      ? generateDelete(
+          db,
+          tableName,
+          schema[tableName] as SQLiteTable,
+          tableFilters,
+          deleteSingleFieldName,
+          typeName,
+          true,
+          features.requireWhere,
           filterCtx,
           { tableName, relationMap: namedRelations, tables },
         )
@@ -885,11 +970,25 @@ export const generateSchemaData = <
         resolve: updateGenerated.resolver,
       };
     }
+    if (updateSingleGenerated) {
+      mutations[updateSingleGenerated.name] = {
+        type: singleTableItemOutput,
+        args: updateSingleGenerated.args,
+        resolve: updateSingleGenerated.resolver,
+      };
+    }
     if (deleteGenerated) {
       mutations[deleteGenerated.name] = {
         type: arrTableItemOutput,
         args: deleteGenerated.args,
         resolve: deleteGenerated.resolver,
+      };
+    }
+    if (deleteSingleGenerated) {
+      mutations[deleteSingleGenerated.name] = {
+        type: singleTableItemOutput,
+        args: deleteSingleGenerated.args,
+        resolve: deleteSingleGenerated.resolver,
       };
     }
     // The insert/update inputs are still built (they type the mutations that survive) but

--- a/src/util/builders/types.ts
+++ b/src/util/builders/types.ts
@@ -29,6 +29,7 @@ export type GeneratorFeatures = {
   update: boolean;
   delete: boolean;
   upsert: boolean;
+  requireWhere: boolean;
 };
 
 /**

--- a/tests/pglite/features.test.ts
+++ b/tests/pglite/features.test.ts
@@ -176,6 +176,7 @@ describe('features: mutations', () => {
     const mutations = gqlSchema.getMutationType()!.getFields();
 
     expect(mutations['updateUsers']).toBeUndefined();
+    expect(mutations['updateUsersSingle']).toBeUndefined();
     expect(gqlSchema.getType('UpdateUsersInput')).toBeUndefined();
     expect(entities.inputs['UpdateUsersInput']).toBeUndefined();
     expect(mutations['createUsers']).toBeDefined();
@@ -185,6 +186,7 @@ describe('features: mutations', () => {
     const mutations = build({ delete: false }).schema.getMutationType()!.getFields();
 
     expect(mutations['deleteUsers']).toBeUndefined();
+    expect(mutations['deleteUsersSingle']).toBeUndefined();
     expect(mutations['createUsers']).toBeDefined();
   });
 

--- a/tests/pglite/mysql-schema.test.ts
+++ b/tests/pglite/mysql-schema.test.ts
@@ -126,6 +126,16 @@ describe('MySQL mutations are returnless', () => {
     expect(entities.mutations['deletePosts'].type).toBe(entities.types['MutationReturn']);
   });
 
+  it('single update/delete variants return MutationReturn and require where', () => {
+    expect(entities.mutations['updateUsersSingle'].type).toBe(entities.types['MutationReturn']);
+    expect(entities.mutations['deleteUsersSingle'].type).toBe(entities.types['MutationReturn']);
+    expect(entities.mutations['updateUsersSingle'].args['where'].type).toBeInstanceOf(GraphQLNonNull);
+    expect(entities.mutations['deleteUsersSingle'].args['where'].type).toBeInstanceOf(GraphQLNonNull);
+    // Plural where stays nullable by default.
+    expect(entities.mutations['updateUsers'].args['where'].type).not.toBeInstanceOf(GraphQLNonNull);
+    expect(entities.mutations['deleteUsers'].args['where'].type).not.toBeInstanceOf(GraphQLNonNull);
+  });
+
   it('generates no upsert mutations unless the feature is on', () => {
     expect(entities.mutations['upsertUsers']).toBeUndefined();
     expect(entities.types['UsersOnConflict']).toBeUndefined();
@@ -143,16 +153,20 @@ describe('MySQL mutations are returnless', () => {
     expect(upsertEntities.mutations['upsertPosts']).toBeDefined();
   });
 
-  it('all 6 mutations exist per table (array+single insert, update, delete)', () => {
+  it('all mutations exist per table (array+single insert, update, delete, and their single variants)', () => {
     const mutationKeys = Object.keys(entities.mutations);
     // Users
     expect(mutationKeys).toContain('createUsers');
     expect(mutationKeys).toContain('createUsersSingle');
     expect(mutationKeys).toContain('updateUsers');
+    expect(mutationKeys).toContain('updateUsersSingle');
     expect(mutationKeys).toContain('deleteUsers');
+    expect(mutationKeys).toContain('deleteUsersSingle');
     // Posts
     expect(mutationKeys).toContain('createPosts');
     expect(mutationKeys).toContain('deletePosts');
+    expect(mutationKeys).toContain('updatePostsSingle');
+    expect(mutationKeys).toContain('deletePostsSingle');
   });
 });
 

--- a/tests/pglite/returned-data.test.ts
+++ b/tests/pglite/returned-data.test.ts
@@ -537,6 +537,28 @@ describe.sequential('Returned data tests', () => {
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
+            updateUserSingle: z
+              .object({
+                args: z
+                  .object({
+                    set: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLObjectType),
+              })
+              .strict(),
             deleteUser: z
               .object({
                 args: z
@@ -552,6 +574,23 @@ describe.sequential('Returned data tests', () => {
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
                 type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
+            deleteUserSingle: z
+              .object({
+                args: z
+                  .object({
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
             createPosts: z
@@ -610,6 +649,28 @@ describe.sequential('Returned data tests', () => {
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
+            updatePostSingle: z
+              .object({
+                args: z
+                  .object({
+                    set: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLObjectType),
+              })
+              .strict(),
             deletePost: z
               .object({
                 args: z
@@ -625,6 +686,23 @@ describe.sequential('Returned data tests', () => {
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
                 type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
+            deletePostSingle: z
+              .object({
+                args: z
+                  .object({
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
             createCustomers: z
@@ -683,6 +761,28 @@ describe.sequential('Returned data tests', () => {
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
+            updateCustomerSingle: z
+              .object({
+                args: z
+                  .object({
+                    set: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLObjectType),
+              })
+              .strict(),
             deleteCustomer: z
               .object({
                 args: z
@@ -698,6 +798,23 @@ describe.sequential('Returned data tests', () => {
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
                 type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
+            deleteCustomerSingle: z
+              .object({
+                args: z
+                  .object({
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
             createTags: z
@@ -756,6 +873,28 @@ describe.sequential('Returned data tests', () => {
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
+            updateTagSingle: z
+              .object({
+                args: z
+                  .object({
+                    set: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLObjectType),
+              })
+              .strict(),
             deleteTag: z
               .object({
                 args: z
@@ -771,6 +910,23 @@ describe.sequential('Returned data tests', () => {
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
                 type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
+            deleteTagSingle: z
+              .object({
+                args: z
+                  .object({
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
           })

--- a/tests/pglite/single-write.test.ts
+++ b/tests/pglite/single-write.test.ts
@@ -1,0 +1,373 @@
+import { rm } from 'node:fs/promises';
+import { createServer, type Server } from 'node:http';
+import { PGlite } from '@electric-sql/pglite';
+import { eq } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/pglite';
+import { GraphQLList, GraphQLNonNull, GraphQLObjectType } from 'graphql';
+import { createYoga } from 'graphql-yoga';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { buildSchema } from '@/index';
+import { GraphQLClient } from '../util/query';
+import type { Context } from './common';
+import { createCtx, schema, setupServer, setupTables, sql, teardownServer, teardownTables } from './common';
+
+const DATA_DIR = `./tests/.temp/pgdata-single-write-${Date.now()}`;
+const ctx: Context = createCtx();
+
+beforeAll(async () => {
+  await setupServer(ctx, 5240, DATA_DIR);
+});
+
+afterAll(async () => {
+  await teardownServer(ctx, DATA_DIR);
+});
+
+beforeEach(async () => {
+  await setupTables(ctx);
+});
+
+afterEach(async () => {
+  await teardownTables(ctx);
+});
+
+describe.sequential('updateSingle / deleteSingle mutations', () => {
+  it('generates the Single variants with a non-null where and a single nullable return type', () => {
+    const mutationFields = ctx.schema.getMutationType()!.getFields();
+
+    for (const fieldName of ['updateUserSingle', 'deleteUserSingle', 'updatePostSingle', 'deletePostSingle']) {
+      const field = mutationFields[fieldName];
+      expect(field).toBeDefined();
+      const whereArg = field!.args.find((arg) => arg.name === 'where');
+      expect(whereArg).toBeDefined();
+      expect(whereArg!.type).toBeInstanceOf(GraphQLNonNull);
+      // Single (nullable) row out — not a list.
+      expect(field!.type).toBeInstanceOf(GraphQLObjectType);
+      expect(field!.type).not.toBeInstanceOf(GraphQLList);
+      expect(field!.type).not.toBeInstanceOf(GraphQLNonNull);
+    }
+  });
+
+  it('keeps where nullable on the plural update/delete mutations by default', () => {
+    const mutationFields = ctx.schema.getMutationType()!.getFields();
+
+    for (const fieldName of ['updateUser', 'deleteUser']) {
+      const whereArg = mutationFields[fieldName]!.args.find((arg) => arg.name === 'where');
+      expect(whereArg).toBeDefined();
+      expect(whereArg!.type).not.toBeInstanceOf(GraphQLNonNull);
+    }
+  });
+
+  it('exposes the Single variants on entities.mutations', () => {
+    const mutations = ctx.entities.mutations as Record<string, any>;
+    expect(mutations['updateUserSingle']).toBeDefined();
+    expect(mutations['deleteUserSingle']).toBeDefined();
+  });
+
+  it('updateSingle updates and returns the one matched row', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			mutation {
+				updateUserSingle(where: { id: { eq: 2 } }, set: { name: "UpdatedSecondUser" }) {
+					id
+					name
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        updateUserSingle: {
+          id: 2,
+          name: 'UpdatedSecondUser',
+        },
+      },
+    });
+
+    // Only the matched row was touched.
+    const names = (await ctx.db.select({ id: schema.Users.id, name: schema.Users.name }).from(schema.Users)).sort(
+      (a, b) => a.id - b.id,
+    );
+    expect(names).toStrictEqual([
+      { id: 1, name: 'FirstUser' },
+      { id: 2, name: 'UpdatedSecondUser' },
+      { id: 5, name: 'FifthUser' },
+    ]);
+  });
+
+  it('updateSingle returns null when nothing matches', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			mutation {
+				updateUserSingle(where: { id: { eq: 999 } }, set: { name: "Nobody" }) {
+					id
+					name
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({ data: { updateUserSingle: null } });
+  });
+
+  it('updateSingle throws and writes nothing when where matches more than one row', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			mutation {
+				updatePostSingle(where: { authorId: { eq: 1 } }, set: { content: "OVERWRITTEN" }) {
+					id
+					content
+				}
+			}
+		`);
+
+    // The field is nullable, so the error surfaces alongside a null field value.
+    expect(res.data?.updatePostSingle ?? null).toBeNull();
+    expect(res.errors?.[0]?.message).toContain('matched more than one row');
+
+    const overwritten = await ctx.db.select().from(schema.Posts).where(eq(schema.Posts.content, 'OVERWRITTEN'));
+    expect(overwritten).toHaveLength(0);
+  });
+
+  it('updateSingle without where is rejected by validation', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			mutation {
+				updateUserSingle(set: { name: "Nobody" }) {
+					id
+				}
+			}
+		`);
+
+    expect(res.errors).toBeDefined();
+
+    const renamed = await ctx.db.select().from(schema.Users).where(eq(schema.Users.name, 'Nobody'));
+    expect(renamed).toHaveLength(0);
+  });
+
+  it('updateSingle rejects a where with no filters', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			mutation {
+				updateUserSingle(where: {}, set: { name: "Nobody" }) {
+					id
+				}
+			}
+		`);
+
+    expect(res.data?.updateUserSingle ?? null).toBeNull();
+    expect(res.errors?.[0]?.message).toContain('at least one filter');
+
+    const renamed = await ctx.db.select().from(schema.Users).where(eq(schema.Users.name, 'Nobody'));
+    expect(renamed).toHaveLength(0);
+  });
+
+  it('deleteSingle deletes and returns the one matched row', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			mutation {
+				deletePostSingle(where: { id: { eq: 6 } }) {
+					id
+					content
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        deletePostSingle: {
+          id: 6,
+          content: '4MESSAGE',
+        },
+      },
+    });
+
+    const remaining = await ctx.db.select({ id: schema.Posts.id }).from(schema.Posts);
+    expect(remaining).toHaveLength(5);
+    expect(remaining.map((post) => post.id)).not.toContain(6);
+  });
+
+  it('deleteSingle returns null when nothing matches', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			mutation {
+				deletePostSingle(where: { id: { eq: 999 } }) {
+					id
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({ data: { deletePostSingle: null } });
+
+    const remaining = await ctx.db.select({ id: schema.Posts.id }).from(schema.Posts);
+    expect(remaining).toHaveLength(6);
+  });
+
+  it('deleteSingle throws and deletes nothing when where matches more than one row', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			mutation {
+				deletePostSingle(where: { authorId: { eq: 5 } }) {
+					id
+				}
+			}
+		`);
+
+    expect(res.data?.deletePostSingle ?? null).toBeNull();
+    expect(res.errors?.[0]?.message).toContain('matched more than one row');
+
+    const remaining = await ctx.db.select({ id: schema.Posts.id }).from(schema.Posts);
+    expect(remaining).toHaveLength(6);
+  });
+
+  it('deleteSingle without where is rejected by validation', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			mutation {
+				deletePostSingle {
+					id
+				}
+			}
+		`);
+
+    expect(res.errors).toBeDefined();
+
+    const remaining = await ctx.db.select({ id: schema.Posts.id }).from(schema.Posts);
+    expect(remaining).toHaveLength(6);
+  });
+
+  it('deleteSingle rejects a where with no filters', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			mutation {
+				deletePostSingle(where: {}) {
+					id
+				}
+			}
+		`);
+
+    expect(res.data?.deletePostSingle ?? null).toBeNull();
+    expect(res.errors?.[0]?.message).toContain('at least one filter');
+
+    const remaining = await ctx.db.select({ id: schema.Posts.id }).from(schema.Posts);
+    expect(remaining).toHaveLength(6);
+  });
+});
+
+// ── features.requireWhere ─────────────────────────────────────────────────────
+
+describe.sequential('features.requireWhere', () => {
+  const dataDir = `./tests/.temp/pgdata-require-where-${Date.now()}`;
+  const rwCtx: { pglite: PGlite; db: any; server: Server; gql: GraphQLClient; schema: any } = {} as any;
+
+  beforeAll(async () => {
+    rwCtx.pglite = new PGlite(dataDir);
+    await rwCtx.pglite.waitReady;
+    rwCtx.db = drizzle({ client: rwCtx.pglite, schema, relations: schema.relations });
+    await rwCtx.db.execute(
+      sql`DO $$ BEGIN CREATE TYPE "role" AS ENUM('admin','user'); EXCEPTION WHEN duplicate_object THEN null; END $$;`,
+    );
+
+    const { schema: gqlSchema } = buildSchema(rwCtx.db, { features: { requireWhere: true } });
+    rwCtx.schema = gqlSchema;
+    const yoga = createYoga({ schema: gqlSchema });
+    rwCtx.server = createServer(yoga);
+    rwCtx.server.listen(5241);
+    rwCtx.gql = new GraphQLClient('http://localhost:5241/graphql');
+  });
+
+  afterAll(async () => {
+    await rwCtx.pglite?.close().catch(console.error);
+    await rm(dataDir, { recursive: true, force: true }).catch(console.error);
+    await new Promise<void>((resolve) => rwCtx.server?.close(() => resolve()));
+  });
+
+  beforeEach(async () => {
+    await setupTables(rwCtx as any);
+  });
+
+  afterEach(async () => {
+    await teardownTables(rwCtx as any);
+  });
+
+  it('makes where non-null on the plural update/delete mutations', () => {
+    const mutationFields = rwCtx.schema.getMutationType()!.getFields();
+
+    for (const fieldName of ['updateUsers', 'deleteUsers', 'updateUsersSingle', 'deleteUsersSingle']) {
+      const whereArg = mutationFields[fieldName]!.args.find((arg: any) => arg.name === 'where');
+      expect(whereArg).toBeDefined();
+      expect(whereArg!.type).toBeInstanceOf(GraphQLNonNull);
+    }
+  });
+
+  it('rejects a plural update without where at validation time', async () => {
+    const res = await rwCtx.gql.queryGql(/* GraphQL */ `
+			mutation {
+				updateUsers(set: { name: "Nobody" }) {
+					id
+				}
+			}
+		`);
+
+    expect(res.errors).toBeDefined();
+
+    const renamed = await rwCtx.db.select().from(schema.Users).where(eq(schema.Users.name, 'Nobody'));
+    expect(renamed).toHaveLength(0);
+  });
+
+  it('rejects a plural delete without where at validation time', async () => {
+    const res = await rwCtx.gql.queryGql(/* GraphQL */ `
+			mutation {
+				deletePosts {
+					id
+				}
+			}
+		`);
+
+    expect(res.errors).toBeDefined();
+
+    const remaining = await rwCtx.db.select({ id: schema.Posts.id }).from(schema.Posts);
+    expect(remaining).toHaveLength(6);
+  });
+
+  it('rejects a plural update/delete whose where has no filters', async () => {
+    const update = await rwCtx.gql.queryGql(/* GraphQL */ `
+			mutation {
+				updateUsers(where: {}, set: { name: "Nobody" }) {
+					id
+				}
+			}
+		`);
+    expect(update.data).toBeFalsy();
+    expect(update.errors?.[0]?.message).toContain('at least one filter');
+
+    const remove = await rwCtx.gql.queryGql(/* GraphQL */ `
+			mutation {
+				deletePosts(where: {}) {
+					id
+				}
+			}
+		`);
+    expect(remove.data).toBeFalsy();
+    expect(remove.errors?.[0]?.message).toContain('at least one filter');
+
+    const remaining = await rwCtx.db.select({ id: schema.Posts.id }).from(schema.Posts);
+    expect(remaining).toHaveLength(6);
+  });
+
+  it('still runs plural update/delete normally with a real where', async () => {
+    const update = await rwCtx.gql.queryGql(/* GraphQL */ `
+			mutation {
+				updateUsers(where: { id: { eq: 1 } }, set: { name: "RenamedFirstUser" }) {
+					id
+					name
+				}
+			}
+		`);
+
+    expect(update).toStrictEqual({
+      data: {
+        updateUsers: [{ id: 1, name: 'RenamedFirstUser' }],
+      },
+    });
+
+    const remove = await rwCtx.gql.queryGql(/* GraphQL */ `
+			mutation {
+				deletePosts(where: { authorId: { eq: 5 } }) {
+					id
+				}
+			}
+		`);
+
+    expect(remove.errors).toBeUndefined();
+    expect(remove.data?.deletePosts).toHaveLength(2);
+  });
+});

--- a/tests/sqlite-custom.test.ts
+++ b/tests/sqlite-custom.test.ts
@@ -74,9 +74,11 @@ beforeAll(async () => {
         deleteFromCustomUsers: entities.mutations.deleteUsers,
         deleteFromCustomCustomers: entities.mutations.deleteCustomers,
         deleteFromCustomPosts: entities.mutations.deletePosts,
+        deleteFromCustomPostsSingle: entities.mutations.deletePostsSingle,
         updateCustomUsers: entities.mutations.updateUsers,
         updateCustomCustomers: entities.mutations.updateCustomers,
         updateCustomPosts: entities.mutations.updatePosts,
+        updateCustomPostsSingle: entities.mutations.updatePostsSingle,
         insertIntoCustomUsers: entities.mutations.createUsers,
         insertIntoCustomUsersSingle: entities.mutations.createUsersSingle,
         insertIntoCustomCustomers: entities.mutations.createCustomers,
@@ -1789,6 +1791,133 @@ describe.sequential('Arguments tests', async () => {
             content: '2MESSAGE',
           },
         ],
+      },
+    });
+  });
+
+  it('Update single', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			mutation {
+				updateCustomPostsSingle(where: { id: { eq: 6 } }, set: { content: "UPDATED" }) {
+					id
+					authorId
+					content
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        updateCustomPostsSingle: {
+          id: 6,
+          authorId: 1,
+          content: 'UPDATED',
+        },
+      },
+    });
+  });
+
+  it('Update single with no match returns null', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			mutation {
+				updateCustomPostsSingle(where: { id: { eq: 999 } }, set: { content: "UPDATED" }) {
+					id
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        updateCustomPostsSingle: null,
+      },
+    });
+  });
+
+  it('Update single with multiple matches throws and writes nothing', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			mutation {
+				updateCustomPostsSingle(where: { authorId: { eq: 5 } }, set: { content: "UPDATED" }) {
+					id
+				}
+			}
+		`);
+
+    expect(res.errors?.[0]?.message).toContain('matched more than one row');
+
+    const check = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				customPosts(where: { content: { eq: "UPDATED" } }) {
+					id
+				}
+			}
+		`);
+    expect(check).toStrictEqual({ data: { customPosts: [] } });
+  });
+
+  it('Update single without where is rejected by validation', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			mutation {
+				updateCustomPostsSingle(set: { content: "UPDATED" }) {
+					id
+				}
+			}
+		`);
+
+    expect(res.errors).toBeDefined();
+  });
+
+  it('Delete single', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			mutation {
+				deleteFromCustomPostsSingle(where: { id: { eq: 6 } }) {
+					id
+					authorId
+					content
+				}
+			}
+		`);
+
+    expect(res).toStrictEqual({
+      data: {
+        deleteFromCustomPostsSingle: {
+          id: 6,
+          authorId: 1,
+          content: '4MESSAGE',
+        },
+      },
+    });
+
+    const check = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				customPosts(where: { id: { eq: 6 } }) {
+					id
+				}
+			}
+		`);
+    expect(check).toStrictEqual({ data: { customPosts: [] } });
+  });
+
+  it('Delete single with multiple matches throws and deletes nothing', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			mutation {
+				deleteFromCustomPostsSingle(where: { authorId: { eq: 5 } }) {
+					id
+				}
+			}
+		`);
+
+    expect(res.errors?.[0]?.message).toContain('matched more than one row');
+
+    const check = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				customPosts(where: { authorId: { eq: 5 } }) {
+					id
+				}
+			}
+		`);
+    expect(check).toStrictEqual({
+      data: {
+        customPosts: [{ id: 4 }, { id: 5 }],
       },
     });
   });

--- a/tests/sqlite.test.ts
+++ b/tests/sqlite.test.ts
@@ -20,6 +20,7 @@ import {
   type AggregateResolver,
   buildSchema,
   type DeleteResolver,
+  type DeleteSingleResolver,
   type ExtractTables,
   type GeneratedEntities,
   type InsertArrResolver,
@@ -27,6 +28,7 @@ import {
   type SelectResolver,
   type SelectSingleResolver,
   type UpdateResolver,
+  type UpdateSingleResolver,
 } from '@/index';
 import * as schema from './schema/sqlite';
 import { GraphQLClient } from './util/query';
@@ -2870,6 +2872,28 @@ describe.sequential('Returned data tests', () => {
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
+            updateUsersSingle: z
+              .object({
+                args: z
+                  .object({
+                    set: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLObjectType),
+              })
+              .strict(),
             deleteUsers: z
               .object({
                 args: z
@@ -2885,6 +2909,23 @@ describe.sequential('Returned data tests', () => {
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
                 type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
+            deleteUsersSingle: z
+              .object({
+                args: z
+                  .object({
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
             createPosts: z
@@ -2943,6 +2984,28 @@ describe.sequential('Returned data tests', () => {
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
+            updatePostsSingle: z
+              .object({
+                args: z
+                  .object({
+                    set: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLObjectType),
+              })
+              .strict(),
             deletePosts: z
               .object({
                 args: z
@@ -2958,6 +3021,23 @@ describe.sequential('Returned data tests', () => {
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
                 type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
+            deletePostsSingle: z
+              .object({
+                args: z
+                  .object({
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
             createCustomers: z
@@ -3016,6 +3096,28 @@ describe.sequential('Returned data tests', () => {
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
+            updateCustomersSingle: z
+              .object({
+                args: z
+                  .object({
+                    set: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLObjectType),
+              })
+              .strict(),
             deleteCustomers: z
               .object({
                 args: z
@@ -3031,6 +3133,23 @@ describe.sequential('Returned data tests', () => {
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
                 type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
+            deleteCustomersSingle: z
+              .object({
+                args: z
+                  .object({
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
           })
@@ -3290,6 +3409,37 @@ describe.sequential('Type tests', () => {
           resolve: UpdateResolver<typeof schema.Users, false>;
         };
       } & {
+        readonly updateCustomersSingle: {
+          type: GraphQLObjectType;
+          args: {
+            set: {
+              type: GraphQLNonNull<GraphQLInputObjectType>;
+            };
+            where: { type: GraphQLNonNull<GraphQLInputObjectType> };
+          };
+          resolve: UpdateSingleResolver<typeof schema.Customers, false>;
+        };
+        readonly updatePostsSingle: {
+          type: GraphQLObjectType;
+          args: {
+            set: {
+              type: GraphQLNonNull<GraphQLInputObjectType>;
+            };
+            where: { type: GraphQLNonNull<GraphQLInputObjectType> };
+          };
+          resolve: UpdateSingleResolver<typeof schema.Posts, false>;
+        };
+        readonly updateUsersSingle: {
+          type: GraphQLObjectType;
+          args: {
+            set: {
+              type: GraphQLNonNull<GraphQLInputObjectType>;
+            };
+            where: { type: GraphQLNonNull<GraphQLInputObjectType> };
+          };
+          resolve: UpdateSingleResolver<typeof schema.Users, false>;
+        };
+      } & {
         readonly deleteCustomers: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
@@ -3310,6 +3460,28 @@ describe.sequential('Type tests', () => {
             where: { type: GraphQLInputObjectType };
           };
           resolve: DeleteResolver<typeof schema.Users, false>;
+        };
+      } & {
+        readonly deleteCustomersSingle: {
+          type: GraphQLObjectType;
+          args: {
+            where: { type: GraphQLNonNull<GraphQLInputObjectType> };
+          };
+          resolve: DeleteSingleResolver<typeof schema.Customers, false>;
+        };
+        readonly deletePostsSingle: {
+          type: GraphQLObjectType;
+          args: {
+            where: { type: GraphQLNonNull<GraphQLInputObjectType> };
+          };
+          resolve: DeleteSingleResolver<typeof schema.Posts, false>;
+        };
+        readonly deleteUsersSingle: {
+          type: GraphQLObjectType;
+          args: {
+            where: { type: GraphQLNonNull<GraphQLInputObjectType> };
+          };
+          resolve: DeleteSingleResolver<typeof schema.Users, false>;
         };
       }
     >();


### PR DESCRIPTION
Adds single-row write variants and an opt-in guard against unbounded writes, for all three dialect builders (PG, MySQL, SQLite).

Closes #24

## What's new

### `update<Table>Single` / `delete<Table>Single`

Every table now gets a Single variant of its update and delete mutations, mirroring the existing `create<Table>Single` / `upsert<Table>Single` precedent:

- `where` is **non-null** (`<Type>Filters!`) and must contain at least one filter — `where: {}` is rejected at resolve time with a `GraphQLError`, so a Single write can never silently become an unbounded one.
- The return type is the single **nullable** row type (`<Type>Item`), not a list. No match returns `null`.
- The variants are gated under the existing `features.update` / `features.delete` flags (default on), share the plural mutations' input types, and are exposed on `entities.mutations` for custom-resolver schemas (`updateUsersSingle`, `deleteUsersSingle`, ...), with full typing in `MutationsCore` and new exported `UpdateSingleResolver` / `DeleteSingleResolver` types.

### `features: { requireWhere: true }`

New build option that makes `where` non-null on the **plural** `update<Table>` / `delete<Table>` mutations and rejects a `where` that collapses to no filters (e.g. `where: {}`). Defaults to `false` for backwards compatibility. The Single variants require a non-empty `where` regardless of this flag.

## Multi-match semantics (the design decision)

If a Single variant's `where` matches **more than one row**, the mutation throws a `GraphQLError` (`"<field>: 'where' matched more than one row — nothing was written!"`) and **writes nothing**. This is implemented as a pre-write check (`SELECT 1 ... LIMIT 2`), which was chosen as the safest consistent behavior across dialects:

- Updating/deleting "one of them" arbitrarily would hide bugs; writing all and then erroring would be worse.
- PG/SQLite additionally guard after the write (`result.length > 1` → throw) in case a row started matching between the check and the write. Both the check and the write run on the same executor, so a caller-supplied transaction (`drizzleExecutorKey`) covers both.
- MySQL has no `RETURNING`, so its Single variants keep the single-match and non-empty-`where` guarantees but still return `MutationReturn` (`{ isSuccess }`) like every other MySQL mutation. Note the check-then-write pair on MySQL (and on PG/SQLite outside a transaction) is inherently subject to a small TOCTOU window; the post-write guard narrows it on the returning dialects.

## Naming

With a `typeNameMapper`, the plural update/delete mutations already use the singular noun (`updateUser` is the plural op), so — unlike `create` — the Single write variants can't rely on singular vs. plural to stay distinct. They always carry the configured `suffixes.single`, falling back to `'Single'` when that suffix is configured as `''` (e.g. `updateUserSingle` alongside plural `updateUser`).

## Docs & tests

- README: new "Single-row update & delete" section; `features` listing updated.
- New `tests/pglite/single-write.test.ts` (ports 5240/5241): happy paths, no-match → null, multi-match → error with nothing written, missing `where` → validation error, empty `where` → resolver error, `requireWhere` introspection + behavior, default-off check.
- Mirrored Single-variant coverage in `tests/sqlite-custom.test.ts` via the `entities.mutations.updatePostsSingle` / `deletePostsSingle` surface.
- MySQL schema-shape assertions extended in `tests/pglite/mysql-schema.test.ts` (MutationReturn, non-null `where`).
- Type-level `MutationsCore` assertion in `tests/sqlite.test.ts` extended with the new keys.

## Test results

- `npx tsc --noEmit` — clean
- `npx biome check` — no new diagnostics (remaining ones preexist on main)
- `npx vitest run tests/pglite/ tests/sqlite.test.ts tests/sqlite-custom.test.ts` — 31 files, 423 tests, all passing

(Docker-based pg/mysql integration suites intentionally not run.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
