### PR TITLE
feat(schema): per-column scalar overrides via scalars map and mapColumnType

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,12 @@ export {
   GraphQLJSON,
   GraphQLUUID,
 } from './util/scalars/index.ts';
+export type {
+  ColumnTypeMapper,
+  ColumnTypeMapperInfo,
+  ScalarOverride,
+  ScalarOverridesConfig,
+} from './util/type-converter/types.ts';
 
 type ObjMap<T> = Record<string, T>;
 
@@ -159,6 +165,8 @@ export const buildSchema = <TDbClient extends AnyDrizzleDB<any>>(
     shouldEagerLoad,
     features,
     complexity,
+    scalars: config?.scalars,
+    mapColumnType: config?.mapColumnType,
   };
 
   let generatorOutput;

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,7 @@ import type {
   GetRemappedTableUpdateDataType,
   OrderByArgs,
 } from './util/builders/index.ts';
+import type { ColumnTypeMapper, ScalarOverridesConfig } from './util/type-converter/types.ts';
 
 export type MakeRequired<T> = T & { [P in keyof T]-?: T[P] };
 
@@ -730,6 +731,56 @@ export type BuildSchemaConfig = {
    * @default true
    */
   eagerLoadRelations?: boolean | ((tableName: string, relationName: string) => boolean);
+  /**
+   * Declarative per-table, per-column scalar overrides — replaces the GraphQL type built-in
+   * detection would pick for a column with the scalar you provide, everywhere that column's
+   * type surfaces: the object type, create/update inputs, filter operands (in a filter type
+   * named `${Scalar}Filter`), and aggregate min/max fields.
+   *
+   * Keys are the Drizzle schema keys: the table's key in your schema object and the column's
+   * property name. The value is either one scalar for both directions, or `{ output, input }`
+   * to type outputs and inputs differently (either side may be omitted to keep the default).
+   *
+   * ```ts
+   * buildSchema(db, {
+   *   scalars: {
+   *     users: {
+   *       balance: GraphQLBigIntString,                      // both directions
+   *       settings: { output: PrettyJSON },                  // output only, input stays default
+   *     },
+   *   },
+   * });
+   * ```
+   *
+   * Validation and coercion become the scalar's job: for an overridden column the generated
+   * resolvers pass values through untouched — `parseValue`/`parseLiteral` results go to the
+   * database driver as-is, and raw driver values go to `serialize` as-is — so the scalar must
+   * accept what the driver produces and produce what the driver accepts.
+   *
+   * A declarative entry fully decides its column and wins over {@link mapColumnType}.
+   */
+  scalars?: ScalarOverridesConfig;
+  /**
+   * Rule-based scalar mapping, called once per column at build time — the tool for applying
+   * a convention across many columns (e.g. "every `numeric` column is `Money`") or for typing
+   * custom column types the built-in detection does not know.
+   *
+   * Return a scalar (or `{ output, input }` pair) to override the column, or `undefined` to
+   * keep the default. `info` carries the table/column schema keys and the types built-in
+   * detection would use (`defaultType` / `defaultInputType`), so rules can key off either the
+   * Drizzle column or the default GraphQL type.
+   *
+   * ```ts
+   * buildSchema(db, {
+   *   mapColumnType: (column, { columnName }) =>
+   *     column.columnType === 'PgNumeric' ? MoneyScalar : undefined,
+   * });
+   * ```
+   *
+   * Same semantics as {@link scalars} otherwise; a column matched by both is decided by
+   * `scalars` alone.
+   */
+  mapColumnType?: ColumnTypeMapper;
   /**
    * Called for every error thrown by a generated resolver, before it reaches the client.
    *

--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -20,6 +20,7 @@ import {
   asc,
   desc,
   eq,
+  extractExtendedColumnType,
   getColumns,
   getTableAsAliasSQL,
   gt,
@@ -59,7 +60,7 @@ import type { ResolveTree } from 'graphql-parse-resolve-info';
 import { getOrCreateLoader } from '../batch-loader/index.ts';
 import { capitalize, uncapitalize } from '../case-ops/index.ts';
 import { remapFromGraphQLCore, remapToGraphQLArrayOutput, remapToGraphQLSingleOutput } from '../data-mappers/index.ts';
-import { drizzleColumnToGraphQLType } from '../type-converter/index.ts';
+import { drizzleColumnToGraphQLType, getColumnScalarOverride } from '../type-converter/index.ts';
 import type {
   ConvertedColumn,
   ConvertedInputColumn,
@@ -492,6 +493,14 @@ export interface TypeCacheCtx {
    * @deprecated No longer used — relation fields now reference the target table's own type directly.
    */
   relationTypeCache: Map<string, GraphQLObjectType>;
+  /**
+   * Per-call cache for a table's converted select-field map, keyed by table reference.
+   * Per-call (not module-level) because scalar overrides can differ between builds that
+   * share the same table objects.
+   */
+  selectFieldCache: WeakMap<object, Record<string, ConvertedColumn>>;
+  /** Per-call cache for a table's column-filter field map, keyed by table reference. */
+  filterFieldCache: WeakMap<object, Record<string, ConvertedInputColumn>>;
   /** Per-call cache for order GraphQL input types, keyed by table reference. */
   orderTypeCache: WeakMap<object, GraphQLInputObjectType>;
   /** Per-call cache for filter GraphQL input types, keyed by table reference. */
@@ -751,7 +760,15 @@ const generateColumnFilterValues = (
 ): GraphQLInputObjectType => {
   const columnGraphQLType = drizzleColumnToGraphQLType(column, columnName, tableName, true, false, true);
 
-  const genericName = resolveGenericFilterName(column, columnName, columnGraphQLType);
+  // A scalar-overridden column gets a filter type named after the scalar (e.g. MoneyFilter)
+  // whose operands are the scalar itself. The override beats the name-based Id heuristic and
+  // every other generic bucket. The cache stays keyed by name, so all columns overridden with
+  // the same scalar share one filter type.
+  const inputOverride = getColumnScalarOverride(column, true);
+
+  const genericName = inputOverride
+    ? inputOverride.name
+    : resolveGenericFilterName(column, columnName, columnGraphQLType);
   const cached = cacheCtx.genericFilterCache.get(genericName);
   if (cached) {
     return cached.main;
@@ -762,7 +779,12 @@ const generateColumnFilterValues = (
   const colArr = new GraphQLList(new GraphQLNonNull(colType));
 
   // IdFilter omits like/notLike/ilike/notIlike — they are nonsensical on UUIDs.
-  const isId = genericName === 'Id';
+  const isId = !inputOverride && genericName === 'Id';
+
+  // String-pattern operators: for overridden columns they only make sense when the
+  // underlying database column is string-typed; otherwise keep the existing rule
+  // (all filters except IdFilter carry them).
+  const withStringOps = inputOverride ? extractExtendedColumnType(column).type === 'string' : !isId;
 
   const baseFields = {
     eq: { type: colType, description: colDesc },
@@ -771,14 +793,14 @@ const generateColumnFilterValues = (
     lte: { type: colType, description: colDesc },
     gt: { type: colType, description: colDesc },
     gte: { type: colType, description: colDesc },
-    ...(isId
-      ? {}
-      : {
+    ...(withStringOps
+      ? {
           like: { type: GraphQLString },
           notLike: { type: GraphQLString },
           ilike: { type: GraphQLString },
           notIlike: { type: GraphQLString },
-        }),
+        }
+      : {}),
     inArray: { type: colArr, description: `Array<${colDesc}>` },
     notInArray: { type: colArr, description: `Array<${colDesc}>` },
     isNull: { type: GraphQLBoolean },
@@ -824,10 +846,9 @@ const generateTableOrderCached = (table: Table) => {
   return remapped;
 };
 
-const filterMap = new WeakMap<object, Record<string, ConvertedInputColumn>>();
 const generateTableFilterValuesCached = (table: Table, tableName: string, cacheCtx: TypeCacheCtx) => {
-  if (filterMap.has(table)) {
-    return filterMap.get(table)!;
+  if (cacheCtx.filterFieldCache.has(table)) {
+    return cacheCtx.filterFieldCache.get(table)!;
   }
 
   const columns = getColumns(table);
@@ -842,15 +863,18 @@ const generateTableFilterValuesCached = (table: Table, tableName: string, cacheC
     ]),
   );
 
-  filterMap.set(table, remapped);
+  cacheCtx.filterFieldCache.set(table, remapped);
 
   return remapped;
 };
 
-const fieldMap = new WeakMap<object, Record<string, ConvertedColumn>>();
-const generateTableSelectTypeFieldsCached = (table: Table, tableName: string): Record<string, ConvertedColumn> => {
-  if (fieldMap.has(table)) {
-    return fieldMap.get(table)!;
+const generateTableSelectTypeFieldsCached = (
+  table: Table,
+  tableName: string,
+  cacheCtx: TypeCacheCtx,
+): Record<string, ConvertedColumn> => {
+  if (cacheCtx.selectFieldCache.has(table)) {
+    return cacheCtx.selectFieldCache.get(table)!;
   }
 
   const columns = getColumns(table);
@@ -863,7 +887,7 @@ const generateTableSelectTypeFieldsCached = (table: Table, tableName: string): R
     ]),
   );
 
-  fieldMap.set(table, remapped);
+  cacheCtx.selectFieldCache.set(table, remapped);
 
   return remapped;
 };
@@ -1069,7 +1093,7 @@ const generateSelectFields = <TWithOrder extends boolean>(
   const table = tables[tableName]!;
   const order = withOrder ? generateTableOrderTypeCached(table, tableName, typeNameMapper, cacheCtx) : undefined;
   const filters = generateTableFilterTypeCached(table, tableName, cacheCtx, typeNameMapper, relationMap, tables);
-  const tableFields = generateTableSelectTypeFieldsCached(table, tableName);
+  const tableFields = generateTableSelectTypeFieldsCached(table, tableName, cacheCtx);
 
   const relationsForTable = relationMap[tableName];
   const relationEntries: [string, TableNamedRelations][] = relationsForTable ? Object.entries(relationsForTable) : [];
@@ -1176,7 +1200,7 @@ const generateSelectFields = <TWithOrder extends boolean>(
         //   (a) this relation field has a concrete type reference, and
         //   (b) when the target table's root call eventually runs, it reuses this same object.
         const targetTable = tables[targetTableName]!;
-        const targetTableFields = generateTableSelectTypeFieldsCached(targetTable, targetTableName);
+        const targetTableFields = generateTableSelectTypeFieldsCached(targetTable, targetTableName, cacheCtx);
         // Get or create a container for the target table's relation fields.
         let targetContainer = cacheCtx.relationFieldContainers.get(targetTableName);
         if (!targetContainer) {

--- a/src/util/builders/mysql.ts
+++ b/src/util/builders/mysql.ts
@@ -46,6 +46,7 @@ import {
   toGraphQLError,
 } from '../builders/common.ts';
 import { remapFromGraphQLArrayInput, remapFromGraphQLSingleInput } from '../data-mappers/index.ts';
+import { registerScalarOverrides } from '../type-converter/index.ts';
 import {
   createRelationAggregateFactory,
   generateAggregate,
@@ -416,6 +417,10 @@ export const generateSchemaData = <
     );
   }
 
+  // Resolve scalar overrides into the type-converter's registry before any type generation —
+  // every subsequent column→GraphQL type decision and runtime value remap consults it.
+  registerScalarOverrides(tables, options);
+
   // Build namedRelations from the drizzle-orm v1 relations config.
   const namedRelations = buildNamedRelations(relations ?? {}, tableEntries);
   // Record each relation target's (composite-aware) primary key for deterministic
@@ -436,6 +441,8 @@ export const generateSchemaData = <
     relationFieldContainers: new Map(),
     fullyBuiltTables: new Set(),
     relationTypeCache: new Map(),
+    selectFieldCache: new WeakMap(),
+    filterFieldCache: new WeakMap(),
     orderTypeCache: new WeakMap(),
     filterTypeCache: new WeakMap(),
     listRelationFilterCache: new Map(),

--- a/src/util/builders/pg.ts
+++ b/src/util/builders/pg.ts
@@ -58,6 +58,7 @@ import {
   remapToGraphQLArrayOutput,
   remapToGraphQLSingleOutput,
 } from '../data-mappers/index.ts';
+import { registerScalarOverrides } from '../type-converter/index.ts';
 import {
   createRelationAggregateFactory,
   generateAggregate,
@@ -663,6 +664,10 @@ export function generateSchemaData<
     );
   }
 
+  // Resolve scalar overrides into the type-converter's registry before any type generation —
+  // every subsequent column→GraphQL type decision and runtime value remap consults it.
+  registerScalarOverrides(tables, options);
+
   // Flatten drizzle-orm v1 TablesRelationalConfig into the canonical shape
   // used throughout common.ts: Record<tableName, Record<relName, TableNamedRelations>>
   const namedRelations = buildNamedRelations(relations ?? {}, tableEntries);
@@ -687,6 +692,8 @@ export function generateSchemaData<
     relationFieldContainers: new Map(),
     fullyBuiltTables: new Set(),
     relationTypeCache: new Map(),
+    selectFieldCache: new WeakMap(),
+    filterFieldCache: new WeakMap(),
     orderTypeCache: new WeakMap(),
     filterTypeCache: new WeakMap(),
     listRelationFilterCache: new Map(),

--- a/src/util/builders/sqlite.ts
+++ b/src/util/builders/sqlite.ts
@@ -55,6 +55,7 @@ import {
   remapToGraphQLArrayOutput,
   remapToGraphQLSingleOutput,
 } from '../data-mappers/index.ts';
+import { registerScalarOverrides } from '../type-converter/index.ts';
 import {
   createRelationAggregateFactory,
   generateAggregate,
@@ -580,6 +581,10 @@ export const generateSchemaData = <
     );
   }
 
+  // Resolve scalar overrides into the type-converter's registry before any type generation —
+  // every subsequent column→GraphQL type decision and runtime value remap consults it.
+  registerScalarOverrides(tables, options);
+
   // Build namedRelations from the drizzle-orm v1 relations config.
   const namedRelations = buildNamedRelations(relations ?? {}, tableEntries);
   // Record each relation target's (composite-aware) primary key for deterministic
@@ -600,6 +605,8 @@ export const generateSchemaData = <
     relationFieldContainers: new Map(),
     fullyBuiltTables: new Set(),
     relationTypeCache: new Map(),
+    selectFieldCache: new WeakMap(),
+    filterFieldCache: new WeakMap(),
     orderTypeCache: new WeakMap(),
     filterTypeCache: new WeakMap(),
     listRelationFilterCache: new Map(),

--- a/src/util/builders/types.ts
+++ b/src/util/builders/types.ts
@@ -9,7 +9,12 @@ import type {
   GraphQLObjectType,
   GraphQLScalarType,
 } from 'graphql';
-import type { ConvertedColumn, ConvertedRelationColumnWithArgs } from '../type-converter/types.ts';
+import type {
+  ColumnTypeMapper,
+  ConvertedColumn,
+  ConvertedRelationColumnWithArgs,
+  ScalarOverridesConfig,
+} from '../type-converter/types.ts';
 import type { ResolvedComplexityOptions } from './common.ts';
 // import type {
 //   ConvertedColumn,
@@ -45,6 +50,10 @@ export type SchemaGeneratorOptions = {
   features: GeneratorFeatures;
   /** Resolved cost-hint settings, or `undefined` when the caller passed `complexity: false`. */
   complexity: ResolvedComplexityOptions | undefined;
+  /** Declarative per-table/per-column scalar overrides. See `BuildSchemaConfig.scalars`. */
+  scalars?: ScalarOverridesConfig;
+  /** Rule-based scalar mapping. See `BuildSchemaConfig.mapColumnType`. */
+  mapColumnType?: ColumnTypeMapper;
 };
 
 export type TableNamedRelations = {

--- a/src/util/data-mappers/index.ts
+++ b/src/util/data-mappers/index.ts
@@ -2,6 +2,7 @@
 import { type Column, getTableColumns, is, One, type Table } from 'drizzle-orm';
 import { GraphQLError } from 'graphql';
 import type { TableNamedRelations } from '../builders/index.ts';
+import { getColumnScalarOverride } from '../type-converter/index.ts';
 
 // drizzle-orm v1 uses compound dataType strings (e.g. "object json"), so inclusion rather
 // than equality. PgGeometryObject is stored as json but has its own object type.
@@ -46,6 +47,13 @@ export const remapToGraphQLCore = (
 
   // For non-relation fields, require a column definition.
   if (!column) {
+    return value;
+  }
+
+  // Columns whose output type is a scalar override hand the driver's raw value straight to
+  // that scalar — serialization is wholly the scalar's job, and converting here first would
+  // double-convert.
+  if (getColumnScalarOverride(column, false)) {
     return value;
   }
 
@@ -137,6 +145,17 @@ export const remapToGraphQLArrayOutput = (
 };
 
 export const remapFromGraphQLCore = (value: any, column: Column, columnName: string) => {
+  // Columns whose input type is a scalar override receive exactly what that scalar's
+  // parseValue/parseLiteral produced — coercion is the scalar's job, so the value goes to
+  // the driver untouched. Only the null-prototype normalization still applies (it undoes a
+  // graphql-js artifact, not a coercion — see the default case below).
+  if (getColumnScalarOverride(column, true)) {
+    if (typeof value === 'object' && value !== null && Object.getPrototypeOf(value) === null) {
+      return Object.assign({}, value);
+    }
+    return value;
+  }
+
   // drizzle-orm v1 uses compound dataType strings (e.g. "object date", "bigint int64").
   // We must check inclusion rather than equality to handle these cases.
   const dataType: string = (column as any).dataType ?? '';

--- a/src/util/type-converter/index.ts
+++ b/src/util/type-converter/index.ts
@@ -1,5 +1,5 @@
-import type { Column } from 'drizzle-orm';
-import { extractExtendedColumnType, is } from 'drizzle-orm';
+import type { Column, Table } from 'drizzle-orm';
+import { extractExtendedColumnType, getTableColumns, is } from 'drizzle-orm';
 import { MySqlInt, MySqlSerial } from 'drizzle-orm/mysql-core';
 import { PgDate, PgDateString, PgInteger, PgSerial, PgTimestamp, PgTimestampString, PgUUID } from 'drizzle-orm/pg-core';
 import { SQLiteInteger } from 'drizzle-orm/sqlite-core';
@@ -8,16 +8,18 @@ import {
   GraphQLEnumType,
   GraphQLFloat,
   GraphQLInputObjectType,
+  type GraphQLInputType,
   GraphQLInt,
   GraphQLList,
   GraphQLNonNull,
   GraphQLObjectType,
-  type GraphQLScalarType,
+  type GraphQLOutputType,
+  GraphQLScalarType,
   GraphQLString,
 } from 'graphql';
 import { capitalize } from '../case-ops/index.ts';
 import { GraphQLBigIntString, GraphQLDate, GraphQLDateTime, GraphQLJSON, GraphQLUUID } from '../scalars/index.ts';
-import type { ConvertedColumn } from './types.ts';
+import type { ColumnTypeMapper, ConvertedColumn, ScalarOverride, ScalarOverridesConfig } from './types.ts';
 
 const allowedNameChars = /^[a-zA-Z0-9_]+$/;
 
@@ -159,6 +161,94 @@ const columnToGraphQLCore = (
   }
 };
 
+/**
+ * Per-column scalar overrides, resolved at build time from `BuildSchemaConfig.scalars` /
+ * `BuildSchemaConfig.mapColumnType` and consulted by every column→GraphQL type decision
+ * (select fields, insert/update inputs, filter operands, aggregate min/max) as well as by
+ * the runtime data mappers, which must not re-coerce a value an override scalar owns.
+ *
+ * Keyed weakly by the column object itself so the registry never outlives the schema.
+ * `registerScalarOverrides` runs on every build and clears entries for columns that no
+ * longer have an override; when two live schemas are built from the same table objects
+ * with different scalar configs, the most recent build wins for runtime value mapping.
+ */
+const columnScalarOverrides = new WeakMap<Column, { output?: GraphQLScalarType; input?: GraphQLScalarType }>();
+
+/** The scalar overriding this column in the given direction, if one was registered. */
+export const getColumnScalarOverride = (column: Column, isInput: boolean): GraphQLScalarType | undefined => {
+  const override = columnScalarOverrides.get(column);
+  return override ? (isInput ? override.input : override.output) : undefined;
+};
+
+const normalizeScalarOverride = (
+  override: ScalarOverride,
+  tableName: string,
+  columnName: string,
+): { output?: GraphQLScalarType; input?: GraphQLScalarType } => {
+  const pair =
+    override instanceof GraphQLScalarType
+      ? { output: override, input: override }
+      : { output: override.output, input: override.input };
+
+  for (const scalar of [pair.output, pair.input]) {
+    if (scalar !== undefined && !(scalar instanceof GraphQLScalarType)) {
+      throw new Error(
+        `Drizzle-GraphQL Error: Scalar override for column '${tableName}.${columnName}' must be a GraphQLScalarType!`,
+      );
+    }
+  }
+
+  return pair;
+};
+
+/**
+ * Resolves the scalar-override config against every column of the given tables and stores
+ * the result in the override registry. Called once per schema build, before any types are
+ * generated — and always, even with no config, so a rebuild clears overrides left behind
+ * by a previous build against the same table objects.
+ *
+ * The declarative `scalars` map wins over `mapColumnType`; a mapper returning `undefined`
+ * leaves the column on built-in detection.
+ */
+export const registerScalarOverrides = (
+  tables: Record<string, Table>,
+  config: { scalars?: ScalarOverridesConfig; mapColumnType?: ColumnTypeMapper },
+): void => {
+  for (const [tableName, table] of Object.entries(tables)) {
+    for (const [columnName, column] of Object.entries(getTableColumns(table))) {
+      const declared = config.scalars?.[tableName]?.[columnName];
+
+      let resolved: { output?: GraphQLScalarType; input?: GraphQLScalarType } | undefined;
+      if (declared !== undefined) {
+        resolved = normalizeScalarOverride(declared, tableName, columnName);
+      } else if (config.mapColumnType) {
+        // Built-in detection throws for column types it has no mapping for; the mapper is
+        // exactly the tool to type such columns, so a failed default becomes `undefined`
+        // rather than an error.
+        let defaultType: GraphQLOutputType | undefined;
+        let defaultInputType: GraphQLInputType | undefined;
+        try {
+          defaultType = columnToGraphQLCore(column, columnName, tableName, false).type as GraphQLOutputType;
+        } catch {}
+        try {
+          defaultInputType = columnToGraphQLCore(column, columnName, tableName, true).type as GraphQLInputType;
+        } catch {}
+
+        const mapped = config.mapColumnType(column, { tableName, columnName, defaultType, defaultInputType });
+        if (mapped !== undefined) {
+          resolved = normalizeScalarOverride(mapped, tableName, columnName);
+        }
+      }
+
+      if (resolved && (resolved.output !== undefined || resolved.input !== undefined)) {
+        columnScalarOverrides.set(column, resolved);
+      } else {
+        columnScalarOverrides.delete(column);
+      }
+    }
+  }
+};
+
 export const drizzleColumnToGraphQLType = <TColumn extends Column, TIsInput extends boolean>(
   column: TColumn,
   columnName: string,
@@ -167,11 +257,19 @@ export const drizzleColumnToGraphQLType = <TColumn extends Column, TIsInput exte
   defaultIsNullable = false,
   isInput: TIsInput = false as TIsInput,
 ): ConvertedColumn<TIsInput> => {
-  const typeDesc = columnToGraphQLCore(column, columnName, tableName, isInput);
-  const noDesc = ['string', 'boolean', 'number'];
-  const { type: baseType } = extractExtendedColumnType(column);
-  if (noDesc.find((e) => e === baseType)) {
-    delete typeDesc.description;
+  const override = getColumnScalarOverride(column, isInput);
+  let typeDesc: ConvertedColumn<boolean>;
+  if (override) {
+    // The override replaces built-in detection entirely; the description mirrors the
+    // pattern used for the built-in named scalars (BigInt, DateTime, JSON, …).
+    typeDesc = { type: override, description: override.name };
+  } else {
+    typeDesc = columnToGraphQLCore(column, columnName, tableName, isInput);
+    const noDesc = ['string', 'boolean', 'number'];
+    const { type: baseType } = extractExtendedColumnType(column);
+    if (noDesc.find((e) => e === baseType)) {
+      delete typeDesc.description;
+    }
   }
 
   if (forceNullable) {

--- a/src/util/type-converter/types.ts
+++ b/src/util/type-converter/types.ts
@@ -1,13 +1,52 @@
+import type { Column } from 'drizzle-orm';
 import type {
   GraphQLEnumType,
   GraphQLFieldConfig,
   GraphQLFieldResolver,
   GraphQLInputObjectType,
+  GraphQLInputType,
   GraphQLList,
   GraphQLNonNull,
   GraphQLObjectType,
+  GraphQLOutputType,
   GraphQLScalarType,
 } from 'graphql';
+
+/**
+ * A scalar override for one column. A bare scalar applies to both directions; the object form
+ * lets output (object type, aggregate min/max) and input (create/update inputs, filter operands)
+ * use different scalars — or override only one side, leaving the other on built-in detection.
+ */
+export type ScalarOverride = GraphQLScalarType | { output?: GraphQLScalarType; input?: GraphQLScalarType };
+
+/**
+ * Declarative per-table, per-column scalar overrides. Keys are the Drizzle schema keys —
+ * the table's key in the schema object and the column's property name (not the SQL names).
+ */
+export type ScalarOverridesConfig = Record<string, Record<string, ScalarOverride>>;
+
+/** Context handed to {@link ColumnTypeMapper} alongside the column itself. */
+export type ColumnTypeMapperInfo = {
+  /** The table's key in the Drizzle schema object. */
+  tableName: string;
+  /** The column's property name on the table object. */
+  columnName: string;
+  /**
+   * The GraphQL type built-in detection would use for output positions (without nullability
+   * wrapping). `undefined` when detection has no mapping for the column's data type — the
+   * mapper is then the only way to give the column a type.
+   */
+  defaultType: GraphQLOutputType | undefined;
+  /** The input-position counterpart of `defaultType`. */
+  defaultInputType: GraphQLInputType | undefined;
+};
+
+/**
+ * Rule-based scalar mapping, called once per column at build time. Return a scalar (or
+ * `{ output, input }` pair) to override the column's GraphQL type, or `undefined` to keep
+ * the built-in detection.
+ */
+export type ColumnTypeMapper = (column: Column, info: ColumnTypeMapperInfo) => ScalarOverride | undefined;
 
 export type ConvertedColumn<TIsInput extends boolean = false> = {
   type:

--- a/tests/pglite/scalar-overrides.test.ts
+++ b/tests/pglite/scalar-overrides.test.ts
@@ -1,0 +1,292 @@
+import { mkdirSync } from 'node:fs';
+import { PGlite } from '@electric-sql/pglite';
+import { buildRelations, sql } from 'drizzle-orm';
+import { integer, jsonb, numeric, pgTable, real, serial, text } from 'drizzle-orm/pg-core';
+import { drizzle } from 'drizzle-orm/pglite';
+import {
+  type GraphQLInputObjectType,
+  type GraphQLObjectType,
+  GraphQLScalarType,
+  type GraphQLSchema,
+  graphql,
+} from 'graphql';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildSchema, GraphQLBigIntString } from '@/index';
+
+// ── Hand-made scalars with distinctive coercion, to prove the generated resolvers
+//    pass values through untouched (no double conversion on top of the scalar's own).
+
+/** Integer cents in the database ⇄ "$12.34" strings over GraphQL. */
+const GraphQLMoney = new GraphQLScalarType<number, string>({
+  name: 'Money',
+  serialize: (value) => {
+    if (typeof value !== 'number' || !Number.isInteger(value)) {
+      throw new TypeError(`Money cannot serialize non-integer value: ${String(value)}`);
+    }
+    return `$${(value / 100).toFixed(2)}`;
+  },
+  parseValue: (value) => {
+    if (typeof value !== 'string' || !/^\$\d+\.\d{2}$/.test(value)) {
+      throw new TypeError(`Money must look like "$12.34", got: ${String(value)}`);
+    }
+    return Math.round(Number(value.slice(1)) * 100);
+  },
+});
+
+/** Output-only: serializes whatever the driver returned as a JSON string. */
+const GraphQLJSONText = new GraphQLScalarType<unknown, string>({
+  name: 'JSONText',
+  serialize: (value) => JSON.stringify(value),
+});
+
+/** Prefixes the stored float with "score:" so serialization is observable. */
+const GraphQLScore = new GraphQLScalarType<number, string>({
+  name: 'Score',
+  serialize: (value) => `score:${String(value)}`,
+  parseValue: (value) => {
+    const parsed = Number(String(value).replace(/^score:/, ''));
+    if (Number.isNaN(parsed)) {
+      throw new TypeError(`Score cannot parse: ${String(value)}`);
+    }
+    return parsed;
+  },
+});
+
+/** Used by mapColumnType for `balance` — must LOSE to the declarative entry. */
+const GraphQLDecoy = new GraphQLScalarType({ name: 'Decoy' });
+
+// ── Schema ────────────────────────────────────────────────────────────────────
+const Products = pgTable('products', {
+  id: serial('id').primaryKey(),
+  name: text('name'),
+  balance: numeric('balance'),
+  priceCents: integer('price_cents').notNull(),
+  meta: jsonb('meta'),
+  score: real('score'),
+});
+const relations = buildRelations({ Products }, {});
+const schema = { Products, relations };
+
+const DATA_DIR = `./tests/.temp/pgdata-scalar-overrides-${Date.now()}`;
+
+let pglite: PGlite;
+let db: any;
+let gqlSchema: GraphQLSchema;
+let entities: any;
+
+const run = (source: string, variableValues?: Record<string, any>) =>
+  graphql({ schema: gqlSchema, source, contextValue: {}, variableValues });
+
+const fieldTypeName = (typeName: string, fieldName: string) =>
+  String((entities.types[typeName] as GraphQLObjectType).getFields()[fieldName]!.type);
+
+const inputFieldTypeName = (inputName: string, fieldName: string) =>
+  String(entities.inputs[inputName].getFields()[fieldName]!.type);
+
+beforeAll(async () => {
+  mkdirSync(DATA_DIR, { recursive: true });
+  pglite = new PGlite(DATA_DIR);
+  await pglite.waitReady;
+  db = (drizzle as any)({ client: pglite, schema, relations, logger: !!process.env['LOG_SQL'] });
+
+  await db.execute(
+    sql`CREATE TABLE "products" (
+      "id" serial PRIMARY KEY,
+      "name" text,
+      "balance" numeric,
+      "price_cents" integer NOT NULL,
+      "meta" jsonb,
+      "score" real
+    );`,
+  );
+
+  const built = buildSchema(db, {
+    scalars: {
+      Products: {
+        balance: GraphQLBigIntString, // exposed scalar, both directions
+        priceCents: GraphQLMoney, // hand-made scalar, both directions
+        meta: { output: GraphQLJSONText }, // asymmetric: output only, input keeps JSON
+      },
+    },
+    mapColumnType: (column, { tableName, columnName, defaultType }) => {
+      expect(tableName).toBe('Products');
+      // The declarative map already decided `balance`; the mapper is not even consulted
+      // for it, so this decoy must never surface.
+      if (columnName === 'balance') {
+        return GraphQLDecoy;
+      }
+      if (column.columnType === 'PgReal') {
+        expect(String(defaultType)).toBe('Float');
+        return GraphQLScore;
+      }
+      return undefined; // everything else keeps built-in detection
+    },
+  });
+  gqlSchema = built.schema;
+  entities = built.entities;
+});
+
+afterAll(async () => {
+  await pglite?.close().catch(() => {});
+});
+
+describe.sequential('schema shape', () => {
+  it('overrides the object type fields, keeping nullability wrapping', () => {
+    expect(fieldTypeName('Products', 'balance')).toBe('BigInt');
+    expect(fieldTypeName('Products', 'priceCents')).toBe('Money!');
+    expect(fieldTypeName('Products', 'meta')).toBe('JSONText');
+  });
+
+  it('applies rule-based mapColumnType overrides', () => {
+    expect(fieldTypeName('Products', 'score')).toBe('Score');
+  });
+
+  it('a mapper returning undefined leaves built-in detection untouched', () => {
+    expect(fieldTypeName('Products', 'id')).toBe('Int!');
+    expect(fieldTypeName('Products', 'name')).toBe('String');
+  });
+
+  it('the declarative map wins over mapColumnType', () => {
+    expect(fieldTypeName('Products', 'balance')).toBe('BigInt');
+    expect(gqlSchema.getType('Decoy')).toBeUndefined();
+  });
+
+  it('overrides the create input, honoring input/output asymmetry', () => {
+    expect(inputFieldTypeName('CreateProductsInput', 'balance')).toBe('BigInt');
+    expect(inputFieldTypeName('CreateProductsInput', 'priceCents')).toBe('Money!');
+    expect(inputFieldTypeName('CreateProductsInput', 'score')).toBe('Score');
+    // meta only overrides output — the input side keeps the default JSON scalar.
+    expect(inputFieldTypeName('CreateProductsInput', 'meta')).toBe('JSON');
+  });
+
+  it('overrides the update input', () => {
+    expect(inputFieldTypeName('UpdateProductsInput', 'balance')).toBe('BigInt');
+    expect(inputFieldTypeName('UpdateProductsInput', 'priceCents')).toBe('Money');
+  });
+
+  it('creates a filter type named after the scalar, without string-pattern operators', () => {
+    const filter = gqlSchema.getType('MoneyFilter') as GraphQLInputObjectType;
+    expect(filter).toBeDefined();
+    const fields = filter.getFields();
+    expect(String(fields['eq']!.type)).toBe('Money');
+    expect(String(fields['gte']!.type)).toBe('Money');
+    expect(String(fields['inArray']!.type)).toBe('[Money!]');
+    // priceCents is an integer column, so like/ilike make no sense.
+    expect(fields['like']).toBeUndefined();
+    expect(fields['ilike']).toBeUndefined();
+    // The Products filter input points the column at the scalar's filter type.
+    const productFilters = gqlSchema.getType('ProductsFilters') as GraphQLInputObjectType;
+    expect(String(productFilters.getFields()['priceCents']!.type)).toBe('MoneyFilter');
+  });
+
+  it('keeps string-pattern operators when the underlying column is string-typed', () => {
+    // balance is a numeric column, which Postgres drivers transport as a string.
+    const filter = gqlSchema.getType('BigIntFilter') as GraphQLInputObjectType;
+    expect(filter).toBeDefined();
+    const fields = filter.getFields();
+    expect(String(fields['eq']!.type)).toBe('BigInt');
+    expect(fields['like']).toBeDefined();
+    expect(fields['ilike']).toBeDefined();
+  });
+
+  it('overrides aggregate min/max fields', () => {
+    const aggregate = (entities.types['ProductsAggregate'] as GraphQLObjectType).getFields();
+    const min = (aggregate['min']!.type as GraphQLObjectType).getFields();
+    const max = (aggregate['max']!.type as GraphQLObjectType).getFields();
+    expect(String(min['priceCents']!.type)).toBe('Money');
+    expect(String(max['balance']!.type)).toBe('BigInt');
+  });
+});
+
+describe.sequential('round-trips', () => {
+  it('creates a row through the override scalars without double conversion', async () => {
+    const res = await run(`mutation {
+      createProductsSingle(values: {
+        name: "widget",
+        balance: "9007199254740993",
+        priceCents: "$12.34",
+        meta: { a: 1 },
+        score: "score:3.5"
+      }) { id name balance priceCents meta score }
+    }`);
+    expect(res.errors).toBeUndefined();
+    expect((res.data as any).createProductsSingle).toEqual({
+      id: 1,
+      name: 'widget',
+      // Larger than Number.MAX_SAFE_INTEGER — survives only if carried as a string.
+      balance: '9007199254740993',
+      priceCents: '$12.34',
+      meta: '{"a":1}',
+      score: 'score:3.5',
+    });
+  });
+
+  it('stores the scalar-parsed value in the database', async () => {
+    const raw = await db.execute(sql`SELECT price_cents, score FROM products WHERE id = 1;`);
+    expect(raw.rows[0]).toEqual({ price_cents: 1234, score: 3.5 });
+  });
+
+  it('accepts override values through variables', async () => {
+    const res = await run(`mutation ($v: CreateProductsInput!) { createProductsSingle(values: $v) { priceCents } }`, {
+      v: { name: 'gadget', priceCents: '$0.99', balance: '17' },
+    });
+    expect(res.errors).toBeUndefined();
+    expect((res.data as any).createProductsSingle.priceCents).toBe('$0.99');
+  });
+
+  it('rejects values the override scalar rejects', async () => {
+    const res = await run(`mutation { createProductsSingle(values: { priceCents: "12.34" }) { id } }`);
+    expect(res.errors?.[0]?.message).toMatch(/Money must look like/);
+  });
+
+  it('filters through the scalar filter type, coercing operands with the scalar', async () => {
+    const res = await run(`{ products(where: { priceCents: { eq: "$12.34" } }) { name priceCents } }`);
+    expect(res.errors).toBeUndefined();
+    expect((res.data as any).products).toEqual([{ name: 'widget', priceCents: '$12.34' }]);
+
+    const gte = await run(`{ products(where: { priceCents: { gte: "$1.00" } }) { name } }`);
+    expect(gte.errors).toBeUndefined();
+    expect((gte.data as any).products).toEqual([{ name: 'widget' }]);
+  });
+
+  it('filters an overridden string-backed column', async () => {
+    const res = await run(`{ products(where: { balance: { eq: "9007199254740993" } }) { name } }`);
+    expect(res.errors).toBeUndefined();
+    expect((res.data as any).products).toEqual([{ name: 'widget' }]);
+  });
+
+  it('updates through the override scalars', async () => {
+    const res = await run(`mutation {
+      updateProducts(set: { priceCents: "$99.99" }, where: { name: { eq: "gadget" } }) { name priceCents }
+    }`);
+    expect(res.errors).toBeUndefined();
+    expect((res.data as any).updateProducts).toEqual([{ name: 'gadget', priceCents: '$99.99' }]);
+  });
+
+  it('aggregates min/max through the override scalars', async () => {
+    const res = await run(`{ productsAggregate { min { priceCents } max { priceCents balance } } }`);
+    expect(res.errors).toBeUndefined();
+    expect((res.data as any).productsAggregate).toEqual({
+      min: { priceCents: '$12.34' },
+      max: { priceCents: '$99.99', balance: '9007199254740993' },
+    });
+  });
+});
+
+describe.sequential('rebuilds', () => {
+  it('a rebuild without overrides restores built-in detection', async () => {
+    const rebuilt = buildSchema(db);
+    const products = rebuilt.entities.types['Products'] as GraphQLObjectType;
+    expect(String(products.getFields()['priceCents']!.type)).toBe('Int!');
+    expect(String(products.getFields()['balance']!.type)).toBe('String');
+    expect(rebuilt.schema.getType('MoneyFilter')).toBeUndefined();
+
+    const res = await graphql({
+      schema: rebuilt.schema,
+      source: `{ productsSingle(where: { name: { eq: "widget" } }) { priceCents } }`,
+      contextValue: {},
+    });
+    expect(res.errors).toBeUndefined();
+    expect((res.data as any).productsSingle.priceCents).toBe(1234);
+  });
+});


### PR DESCRIPTION
Implements per-column scalar mapping so a column can be typed with any exposed or imported GraphQL scalar instead of what built-in detection picks.

Closes #33

## API

Both shapes from the issue are implemented:

```ts
buildSchema(db, {
  // Declarative one-offs, keyed by Drizzle schema keys (table key + column property name)
  scalars: {
    Products: {
      balance: GraphQLBigIntString,          // both directions
      meta: { output: GraphQLJSONText },     // output only — input keeps built-in detection
    },
  },
  // Rule-based conventions, called once per column at build time
  mapColumnType: (column, { tableName, columnName, defaultType, defaultInputType }) =>
    column.columnType === 'PgNumeric' ? MoneyScalar : undefined, // undefined = keep default
});
```

Why both: the codebase funnels every column→GraphQL type decision through a single converter (`drizzleColumnToGraphQLType`), so once one form works the other is nearly free — and they serve different jobs. The map is the ergonomic choice for typing a handful of known columns; the function is the only reasonable way to apply a convention ("every numeric column is `Money`") or to type custom column types detection does not know. Precedence is simple: a declarative entry fully decides its column and the mapper is not consulted for it; a mapper returning `undefined` falls through to built-in detection.

New exported types: `ScalarOverride`, `ScalarOverridesConfig`, `ColumnTypeMapper`, `ColumnTypeMapperInfo`.

## Semantics

**The override applies everywhere the column's type surfaces.** Object type fields, create/update inputs, filter operand types, and aggregate `min`/`max` fields all flow through the one converter, which now consults an override registry first. Nullability wrapping is unchanged (`Money!` for a `notNull` column, stripped on update inputs as before).

**Filters.** The generic filter cache is keyed by name, so an overridden column gets a filter type named after its scalar — `MoneyFilter` / `MoneyFilterOr` — with the scalar as the operand type for `eq/ne/lt/lte/gt/gte/inArray/notInArray`. All columns overridden with the same scalar share that one filter type. String-pattern operators (`like`, `notLike`, `ilike`, `notIlike`) are included only when the underlying database column is string-typed (e.g. `numeric`, which PG transports as strings) — on an integer column overridden to `Money` they make no sense and are omitted. The override also beats the `id`/`*Id` name heuristic that normally forces `IdFilter`.

**No double conversion.** For an overridden column the data mappers pass values through untouched in both directions: whatever the scalar's `parseValue`/`parseLiteral` produced goes to the driver as-is (inserts, updates, upserts, and filter operands all funnel through `remapFromGraphQLCore`), and the raw driver value goes to the scalar's `serialize` as-is (selects, mutation returns, and aggregate rows all funnel through `remapToGraphQLCore`). Validation and coercion are wholly the scalar's job, so the scalar must accept what the driver produces and produce what the driver accepts. The only remap kept on the input side is the null-prototype→plain-object normalization, which undoes a graphql-js artifact rather than coercing a value.

## Implementation

- `src/util/type-converter/index.ts` — a `WeakMap<Column, { output?, input? }>` registry plus `registerScalarOverrides(tables, options)`, which each dialect generator (`pg`, `mysql`, `sqlite`) calls at the start of every build, before any type generation. Registration resolves the declarative map, then the mapper (handing it the default output/input types detection would pick), and **deletes** entries for columns with no override — so rebuilding without config restores built-in behavior. `drizzleColumnToGraphQLType` checks the registry before running detection.
- `src/util/data-mappers/index.ts` — registry-aware pass-through in `remapFromGraphQLCore` / `remapToGraphQLCore` (covers all dialects' resolvers and the aggregate assembly).
- `src/util/builders/common.ts` — scalar-named filter types with the string-op rule above. Also moved the module-level select-field and filter-field `WeakMap` caches into the per-build `TypeCacheCtx`: they cached converted column types across builds, so two schemas built from the same table objects with different scalar configs would have leaked types into each other.
- Config plumbed `BuildSchemaConfig` → `SchemaGeneratorOptions` → all three generators.

Known sharing caveat (documented on the registry): the registry is keyed by the column objects themselves, so if two *live* schemas are built from the same table objects with different scalar configs, the most recent build wins for runtime value remapping. Each schema's type shape is captured at build time and is unaffected.

## Tests

`tests/pglite/scalar-overrides.test.ts` (18 tests, PGlite, no ports): exposed-scalar override (`GraphQLBigIntString` on `numeric`), hand-made scalars with distinctive coercion (`Money` cents⇄`"$12.34"`, `Score`, output-only `JSONText`) proving no double conversion — including a raw-SQL assertion that the parsed value is what hits the database; SDL shape across object type, create/update inputs, `MoneyFilter`/`BigIntFilter` (operator types, absent vs present `like` ops), and aggregate min/max; create/query/update/filter/aggregate round-trips; variables; scalar rejection errors; `{ output, input }` asymmetry; `mapColumnType` rules with `undefined` fall-through; declarative-beats-mapper precedence; and a rebuild without config restoring defaults.

Verified: `npx tsc --noEmit` clean, `npx biome check` clean on all touched files, `npx vitest run tests/pglite/ tests/sqlite.test.ts tests/sqlite-custom.test.ts` — 31 files, 416 tests passed (Docker-based pg/mysql suites not run per repo guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
