### PR TITLE
feat(query): support relation filters for .through() many-to-many relations

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,8 +204,10 @@ A **to-many** relation takes a `some` / `none` / `every` wrapper
 -   `some: {}` means "at least one related row exists"; `none: {}` means "none exist"
 -   Several modes may be given at once and are `AND`ed together
 -   A relation whose name collides with a column name is skipped — the column keeps the field
--   Many-to-many relations declared with `.through()` are not filterable yet and are left out
-    of the filter input
+-   Many-to-many relations declared with `.through()` are filterable too: the `EXISTS`
+    subquery joins the junction table to the target, so
+    `users(where: { roles: { some: { name: { eq: "admin" } } } })` works the same as a direct
+    to-many relation
 
 ## Aggregate queries
 

--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -890,14 +890,6 @@ const generateTableOrderTypeCached = (
 };
 
 /**
- * Relations that can be expressed as a correlated `EXISTS` subquery. Many-to-many relations
- * declared with `.through()` need a junction join that the filter builder doesn't emit yet,
- * so they're left out of the filter input entirely — a missing field is a clean GraphQL
- * validation error, whereas a silently ignored filter would return too many rows.
- */
-const isFilterableRelation = (relation: Relation<string>): boolean => !(relation as any).through;
-
-/**
  * `${Target}ListRelationFilter` — the Prisma-style some/every/none wrapper for a to-many
  * relation. Shared by every table that points at the same target, and built through a thunk
  * so mutually-referencing tables (Users.posts ⇄ Posts.author) don't recurse forever.
@@ -967,7 +959,7 @@ const generateRelationFilterFields = (
 
     const targetTable = tables[relEntry.targetTableName];
     const relation = (relEntry as any).relation ?? relEntry;
-    if (!targetTable || !isFilterableRelation(relation)) {
+    if (!targetTable) {
       continue;
     }
 
@@ -1544,7 +1536,90 @@ const buildRelationJoinCondition = (
 };
 
 /**
+ * Resolves one side of a `.through()` junction pair to the corresponding column on the
+ * aliased junction table. Drizzle stores the junction column as a RelationsBuilderColumn
+ * (`_.column` is the Column, `_.key` its property name), so look up by property name first
+ * and fall back to matching by SQL name.
+ */
+const resolveJunctionColumn = (aliasedThrough: Table, junctionRef: any, relationName: string): Column => {
+  const throughColumns = getColumns(aliasedThrough);
+
+  const key: string | undefined = junctionRef?._?.key;
+  const byKey = key ? throughColumns[key] : undefined;
+  if (byKey) {
+    return byKey;
+  }
+
+  const columnName: string | undefined = junctionRef?._?.column?.name;
+  const byName = columnName ? Object.values(throughColumns).find((c) => c.name === columnName) : undefined;
+  if (!byName) {
+    throw new GraphQLError(`WHERE ${relationName}: Relation cannot be used as a filter`);
+  }
+
+  return byName;
+};
+
+/**
+ * Join conditions for a `.through()` (many-to-many) relation, split into the two legs of the
+ * junction: `correlation` ties the parent row to the aliased junction table on the relation's
+ * source keys, `junctionJoin` ties the aliased junction table to the aliased target on the
+ * target keys. Column matching mirrors {@link buildRelationJoinCondition} — by SQL name on the
+ * parent/target so aliased proxies work — while junction columns come from the relation's own
+ * `through` metadata.
+ */
+const buildThroughJoinConditions = (
+  parentTable: Table,
+  relation: Relation<string>,
+  aliasedThrough: Table,
+  aliasedTarget: Table,
+  relationName: string,
+): { correlation: SQL | undefined; junctionJoin: SQL | undefined } => {
+  const sourceColumns = (relation as any).sourceColumns as Column[] | undefined;
+  const targetColumns = (relation as any).targetColumns as Column[] | undefined;
+  const through = (relation as any).through as { source: any[]; target: any[] } | undefined;
+
+  if (
+    !sourceColumns?.length ||
+    !targetColumns?.length ||
+    through?.source.length !== sourceColumns.length ||
+    through.target.length !== targetColumns.length
+  ) {
+    throw new GraphQLError(`WHERE ${relationName}: Relation cannot be used as a filter`);
+  }
+
+  const parentColumns = Object.values(getColumns(parentTable));
+  const targetTableColumns = Object.values(getColumns(aliasedTarget));
+
+  const correlationConditions: SQL[] = [];
+  for (let i = 0; i < sourceColumns.length; i++) {
+    const localColumn = parentColumns.find((c) => c.name === sourceColumns[i]!.name);
+    if (!localColumn) {
+      throw new GraphQLError(`WHERE ${relationName}: Relation cannot be used as a filter`);
+    }
+    correlationConditions.push(eq(localColumn, resolveJunctionColumn(aliasedThrough, through.source[i], relationName)));
+  }
+
+  const junctionJoinConditions: SQL[] = [];
+  for (let i = 0; i < targetColumns.length; i++) {
+    const foreignColumn = targetTableColumns.find((c) => c.name === targetColumns[i]!.name);
+    if (!foreignColumn) {
+      throw new GraphQLError(`WHERE ${relationName}: Relation cannot be used as a filter`);
+    }
+    junctionJoinConditions.push(
+      eq(resolveJunctionColumn(aliasedThrough, through.target[i], relationName), foreignColumn),
+    );
+  }
+
+  return {
+    correlation: correlationConditions.length > 1 ? and(...correlationConditions) : correlationConditions[0],
+    junctionJoin: junctionJoinConditions.length > 1 ? and(...junctionJoinConditions) : junctionJoinConditions[0],
+  };
+};
+
+/**
  * Builds one `[NOT] EXISTS (SELECT 1 FROM target alias WHERE …)` for a relation filter.
+ * A `.through()` (many-to-many) relation adds an `INNER JOIN` on the aliased junction table
+ * inside the subquery, correlated to the parent on the relation's source keys.
  *
  * `some` / the to-one shorthand match when a related row satisfies the inner filters, `none`
  * when none does, and `every` is expressed as "no related row fails the inner filters".
@@ -1563,7 +1638,7 @@ const buildRelationExists = (
   const targetTable = ctx.tables[targetTableName];
   const relation = ((relEntry as any).relation ?? relEntry) as Relation<string>;
 
-  if (!targetTable || !isFilterableRelation(relation)) {
+  if (!targetTable) {
     throw new GraphQLError(`WHERE ${relationName}: Relation cannot be used as a filter`);
   }
 
@@ -1571,7 +1646,28 @@ const buildRelationExists = (
   const aliases = ctx.aliases;
   const aliasedTarget = aliasedTable(targetTable, `dgql_rel_${aliases.n++}`);
 
-  const joinCondition = buildRelationJoinCondition(parentTable, relation, aliasedTarget, relationName);
+  // A `.through()` relation reaches the target via a junction table: the subquery joins the
+  // aliased junction to the aliased target and correlates the junction to the parent, so
+  // `some` / `none` / `every` compile exactly like the direct case with a longer FROM clause.
+  const throughTable = (relation as any).throughTable as Table | undefined;
+  let fromClause: SQL;
+  let joinCondition: SQL | undefined;
+  if (throughTable) {
+    const aliasedThrough = aliasedTable(throughTable, `dgql_rel_${aliases.n++}`);
+    const { correlation, junctionJoin } = buildThroughJoinConditions(
+      parentTable,
+      relation,
+      aliasedThrough,
+      aliasedTarget,
+      relationName,
+    );
+    fromClause = sql`${getTableAsAliasSQL(aliasedTarget)} inner join ${getTableAsAliasSQL(aliasedThrough)} on ${junctionJoin}`;
+    joinCondition = correlation;
+  } else {
+    fromClause = getTableAsAliasSQL(aliasedTarget);
+    joinCondition = buildRelationJoinCondition(parentTable, relation, aliasedTarget, relationName);
+  }
+
   // A relation declared with its own `where` only ever exposes the rows it selects, so the
   // subquery has to honour it too — otherwise a filter could match a row the relation hides.
   const relationWhere = (relation as any).where
@@ -1588,14 +1684,14 @@ const buildRelationExists = (
       return undefined;
     }
 
-    return sql`not exists (select 1 from ${getTableAsAliasSQL(aliasedTarget)} where ${and(joinCondition, relationWhere, not(inner))})`;
+    return sql`not exists (select 1 from ${fromClause} where ${and(joinCondition, relationWhere, not(inner))})`;
   }
 
   const condition = and(joinCondition, relationWhere, inner);
 
   return mode === 'none'
-    ? sql`not exists (select 1 from ${getTableAsAliasSQL(aliasedTarget)} where ${condition})`
-    : sql`exists (select 1 from ${getTableAsAliasSQL(aliasedTarget)} where ${condition})`;
+    ? sql`not exists (select 1 from ${fromClause} where ${condition})`
+    : sql`exists (select 1 from ${fromClause} where ${condition})`;
 };
 
 /**

--- a/tests/pglite/through-relation-filters.test.ts
+++ b/tests/pglite/through-relation-filters.test.ts
@@ -1,0 +1,247 @@
+import { rm } from 'node:fs/promises';
+import { PGlite } from '@electric-sql/pglite';
+import { buildRelations, createRelationsHelper, sql } from 'drizzle-orm';
+import { integer, pgTable, primaryKey, text } from 'drizzle-orm/pg-core';
+import { drizzle } from 'drizzle-orm/pglite';
+import { type GraphQLInputObjectType, type GraphQLSchema, graphql } from 'graphql';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildSchema } from '@/index';
+
+// ── Many-to-many (.through()) schema ─────────────────────────────────────────
+const Users = pgTable('users', {
+  id: integer('id').primaryKey(),
+  name: text('name').notNull(),
+});
+const Roles = pgTable('roles', {
+  id: integer('id').primaryKey(),
+  name: text('name').notNull(),
+});
+const UsersToRoles = pgTable(
+  'users_to_roles',
+  {
+    userId: integer('user_id').notNull(),
+    roleId: integer('role_id').notNull(),
+  },
+  (t) => [primaryKey({ columns: [t.userId, t.roleId] })],
+);
+
+const r = createRelationsHelper({ Users, Roles, UsersToRoles });
+const relations = buildRelations(
+  { Users, Roles, UsersToRoles },
+  {
+    Users: {
+      roles: r.many.Roles({
+        from: r.Users.id.through(r.UsersToRoles.userId),
+        to: r.Roles.id.through(r.UsersToRoles.roleId),
+      }),
+    },
+    Roles: {
+      users: r.many.Users({
+        from: r.Roles.id.through(r.UsersToRoles.roleId),
+        to: r.Users.id.through(r.UsersToRoles.userId),
+      }),
+    },
+  },
+);
+const schema = { Users, Roles, UsersToRoles, relations };
+
+const DATA_DIR = `./tests/.temp/pgdata-through-relation-filters-${Date.now()}`;
+let pglite: PGlite;
+let db: any;
+let gqlSchema: GraphQLSchema;
+let entities: any;
+
+const query = async (source: string) => await graphql({ schema: gqlSchema, source, contextValue: {} });
+
+beforeAll(async () => {
+  pglite = new PGlite(DATA_DIR);
+  await pglite.waitReady;
+  db = (drizzle as any)({ client: pglite, schema, relations, logger: !!process.env['LOG_SQL'] });
+
+  await db.execute(sql`CREATE TABLE "users" ("id" integer PRIMARY KEY NOT NULL, "name" text NOT NULL);`);
+  await db.execute(sql`CREATE TABLE "roles" ("id" integer PRIMARY KEY NOT NULL, "name" text NOT NULL);`);
+  await db.execute(
+    sql`CREATE TABLE "users_to_roles" ("user_id" integer NOT NULL, "role_id" integer NOT NULL, PRIMARY KEY ("user_id", "role_id"));`,
+  );
+
+  await db.insert(Users).values([
+    { id: 1, name: 'Alice' },
+    { id: 2, name: 'Bob' },
+    { id: 3, name: 'Carol' },
+    { id: 4, name: 'Dave' },
+  ]);
+  await db.insert(Roles).values([
+    { id: 1, name: 'admin' },
+    { id: 2, name: 'editor' },
+    { id: 3, name: 'viewer' },
+  ]);
+  // Alice: admin + editor; Bob: editor; Carol: viewer; Dave: no roles.
+  await db.insert(UsersToRoles).values([
+    { userId: 1, roleId: 1 },
+    { userId: 1, roleId: 2 },
+    { userId: 2, roleId: 2 },
+    { userId: 3, roleId: 3 },
+  ]);
+
+  const built = buildSchema(db);
+  gqlSchema = built.schema;
+  entities = built.entities;
+});
+
+afterAll(async () => {
+  await pglite?.close().catch(() => {});
+  await rm(DATA_DIR, { recursive: true, force: true }).catch(() => {});
+});
+
+describe.sequential('through-relation filters', () => {
+  it('filters a table by a through-relation with `some`', async () => {
+    const result = await query(`{
+      users(where: { roles: { some: { name: { eq: "admin" } } } }, orderBy: { id: { direction: asc, priority: 1 } }) {
+        id
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([{ id: 1 }]);
+  });
+
+  it('`some: {}` matches rows with at least one related row', async () => {
+    const result = await query(`{
+      users(where: { roles: { some: {} } }, orderBy: { id: { direction: asc, priority: 1 } }) { id }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
+  });
+
+  it('filters a table by a through-relation with `none`', async () => {
+    const result = await query(`{
+      users(where: { roles: { none: { name: { eq: "admin" } } } }, orderBy: { id: { direction: asc, priority: 1 } }) {
+        id
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([{ id: 2 }, { id: 3 }, { id: 4 }]);
+  });
+
+  it('`none: {}` matches rows with no related rows at all', async () => {
+    const result = await query(`{
+      users(where: { roles: { none: {} } }) { id }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([{ id: 4 }]);
+  });
+
+  it('filters a table by a through-relation with `every`', async () => {
+    // Bob only holds editor; Dave matches vacuously (no roles).
+    const result = await query(`{
+      users(where: { roles: { every: { name: { eq: "editor" } } } }, orderBy: { id: { direction: asc, priority: 1 } }) {
+        id
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([{ id: 2 }, { id: 4 }]);
+  });
+
+  it('combines several match modes on one through-relation', async () => {
+    const result = await query(`{
+      users(where: {
+        roles: {
+          some: { name: { eq: "editor" } }
+          none: { name: { eq: "admin" } }
+        }
+      }) { id }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([{ id: 2 }]);
+  });
+
+  it('filters from the reverse side of the junction', async () => {
+    const result = await query(`{
+      roles(where: { users: { some: { name: { eq: "Alice" } } } }, orderBy: { id: { direction: asc, priority: 1 } }) {
+        id
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.roles).toEqual([{ id: 1 }, { id: 2 }]);
+  });
+
+  it('ANDs a through-relation filter with column filters', async () => {
+    // Names containing "o": Bob and Carol; only Bob holds editor.
+    const result = await query(`{
+      users(where: { name: { like: "%o%" }, roles: { some: { name: { eq: "editor" } } } }) { id }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([{ id: 2 }]);
+  });
+
+  it('supports through-relation filters inside OR', async () => {
+    const result = await query(`{
+      users(
+        where: { OR: [{ name: { eq: "Carol" } }, { roles: { some: { name: { eq: "admin" } } } }] }
+        orderBy: { id: { direction: asc, priority: 1 } }
+      ) { id }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([{ id: 1 }, { id: 3 }]);
+  });
+
+  it('nests a through-relation filter inside another through-relation filter', async () => {
+    // Users sharing a role with Bob (editor): Alice and Bob. Exercises alias uniqueness
+    // across nested EXISTS subqueries that each add a junction alias.
+    const result = await query(`{
+      users(
+        where: { roles: { some: { users: { some: { name: { eq: "Bob" } } } } } }
+        orderBy: { id: { direction: asc, priority: 1 } }
+      ) { id }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([{ id: 1 }, { id: 2 }]);
+  });
+
+  it('applies through-relation filters to aggregate queries', async () => {
+    const result = await query(`{
+      usersAggregate(where: { roles: { some: { name: { eq: "editor" } } } }) { count }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.usersAggregate).toEqual({ count: 2 });
+  });
+
+  describe('schema shape', () => {
+    const input = (name: string) => (entities.inputs as Record<string, GraphQLInputObjectType>)[name]!;
+
+    it('exposes through-relations as the some/none/every wrapper', () => {
+      const fields = input('UsersFilters').getFields();
+
+      expect(fields['roles']).toBeDefined();
+      const rolesFilter = fields['roles']!.type as GraphQLInputObjectType;
+      expect(rolesFilter.name).toBe('RolesListRelationFilter');
+      expect(Object.keys(rolesFilter.getFields())).toEqual(['some', 'none', 'every']);
+      expect(rolesFilter.getFields()['some']!.type).toBe(input('RolesFilters'));
+    });
+
+    it('exposes the reverse through-relation too', () => {
+      const fields = input('RolesFilters').getFields();
+
+      expect(fields['users']).toBeDefined();
+      expect((fields['users']!.type as GraphQLInputObjectType).name).toBe('UsersListRelationFilter');
+    });
+
+    it('offers through-relation filters in the OR variant', () => {
+      const orField = input('UsersFilters').getFields()['OR']!;
+      const orType = (orField.type as any).ofType.ofType as GraphQLInputObjectType;
+
+      expect(orType.name).toBe('UsersFiltersOr');
+      expect(orType.getFields()['roles']).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Relation filters (`some` / `none` / `every`) now work on many-to-many relations declared with `.through()`. They were previously left out of the filter input entirely, so schemas full of junction-table relations (e.g. migrated from Prisma implicit m2m) couldn't express "users who hold role X" without a hand-written resolver.

Closes #19

## Compilation strategy

The existing `EXISTS` compilation extends naturally — a through-relation just needs a longer `FROM` clause inside the subquery:

- **Direct relation** (unchanged): `EXISTS (SELECT 1 FROM target AS dgql_rel_N WHERE <parent-correlation> AND <inner filter>)`
- **Through relation**: `EXISTS (SELECT 1 FROM target AS dgql_rel_N INNER JOIN junction AS dgql_rel_M ON <junction.target-keys = target-keys> WHERE <parent.source-keys = junction.source-keys> AND <inner filter>)`

Details:

- `buildRelationExists` in `src/util/builders/common.ts` branches on the relation's `throughTable` (drizzle-orm 1.x puts the junction `Table` there, with the paired junction columns in `relation.through.source` / `relation.through.target`). It builds the subquery's `FROM` clause and correlation, and everything downstream — mode handling, the relation's own declared `where`, nested inner filters — is shared with the direct case.
- `none` and `every` carry over unchanged: `none` is `NOT EXISTS (join WHERE inner)`, `every` is `NOT EXISTS (join WHERE NOT inner)` (vacuously true with no inner condition), exactly as compiled for direct relations.
- Both the junction and the target reuse the existing `dgql_rel_N` alias counter, so nested and mutually-referencing through-filters (`roles: { some: { users: { some: … } } }`) never collide.
- The junction's columns are resolved on the aliased junction proxy by property key first (drizzle's `RelationsBuilderColumn._.key`), falling back to SQL name — mirroring how drizzle-orm's own `relationToSQL` reads them.
- The filter input reuses the target table's existing `<Target>Filters` / `<Target>ListRelationFilter` types, so a through-relation looks identical to a direct to-many relation in the SDL.
- The machinery lives in `common.ts` and the emitted SQL (`EXISTS` + `INNER JOIN`) is dialect-portable, so PostgreSQL, MySQL, and SQLite all get it.

The README note that `.through()` relations are excluded from the filter input is replaced with a description (and example) of the new behavior.

## Tests

New `tests/pglite/through-relation-filters.test.ts` (self-contained schema: `users` / `roles` / `users_to_roles`, through-relations declared in both directions), covering:

- `some` ("users who hold role admin"), `some: {}`, `none`, `none: {}`, `every`, and several modes combined on one relation
- filtering from the reverse side of the junction
- a through-relation filter combined with column filters (implicit `AND`) and nested inside `OR`
- a through-filter nested inside another through-filter (alias uniqueness across nested `EXISTS`)
- through-filters on aggregate queries
- SDL shape: the relation now appears in the filter input (`UsersFilters.roles: RolesListRelationFilter` with `some`/`none`/`every`, the reverse field, and the `OR` variant)

Verification: `npx tsc --noEmit` clean, `npx biome check` clean on changed files, `npx vitest run tests/pglite/ tests/sqlite.test.ts tests/sqlite-custom.test.ts` — 31 files, 412 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
