### PR TITLE
feat: atomic column updates, relation pagination parity, mutation return shapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ const { schema } = buildSchema(db, {
         delete: false,            // delete<Table> / delete<Table>Single mutations
         upsert: true,             // upsert<Table> / upsert<Table>Single mutations (off by default)
         nestedWrites: true,       // relation fields on the create/update inputs (off by default)
+        fieldUpdateOperations: true, // increment/push operations on the update input (off by default)
+        countMutations: true,     // update<Table>Count / delete<Table>Count mutations (off by default)
         requireWhere: true,       // make `where` non-null on plural update/delete (off by default)
     },
 })
@@ -111,8 +113,8 @@ const { schema } = buildSchema(db, {
 
 -   Any flag left out keeps its default of `true`, so `{ features: { delete: false } }`
     changes nothing else
--   `upsert` and `nestedWrites` are the exceptions: both default to `false`, so the upsert
-    mutations and the relation fields on the write inputs only exist if you ask for them
+-   `upsert`, `nestedWrites`, `fieldUpdateOperations` and `countMutations` are the
+    exceptions: all four default to `false`, so they only exist if you ask for them
 -   `groupBy` needs `aggregates`: it reuses those output types, so turning `aggregates` off
     turns the group-by queries off with it
 -   Turning off `insert` or `update` also drops the input type that only that mutation
@@ -467,7 +469,10 @@ enum. Rows sharing the same combination of those columns collapse to one:
 -   `where` is applied **before** rows are collapsed; `limit` and `offset` are applied
     **after**, so `limit: 10` returns ten distinct rows
 -   Several columns are treated as one combined key, not as independent ones
--   `distinct` is available on list queries only — a single query returns one row either way
+-   `distinct` is also available on to-many relation fields, where it means one row per
+    distinct value **per parent** — the window is partitioned by the foreign key as well as
+    the requested columns
+-   `distinct` is not on single queries — those return one row either way
 
 It runs as an extra `row_number() over (partition by …)` query that picks the surviving
 rows' primary keys, after which the main query is narrowed to them — so it needs the same
@@ -535,6 +540,32 @@ field, and passing it back as `after` resumes strictly after that row.
     cursor pagination (its `cursor` field resolves to `null`)
 -   If a table has a real column named `cursor`, the column wins and the meta field is
     skipped
+
+To-many relation fields take `after` and `distinct` too, with the same meaning they have on
+a root list of the same table — a relation field is a list of the target table, so it gets
+that table's whole pagination surface:
+
+```graphql
+{
+    users {
+        id
+        posts(orderBy: { createdAt: { direction: desc, priority: 1 } }, limit: 10, after: "…") {
+            id
+            cursor
+        }
+    }
+}
+```
+
+Drizzle's `with:` clause cannot express either one — keyset needs a predicate over the
+request's own total order, `distinct` needs a window pass, and a `cursor` has to be computed
+from the raw row. So a relation field that is passed `after` or `distinct`, or that selects
+`cursor`, drops out of the eager fetch and resolves through the request-scoped batch loader
+instead, which implements all three. That is still **one query per relation** across every
+parent in the batch (`distinct` adds its key-selection pass, as on a root list) — never one
+per parent. Nothing about the arguments changes; only how many round-trips the request
+costs.
+
 
 ## Upsert
 
@@ -660,6 +691,71 @@ and interleaves awaited statements inside a transaction, which a synchronous SQL
 cannot do — `buildSchema` rejects both combinations rather than generating something that
 half-works.
 
+## Atomic column updates
+
+`Update<Table>Input` sets columns to values, so "increment the view count" is a read followed
+by a write of the number the read returned — two round-trips, and a lost update whenever two
+clients read the same number. `features.fieldUpdateOperations` replaces qualifying columns'
+update fields with an operations input, so the arithmetic happens in the database:
+
+```graphql
+mutation {
+    updatePostsSingle(where: { id: { eq: 1 } }, set: { views: { increment: 1 } }) {
+        views
+    }
+}
+```
+
+compiles to `SET views = views + 1`. The flag changes the update inputs only; insert inputs
+are untouched.
+
+-   **Numeric columns** (`Int`, `Float`, `BigInt`, `Decimal`) take
+    `set` / `increment` / `decrement` / `multiply` / `divide`
+-   **Array columns** take `set` / `push`, where `push` appends to the existing array
+-   Exactly one operation per column. Passing two, or `{}`, is a `GraphQLError` naming the
+    column — graphql-js has no `@oneOf` on the version range this library supports, so it is
+    enforced at resolve time rather than by the type
+-   `set` is the explicit spelling of the plain assignment the field had before the flag, so
+    every existing update has a one-key rewrite: `{ views: 5 }` → `{ views: { set: 5 } }`
+-   The input types are named for the **scalar**, not the column — every `Int` column in the
+    schema shares one `IntFieldUpdate` — and a column claimed by a `scalarOverrides` entry
+    keeps its plain field, since the override decides what that column accepts
+
+Two things follow the database's own semantics rather than being guarded:
+
+-   `increment`/`multiply` on an integer column can overflow, and `divide` on one **rounds**
+    the way the dialect rounds (PostgreSQL truncates toward zero; use a `Float` or `Decimal`
+    column if you need the fraction)
+-   `divide: 0` raises the driver's division-by-zero error, surfaced as a `GraphQLError`
+
+## Row counts instead of rows
+
+The plural `update<Table>` / `delete<Table>` mutations always `RETURNING *`, which is wasted
+work — and wasted bandwidth — when a client only wants to know how many rows were touched.
+`features.countMutations` adds a count-returning variant of each:
+
+```graphql
+mutation {
+    deletePostsCount(where: { status: { eq: "spam" } })
+    updatePostsCount(where: { draft: { eq: true } }, set: { draft: false })
+}
+```
+
+-   Both return `Int!` — the number of rows the write affected — and add no new output type
+    to the schema
+-   Arguments are exactly the plural mutation's, so a client swaps one field name for the
+    other; `features.requireWhere` applies to them the same way
+-   They follow the feature switch of the write they mirror: `updateCount` needs
+    `features.update`, `deleteCount` needs `features.delete`
+-   **MySQL** gets them too, and they are arguably most useful there: MySQL's other mutations
+    return only `MutationReturn { isSuccess }`, so a row count is strictly more information
+-   `update<Table>Count` **rejects** nested writes with a `GraphQLError` — a nested write
+    needs the parent rows this mutation deliberately does not read back. Use the plural
+    mutation for those
+-   The count is read from whichever field the driver reports it in (`rowCount`,
+    `affectedRows`, `rowsAffected`, `changes`, `count`); a driver that reports none is a
+    `GraphQLError` rather than a silent `0`
+
 ## Single-row update & delete
 
 Alongside the plural `update<Table>` / `delete<Table>` mutations, every table gets an
@@ -685,6 +781,17 @@ mutation {
     MySQL mutation
 -   The variants are generated under `features.update` / `features.delete`, share the plural
     mutations' input types, and appear in `entities.mutations` for custom schemas
+
+### Mutation return shapes
+
+Every mutation that returns rows returns them non-null, with two exceptions that are
+deliberate rather than accidental:
+
+| Mutation | Returns | Why |
+| --- | --- | --- |
+| `create<Table>Single` | `Table!`, or `Table` under `conflictDoNothing` | An insert of one row returns that row. It can only fail to produce one when the `conflictDoNothing` build option swallows a conflict, so it is nullable exactly when that option is set |
+| `update<Table>Many` | `[Table]!` | Each entry's updated rows **in entry order**. An entry whose `where` matched nothing contributes `null` in its slot, so the response lines up with the request positionally — the nullable element is the whole point |
+| everything else | `[Table!]!` / `Table!` / `Table` | — |
 
 The plural mutations still accept a missing `where` (a full-table write) by default. To rule
 that out at the type level, `features: { requireWhere: true }` makes `where` non-null on

--- a/TODO.md
+++ b/TODO.md
@@ -30,16 +30,21 @@ Supabase's `pg_graphql`. Roughly ordered within each group; nothing here is comm
   column is not portable today.
 - **Views and computed fields** — Drizzle views are not picked up, and there is no way to add
   a derived field backed by SQL. Reachable now by composing a custom schema.
-- **Relay connections** — `Node` interface, global IDs, `PageInfo`, cursor pagination. A large
-  surface, and the current `limit`/`offset` covers most uses; worth doing only if a client
-  framework demands it.
+- **Relay connections** — `Node` interface, global IDs, `PageInfo`, `edges`/`node` wrappers.
+  Keyset pagination itself has landed (`cursor` + `after`, on list queries and on to-many
+  relation fields alike); what is left is the Relay *shape* around it, which is a large
+  surface and worth doing only if a client framework demands it.
 - **Subscriptions / live queries** — needs a change-feed (`LISTEN`/`NOTIFY`, binlog, polling)
   that this library does not have and cannot fake cheaply.
-- **`affected_rows` on mutation payloads** — Hasura exposes it, and MySQL's returnless
-  mutations would benefit most. (Descriptions and deprecations themselves have landed as the
-  `describeColumn` / `describeTable` / `describeRelation` / `deprecateColumn` hooks; reading
-  them out of database comments automatically is still open, and needs a catalogue query
-  drizzle does not expose.)
+- **Reading descriptions out of database comments** — the description and deprecation hooks
+  themselves have landed (`describeColumn` / `describeTable` / `describeRelation` /
+  `deprecateColumn`); populating them automatically from column and table comments is still
+  open, and needs a catalogue query drizzle does not expose.
+- **`affected_rows` on the row-returning mutation payloads** — `features.countMutations` adds
+  `update<Table>Count` / `delete<Table>Count`, which answer the same question, but a caller
+  who wants the rows *and* the count still needs two fields. Hasura returns both in one
+  payload; doing the same here means a wrapper object type per table, which is a much larger
+  schema change than the count mutations were.
 - **Many-to-many relation filters** — relations declared with `.through()` are currently left
   out of the filter input entirely. Same gap exists for relation aggregates.
 

--- a/llms.txt
+++ b/llms.txt
@@ -36,8 +36,11 @@ For each table, `buildSchema` generates:
 - **Insert** mutations (single + array), default-prefixed `create` (e.g. `createUsers`).
 - An **update** mutation, default-prefixed `update`.
 - A **delete** mutation, default-prefixed `delete`.
+- Under `features.countMutations`, `update<Table>Count` / `delete<Table>Count` variants returning `Int!` — the number of rows affected — with the plural mutation's arguments and no row payload.
 
-> MySQL mutations return only a success flag (`{ isSuccess }`), no row payload. PostgreSQL and SQLite mutations return the affected rows.
+> MySQL mutations return only a success flag (`{ isSuccess }`), no row payload. PostgreSQL and SQLite mutations return the affected rows. Two return shapes are deliberate exceptions to non-null rows: `create<Table>Single` is nullable only under the `conflictDoNothing` option, and `update<Table>Many` returns `[Table]!` because an entry whose `where` matched nothing contributes `null` in its slot, keeping the response positionally aligned with the request.
+
+> `features.fieldUpdateOperations` turns a numeric column's update field into `{ set | increment | decrement | multiply | divide }` and an array column's into `{ set | push }`, so the arithmetic runs in the database (`SET views = views + 1`). Exactly one operation per column, enforced at resolve time. Insert inputs are unchanged.
 
 ## Custom schemas with `entities`
 
@@ -73,6 +76,7 @@ const schema = new GraphQLSchema({
 ## Relations & N+1 handling
 
 - **Root queries** (`entities.queries.*`) eagerly load every requested relation in a single round-trip via Drizzle's relational query builder (`with:`), including nested relations and per-relation `where` / `orderBy` / `limit` / `offset`.
+- A to-many relation field also takes `after` (keyset cursor) and `distinct`, matching a root list of the target table; `distinct` there means one row per distinct value **per parent**. Drizzle's `with:` cannot express either, so a relation passed `after` or `distinct` — or selecting the `cursor` meta field — drops out of the eager fetch and resolves through the batch loader, still one query per relation across the whole batch rather than one per parent.
 - **Mutations (PostgreSQL & SQLite)** re-fetch affected rows by primary key (single or composite) through one relational query when the selection set includes relation fields. `delete` mutations use the request-scoped batch loader instead. MySQL mutations return only a success flag, so this does not apply.
 - **Custom schemas** can use standalone, request-batched relation resolvers exported as `entities.fieldResolvers[TableName][relationName]`. These dedupe all sibling loads in a request into one `IN (...)` query (keyed on the GraphQL `context`). Per-parent `limit`/`offset` on a to-many relation is applied across the whole batch with a `ROW_NUMBER() OVER (PARTITION BY ...)` window function — still one query.
 
@@ -114,7 +118,7 @@ Second argument to `buildSchema(db, config?)`:
 - `suffixes?: { list?; single? }` — customize query name suffixes. Default `{ list: '', single: 'Single' }`. List and single suffixes cannot be identical unless a `typeNameMapper` is provided.
 - `conflictDoNothing?: boolean` — (PostgreSQL only) apply `ON CONFLICT DO NOTHING` to inserts. Default `false`.
 - `typeNameMapper?: (tableName: string) => { singular: string; plural: string } | undefined` — customize generated type/field names per table.
-- `features?: { aggregates?; groupBy?; relationAggregates?; distinct?; insert?; update?; updateMany?; delete?; upsert?; nestedWrites?; requireWhere? }` — which operations to generate. Everything defaults to `true` except `upsert`, `nestedWrites` and `requireWhere`, which default to `false`.
+- `features?: { aggregates?; groupBy?; relationAggregates?; distinct?; insert?; update?; updateMany?; delete?; upsert?; nestedWrites?; fieldUpdateOperations?; countMutations?; requireWhere? }` — which operations to generate. Everything defaults to `true` except `upsert`, `nestedWrites`, `fieldUpdateOperations`, `countMutations` and `requireWhere`, which default to `false`.
 - `enumNameMapper?: ({ enumName, schema, tableName, columnName, values }) => string | undefined` — name the GraphQL enum a column maps to. By default a declared database enum becomes one shared `<EnumName>Enum` across every column that uses it; an inline value list stays per-column (`<Table><Column>Enum`). Returning `undefined` keeps the default.
 - `describeColumn?: (column, { tableName, columnName }) => string | undefined` — description for a column, applied to its object-type field, create/update input fields, filter field, min/max aggregates and group keys.
 - `describeTable?: (tableName) => string | undefined` / `describeRelation?: (tableName, relationName) => string | undefined` — descriptions for the table's object type and its relation fields.
@@ -125,7 +129,7 @@ Second argument to `buildSchema(db, config?)`:
 
 From `drizzle-graphql`:
 - `buildSchema(db, config?)` — main entry point.
-- `createRelationResolverFactory`, `extractFilters`, `extractOrderBy`, `extractRelationJoinColumns` — helpers for custom relation resolvers.
+- `createRelationResolverFactory(db, tables, nullOrdering, filterCtx?)`, `extractFilters`, `extractOrderBy`, `extractRelationJoinColumns` — helpers for custom relation resolvers. `nullOrdering` is the dialect's native `ORDER BY` placement for `NULL` — `'nulls-largest'` for PostgreSQL, `'nulls-smallest'` for MySQL and SQLite — and the keyset predicate behind a relation's `after` argument must match it.
 - Types: `AnyDrizzleDB`, `BuildSchemaConfig`, `GeneratedData`, `GeneratedEntities`, `GeneratedInputs`, `GeneratedOutputs`, `QueriesCore`, `MutationsCore`, `MutationReturnlessResult`, `SelectResolver`, `SelectSingleResolver`, `InsertResolver`, `InsertArrResolver`, `UpdateResolver`, `DeleteResolver`, `RelationResolverFactory`, `TableNamedRelations`, and Drizzle schema-extraction utility types (`ExtractTables`, `ExtractRelations`, `ExtractTableRelations`, `ExtractTableByName`).
 
 ## Optional

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,6 +132,8 @@ export const buildSchema = <TDbClient extends AnyDrizzleDB<any>>(
     delete: config?.features?.delete ?? true,
     upsert: config?.features?.upsert ?? false,
     nestedWrites: config?.features?.nestedWrites ?? false,
+    fieldUpdateOperations: config?.features?.fieldUpdateOperations ?? false,
+    countMutations: config?.features?.countMutations ?? false,
     requireWhere: config?.features?.requireWhere ?? false,
   };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -725,6 +725,51 @@ export type SchemaFeatures = {
    */
   nestedWrites?: boolean;
   /**
+   * Operation inputs on the update `set`, so a column can be changed relative to its current
+   * value instead of only replaced.
+   *
+   * ```graphql
+   * updatePostsSingle(where: { id: { eq: "p1" } }, set: { views: { increment: 1 } }) { views }
+   * ```
+   *
+   * Every numeric column's field on `Update<Table>Input` becomes a `<Scalar>FieldUpdate`
+   * input carrying `set`, `increment`, `decrement`, `multiply` and `divide`; every array
+   * column's becomes a `<Scalar>ListFieldUpdate` carrying `set` and `push`. Exactly one
+   * operation per field, checked at resolve time. `set` is the explicit spelling of what the
+   * field did before, so `set: { views: 42 }` becomes `set: { views: { set: 42 } }`.
+   *
+   * The arithmetic happens in the database (`SET views = views + 1`), so a counter no longer
+   * needs a read-modify-write round trip and no longer loses concurrent updates. Rounding on
+   * an integer column, and division by zero, follow the database's own rules rather than
+   * being guarded here. Columns owned by a scalar override keep their plain type — an
+   * override owns what the column accepts.
+   *
+   * Off by default: it changes the type of every numeric and array field on every update
+   * input, which no existing document is written against.
+   *
+   * @default false
+   */
+  fieldUpdateOperations?: boolean;
+  /**
+   * `update<Table>Count` / `delete<Table>Count` mutations — the same write as the plural
+   * `update<Table>` / `delete<Table>`, returning the number of rows affected instead of the
+   * rows themselves.
+   *
+   * ```graphql
+   * deletePostsCount(where: { published: { eq: false } })   # Int!
+   * ```
+   *
+   * A mass update or delete otherwise has to `RETURNING *` every row it touched purely so
+   * the caller can count them, which crosses the driver and is serialized through GraphQL
+   * for nothing. Each mutation is generated only when its plural counterpart is
+   * (`features.update` / `features.delete`), and honours `features.requireWhere`.
+   *
+   * Off unless asked for, so an existing schema does not grow new mutations on upgrade.
+   *
+   * @default false
+   */
+  countMutations?: boolean;
+  /**
    * Makes `where` non-null on the plural `update<Table>` / `delete<Table>` mutations, and
    * rejects a `where` that collapses to no filters (e.g. `where: {}`), so a schema can rule
    * out unbounded writes at the type level. Off by default for backwards compatibility.

--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -48,7 +48,7 @@ import {
   type SQL,
   sql,
 } from 'drizzle-orm';
-import type { GraphQLFieldResolver } from 'graphql';
+import type { GraphQLFieldConfigArgumentMap, GraphQLFieldResolver } from 'graphql';
 import {
   GraphQLBoolean,
   GraphQLEnumType,
@@ -81,16 +81,19 @@ import type {
   ConvertedRelationColumnWithArgs,
   SchemaDocs,
 } from '../type-converter/types.ts';
+import { fieldUpdateInputType, remapUpdateInput } from './field-updates.ts';
 // Type-only: the nested-write module imports this one at runtime, so the dependency has to
 // stay one-directional. The implementation is injected by the dialect builder.
-import type { NestedWriteTypes } from './nested-writes.ts';
+import type { NestedWriteRuntime, NestedWriteTypes } from './nested-writes.ts';
 import type {
+  CreatedResolver,
   FilterColumnOperators,
   FilterColumnOperatorsCore,
   Filters,
   FiltersCore,
   GeneratedTableTypes,
   GeneratedTableTypesOutputs,
+  GeneratorFeatures,
   OrderByArgs,
   ProcessedTableSelectArgs,
   SelectData,
@@ -709,9 +712,20 @@ const batchedPaginatedRelationQuery = async (
  *   2. When limit/offset args are present, falls back to a direct per-item query.
  *   3. Otherwise batches all sibling resolver calls within the same GraphQL execution tick
  *      into a single IN-clause query, eliminating N+1 database round-trips.
+ *
+ * `nullOrdering` is the dialect's native `ORDER BY` placement for `NULL` — the keyset
+ * predicate behind a relation's `after` argument has to match it, or rows with a `NULL` in an
+ * ordered column would be skipped instead of paged through. It has no sensible default, so
+ * each dialect builder states it: `'nulls-largest'` for PostgreSQL, `'nulls-smallest'` for
+ * MySQL and SQLite.
  */
 export const createRelationResolverFactory =
-  (db: any, tables: Record<string, Table>, filterCtx?: RelationFilterBase): RelationResolverFactory =>
+  (
+    db: any,
+    tables: Record<string, Table>,
+    nullOrdering: NullOrdering,
+    filterCtx?: RelationFilterBase,
+  ): RelationResolverFactory =>
   ({ tableName, relationName, relEntry, isOne }) => {
     const parentTable = tables[tableName];
     const targetTableName = relEntry.targetTableName;
@@ -730,7 +744,7 @@ export const createRelationResolverFactory =
     // Resolved at build time (composite keys included) — used to tiebreak paginated batches.
     const targetPkNames = relEntry.targetPkNames ?? [];
 
-    return async (parent, args, context) => {
+    return async (parent, args, context, info) => {
       // Eager path: the parent resolver pre-fetched this relation via Drizzle's `with`.
       if (parent[relationName] !== undefined) {
         return parent[relationName];
@@ -741,17 +755,53 @@ export const createRelationResolverFactory =
         return isOne ? null : [];
       }
 
-      const { where: whereArg, orderBy: orderByArg, limit, offset } = (args ?? {}) as any;
+      const { where: whereArg, orderBy: orderByArg, limit, offset, after } = (args ?? {}) as any;
+      const distinct = ((args ?? {}) as any).distinct?.length ? ((args ?? {}) as any).distinct : undefined;
+
+      // ── keyset (cursor) pagination ──
+      // The same rules the root list follows, over the related rows of one parent: the cursor
+      // is defined over the request's orderBy plus the target's primary-key tiebreak, and the
+      // keyset predicate is a plain condition on the target's own columns — so it filters each
+      // parent's rows independently even though the batch fetches them all at once.
+      const cursorSelected = !isOne && !!info && selectsCursorField(info, targetTable);
+      let cursorEntries: CursorOrderEntry[] | undefined;
+      if (!isOne && (after != null || cursorSelected)) {
+        if (after != null && distinct) {
+          throw new GraphQLError("'after' cannot be combined with 'distinct'.");
+        }
+        if (orderByHasRelationEntry(orderByArg)) {
+          if (after != null) {
+            throw new GraphQLError(
+              "'after' cannot be combined with an orderBy that orders through a relation — a related row's value cannot be encoded into a cursor.",
+            );
+          }
+          // `cursor` was selected under a relation ordering — the field resolves to null.
+        } else if (!targetPkNames.length) {
+          if (after != null) {
+            throw new GraphQLError(
+              `Table ${targetTableName} has no primary key, so cursor pagination cannot be used on it.`,
+            );
+          }
+          // `cursor` was selected but no total order exists — the field resolves to null.
+        } else {
+          cursorEntries = cursorOrderingEntries(orderByArg, targetPkNames);
+        }
+      }
+      const cursorValues = after != null && cursorEntries ? decodeCursor(after, cursorEntries) : undefined;
 
       // Batch path: collect all sibling calls in this tick and execute one query.
       // Pagination args are part of the loader key so siblings sharing identical
       // args batch together; per-parent limit/offset is applied inside the batch
       // via a window function rather than bailing to a per-parent query (N+1).
+      // `cursorEntries` joins the key because it changes the ordering, not just the filter.
       const argsKey = JSON.stringify({
         where: whereArg ?? null,
         orderBy: orderByArg ?? null,
         limit: limit ?? null,
         offset: offset ?? null,
+        after: after ?? null,
+        distinct: distinct ?? null,
+        cursor: cursorEntries ? 1 : 0,
       });
       const loaderKey = `${tableName}::${relationName}::${argsKey}`;
 
@@ -760,16 +810,41 @@ export const createRelationResolverFactory =
         // executor — the transaction on the context, when there is one.
         const executor = resolveExecutor(db, context);
         const uniqueIds = [...new Set(parentIds)];
-        const whereCondition = and(
+        let whereCondition = and(
           inArray(foreignCol, uniqueIds),
           whereArg
             ? extractFilters(targetTable, targetTableName, whereArg, relationFilterCtx(filterCtx, targetTableName))
             : undefined,
+          cursorValues ? buildCursorCondition(targetTable, cursorEntries!, cursorValues, nullOrdering) : undefined,
         );
+
+        if (distinct) {
+          // Partitioned by the foreign key as well as the requested columns, so "one row per
+          // distinct value" means one per parent — `users { posts(distinct: [status]) }` gives
+          // each user one post per status, not one post per status across all users. The pass
+          // runs first and the batch query is then narrowed to the keys it picked, exactly as
+          // the root list does.
+          const keys = await selectDistinctKeys({
+            db: executor,
+            table: targetTable,
+            tableName: targetTableName,
+            distinct,
+            pkNames: targetPkNames,
+            where: whereCondition,
+            orderBy: orderByArg,
+            partitionBy: [foreignCol],
+          });
+          if (!keys.length) {
+            return parentIds.map(() => (isOne ? null : []));
+          }
+          whereCondition = and(whereCondition, primaryKeyRestriction(targetTable, targetPkNames, keys));
+        }
 
         let rows: any[];
         if (limit != null || offset != null) {
-          // Per-parent pagination across the whole batch in one query.
+          // Per-parent pagination across the whole batch in one query. Its window ordering is
+          // the request's orderBy plus the primary key, which is the cursor's total order too,
+          // so a cursor page and a limit/offset page agree on row order.
           rows = await batchedPaginatedRelationQuery(
             executor,
             targetTable,
@@ -785,10 +860,20 @@ export const createRelationResolverFactory =
           // Use plain db.select() so column refs are never aliased — avoids drizzle-orm v1
           // RQB aliasing requirements that would require referencing via aliasedTable proxy.
           let q = executor.select().from(targetTable).where(whereCondition) as any;
-          if (orderByArg) {
-            q = q.orderBy(...extractOrderBy(targetTable, orderByArg, relationFilterCtx(filterCtx, targetTableName)));
+          const orderExprs = cursorEntries
+            ? cursorOrderExprs(targetTable, cursorEntries)
+            : orderByArg
+              ? extractOrderBy(targetTable, orderByArg, relationFilterCtx(filterCtx, targetTableName))
+              : [];
+          if (orderExprs.length) {
+            q = q.orderBy(...orderExprs);
           }
           rows = await q;
+        }
+
+        // Before remapping, which rewrites dates and bigints into their transport forms.
+        if (cursorEntries) {
+          attachRowCursors(rows, cursorEntries);
         }
 
         // Group by FK value before remapping (remapping may delete null fields).
@@ -874,6 +959,11 @@ export interface TypeCacheCtx {
    * generator emits no descriptions of its own for column and relation fields.
    */
   docs: SchemaDocs;
+  /**
+   * The build's resolved feature flags. Like `complexity` and `docs`, not a cache — the type
+   * builders are several calls deep and this context is already threaded through them.
+   */
+  features: GeneratorFeatures;
 }
 
 /**
@@ -1973,6 +2063,15 @@ const generateSelectFields = <TWithOrder extends boolean>(
         continue;
       }
 
+      // A to-many relation field is a list of the target table, so it takes the same
+      // pagination surface a root list of that table does. `after` and `distinct` are the
+      // two drizzle's `with:` clause cannot express, so a request that passes either drops
+      // the relation out of the eager fetch and resolves it through the batch loader, which
+      // implements both — see extractRelationsParamsInner.
+      const targetDistinctEnum = cacheCtx.features.distinct
+        ? generateDistinctEnum(tables[targetTableName]!, resolveTypeName(targetTableName, typeNameMapper))
+        : undefined;
+
       rawRelationFields.push([
         relationName,
         {
@@ -1982,6 +2081,14 @@ const generateSelectFields = <TWithOrder extends boolean>(
             orderBy: { type: relSelectData.order! },
             offset: { type: GraphQLInt },
             limit: { type: GraphQLInt },
+            after: {
+              type: GraphQLString,
+              description:
+                "Keyset pagination: only return related rows strictly after this cursor (a row's `cursor` field from a previous page of this relation, under the same orderBy).",
+            },
+            ...(targetDistinctEnum
+              ? { distinct: { type: new GraphQLList(new GraphQLNonNull(targetDistinctEnum)) } }
+              : {}),
           },
           resolve,
           ...relationDocs,
@@ -2108,10 +2215,13 @@ export const generateTableTypes = <WithReturning extends boolean>(
   const updateFields = Object.fromEntries(
     columnEntries.map(([columnName, column]) => {
       const converted = drizzleColumnToGraphQLType(column, columnName, tableName, true, false, true);
-      return [
-        columnName,
-        { ...converted, ...inputFieldDocs(cacheCtx.docs, column, tableName, columnName, converted.type) },
-      ];
+      // A numeric or array column takes an operations input instead of the bare scalar, so
+      // it can be changed relative to its current value rather than only replaced.
+      const operations = cacheCtx.features.fieldUpdateOperations
+        ? fieldUpdateInputType(column, columnName, tableName)
+        : undefined;
+      const field = operations ? { ...converted, type: operations } : converted;
+      return [columnName, { ...field, ...inputFieldDocs(cacheCtx.docs, column, tableName, columnName, field.type) }];
     }),
   );
 
@@ -2956,6 +3066,22 @@ const extractRelationsParamsInner = (
       continue;
     }
 
+    // `after`, `distinct` and the `cursor` field are the relation-level half of the root
+    // list's keyset and distinct machinery, and drizzle's `with:` clause can express none of
+    // them: keyset needs a predicate over the request's own total order, distinct needs a
+    // window pass, and a cursor has to be computed from the raw row. As with an aliased
+    // relation above, the fix is to leave the relation out of the eager clause — the field
+    // resolver's batch loader implements all three, still in one query per relation.
+    const eagerArgs = (field as ResolveTree).args as Partial<TableSelectArgs> | undefined;
+    if (
+      !is((relEntry as any).relation ?? relEntry, One) &&
+      (eagerArgs?.after != null ||
+        !!(eagerArgs?.distinct as string[] | undefined)?.length ||
+        isCursorFieldSelected(relFieldSelection, tables[targetTableName]!))
+    ) {
+      continue;
+    }
+
     const columns = extractSelectedColumnsFromTree(relFieldSelection, tables[targetTableName]!, {
       tableName: targetTableName,
       relationMap,
@@ -3365,6 +3491,39 @@ export const isCursorFieldSelected = (tree: Record<string, ResolveTree> | undefi
 };
 
 /**
+ * Whether a field's own selection set asks for the `cursor` meta field, read straight off the
+ * AST. The relation resolvers need this per parent row on the batch path, where parsing a
+ * full resolve tree each time would cost far more than the one-level walk the question needs;
+ * fragment spreads are followed, and a real column named `cursor` keeps the field for itself
+ * exactly as in {@link isCursorFieldSelected}.
+ */
+const selectsCursorField = (info: any, table: Table): boolean => {
+  if (getColumns(table)[CURSOR_FIELD_NAME]) {
+    return false;
+  }
+
+  const visited = new Set<string>();
+  const walk = (selections: any[]): boolean =>
+    selections.some((selection) => {
+      if (selection.kind === 'Field') {
+        return selection.name.value === CURSOR_FIELD_NAME;
+      }
+      if (selection.kind === 'InlineFragment') {
+        return walk(selection.selectionSet.selections);
+      }
+      const name = selection.name?.value;
+      if (!name || visited.has(name)) {
+        return false;
+      }
+      visited.add(name);
+      const fragment = info.fragments?.[name];
+      return fragment ? walk(fragment.selectionSet.selections) : false;
+    });
+
+  return (info.fieldNodes ?? []).some((node: any) => !!node.selectionSet && walk(node.selectionSet.selections));
+};
+
+/**
  * Computes and attaches each row's opaque cursor (under a namespaced property the `cursor`
  * field's resolver reads). Must run on the raw driver rows, before output remapping rewrites
  * dates and bigints into their transport forms.
@@ -3693,6 +3852,10 @@ export const mysqlValuesColumnRef = (columnName: string): SQL => sql`values(${sq
  * `row_number() over (partition by … order by …)` pass and the main query is narrowed to the
  * keys it returns. `orderExprs` is the full ordering (the request's `orderBy` plus the primary
  * key tiebreak); the caller applies the same ordering to the main query, so the two agree.
+ *
+ * `partitionBy` prepends extra columns to the window's partition. A to-many relation field
+ * uses it to pass the foreign key, which makes the pass distinct *within each parent* rather
+ * than across the whole batch — the same meaning `distinct` has on a root list.
  */
 export const selectDistinctKeys = async (params: {
   db: any;
@@ -3704,18 +3867,20 @@ export const selectDistinctKeys = async (params: {
   orderBy: Record<string, any> | undefined;
   limit?: number;
   offset?: number;
+  partitionBy?: Column[];
 }): Promise<Record<string, any>[]> => {
-  const { db, table, tableName, distinct, pkNames, where, orderBy, limit, offset } = params;
+  const { db, table, tableName, distinct, pkNames, where, orderBy, limit, offset, partitionBy } = params;
   const cols = getColumns(table);
 
   if (!pkNames.length) {
     throw new GraphQLError(`Table ${tableName} has no primary key, so 'distinct' cannot be applied to it.`);
   }
 
-  const partitionCols = distinct.map((name) => cols[name]).filter(Boolean);
-  if (!partitionCols.length) {
+  const requestedCols = distinct.map((name) => cols[name]).filter(Boolean);
+  if (!requestedCols.length) {
     throw new GraphQLError(`No known columns were given to 'distinct' on ${tableName}.`);
   }
+  const partitionCols = [...(partitionBy ?? []), ...requestedCols];
 
   const orderEntries = orderBy ? orderByEntries(orderBy) : [];
   // Both orderings must agree, so build each from the same entries — once against the table
@@ -3923,8 +4088,10 @@ export const computeResolverFieldNames = (
   updateFieldName: string;
   updateManyFieldName: string;
   updateSingleFieldName: string;
+  updateCountFieldName: string;
   deleteFieldName: string;
   deleteSingleFieldName: string;
+  deleteCountFieldName: string;
 } => {
   const mapped = typeNameMapper?.(tableName);
   const typeName = mapped ? capitalize(mapped.singular) : capitalize(tableName);
@@ -3953,6 +4120,11 @@ export const computeResolverFieldNames = (
   const writeSingleSuffix = suffixes.single === '' ? 'Single' : suffixes.single;
   const updateSingleFieldName = `${updateFieldName}${writeSingleSuffix}`;
   const deleteSingleFieldName = `${deleteFieldName}${writeSingleSuffix}`;
+  // The count variants are the plural write under another name, so they take the plural
+  // noun rather than the singular one the plural mutations inherited from the mapper.
+  const pluralNoun = mapped ? capitalize(mapped.plural) : capitalize(tableName);
+  const updateCountFieldName = `${prefixes.update}${pluralNoun}Count`;
+  const deleteCountFieldName = `${prefixes.delete}${pluralNoun}Count`;
   return {
     typeName,
     listFieldName,
@@ -3966,8 +4138,10 @@ export const computeResolverFieldNames = (
     updateFieldName,
     updateManyFieldName,
     updateSingleFieldName,
+    updateCountFieldName,
     deleteFieldName,
     deleteSingleFieldName,
+    deleteCountFieldName,
   };
 };
 
@@ -4018,6 +4192,38 @@ export const extractRequiredFilters = <TTable extends Table>(
 };
 
 /**
+ * How many rows a returnless write reported affecting. The three dialects' drivers each
+ * spell it differently — `rowCount` (node-postgres, Neon), `affectedRows` (PGlite, and MySQL
+ * on its result header), `count` (postgres.js), `rowsAffected` (libsql), `changes`
+ * (better-sqlite3) — and none of them is reachable through a common drizzle type, so the
+ * shape is probed rather than declared.
+ *
+ * Only the result object itself is read, plus `affectedRows` one level in, since MySQL
+ * returns `[header, fields]`. A row of the table is never inspected, so a table with a
+ * column named `count` cannot be mistaken for a count.
+ */
+export const rowsAffected = (result: any, fieldName: string): number => {
+  const asNumber = (value: unknown): number | undefined =>
+    typeof value === 'number' ? value : typeof value === 'bigint' ? Number(value) : undefined;
+
+  if (result && typeof result === 'object') {
+    for (const key of ['rowCount', 'affectedRows', 'rowsAffected', 'changes', 'count']) {
+      const value = asNumber((result as any)[key]);
+      if (value !== undefined) {
+        return value;
+      }
+    }
+    const header = Array.isArray(result) ? result[0] : undefined;
+    const affected = header && typeof header === 'object' ? asNumber(header.affectedRows) : undefined;
+    if (affected !== undefined) {
+      return affected;
+    }
+  }
+
+  throw new GraphQLError(`${fieldName}: the driver did not report how many rows the write affected.`);
+};
+
+/**
  * Guard for the `Single` write variants: throws before anything is written when `where`
  * matches more than one row, so a multi-row update/delete never executes. Probed with a
  * `LIMIT 2` select rather than a count so the check stays cheap on large matches.
@@ -4032,6 +4238,99 @@ export const assertSingleMatch = async (
   if (matched.length > 1) {
     throw new GraphQLError(`${fieldName}: 'where' matched more than one row — nothing was written!`);
   }
+};
+
+/**
+ * `update<Tables>Count` / `delete<Tables>Count` — the plural write without the payload
+ * (`features.countMutations`).
+ *
+ * The plural `update` and `delete` always `RETURNING *`, which is the wrong shape for
+ * "archive everything older than a year": the caller pays to ship rows it does not want, and
+ * on a large match that cost is the whole mutation. These return `Int!` instead — how many
+ * rows the write touched, as the driver reported it, with no RETURNING clause at all.
+ *
+ * Dialect-independent: drizzle's update/delete builders take the same calls everywhere, and
+ * the drivers' disagreement about how to spell the row count is handled by
+ * {@link rowsAffected}.
+ */
+export const generateWriteCount = ({
+  db,
+  tableName,
+  table,
+  kind,
+  setArgs,
+  filterArgs,
+  fieldName,
+  requireWhere,
+  filterCtx,
+  txCtx,
+  nested,
+}: {
+  db: any;
+  tableName: string;
+  table: Table;
+  kind: 'update' | 'delete';
+  /** The update `set` input; omitted for the delete variant, which has nothing to set. */
+  setArgs?: GraphQLInputObjectType;
+  filterArgs: GraphQLInputObjectType;
+  fieldName: string;
+  requireWhere: boolean;
+  filterCtx?: RelationFilterBase;
+  txCtx?: MutationTxCtx;
+  nested?: NestedWriteRuntime;
+}): CreatedResolver => {
+  const queryArgs = {
+    ...(setArgs ? { set: { type: new GraphQLNonNull(setArgs) } } : {}),
+    where: {
+      type: requireWhere ? new GraphQLNonNull(filterArgs) : filterArgs,
+    },
+  } as GraphQLFieldConfigArgumentMap;
+
+  return {
+    name: fieldName,
+    resolver: async (_source, args: { where?: any; set?: Record<string, any> }, context, info) => {
+      try {
+        return await runMutation(db, context, info, txCtx, async (executor) => {
+          const { where, set } = args;
+
+          const relationCtx = relationFilterCtx(filterCtx, tableName);
+          const filters = requireWhere
+            ? extractRequiredFilters(table, tableName, where, fieldName, relationCtx)
+            : where
+              ? extractFilters(table, tableName, where, relationCtx)
+              : undefined;
+
+          let query: any;
+          if (kind === 'delete') {
+            query = executor.delete(table);
+          } else {
+            // Nested writes need the parent rows they attach to, which is exactly what this
+            // mutation exists not to fetch — so they are refused rather than silently dropped.
+            const entry = nested?.enabled(tableName) ? nested.split(tableName, set!) : undefined;
+            if (entry && nested!.hasOps(entry.ops)) {
+              throw new GraphQLError(
+                `${fieldName} does not support nested writes — use ${fieldName.slice(0, -'Count'.length)} instead.`,
+              );
+            }
+            const values = remapUpdateInput(entry ? entry.columns : set!, table, tableName);
+            if (!Object.keys(values).length) {
+              throw new GraphQLError('Unable to update with no values specified!');
+            }
+            query = executor.update(table).set(values);
+          }
+
+          if (filters) {
+            query = query.where(filters);
+          }
+
+          return rowsAffected(await query, fieldName);
+        });
+      } catch (e) {
+        throw toGraphQLError(e);
+      }
+    },
+    args: queryArgs,
+  };
 };
 
 /** GraphQL argument map for a list/array select field. */

--- a/src/util/builders/field-updates.ts
+++ b/src/util/builders/field-updates.ts
@@ -1,0 +1,251 @@
+// @ts-nocheck — drizzle-orm 1.0 type compat not guaranteed, same as its sibling builders
+/**
+ * Atomic column operations on the update `set` (`features.fieldUpdateOperations`).
+ *
+ * Without them `Update<Table>Input` is set-only, so "increment the view count" is a read
+ * followed by a write of the value the read returned — two round trips, and a lost update
+ * whenever two clients read the same number. The operation happens in the database instead:
+ * `set: { views: { increment: 1 } }` compiles to `SET views = views + 1`.
+ *
+ * The build side turns a qualifying column's update-input field into an operations input;
+ * the runtime side splits a `set` back into plain column values and SQL expressions, which
+ * drizzle's `.set()` accepts side by side.
+ */
+import type { Column, SQL, Table } from 'drizzle-orm';
+import { getColumns, sql } from 'drizzle-orm';
+import {
+  GraphQLError,
+  GraphQLFloat,
+  GraphQLInputObjectType,
+  type GraphQLInputType,
+  GraphQLInt,
+  GraphQLList,
+  GraphQLNonNull,
+  type GraphQLScalarType,
+} from 'graphql';
+import { remapFromGraphQLCore, remapFromGraphQLSingleInput } from '../data-mappers/index.ts';
+import { GraphQLBigIntString, GraphQLDecimalString } from '../scalars/index.ts';
+import { drizzleColumnToGraphQLType, getColumnScalarOverride } from '../type-converter/index.ts';
+
+/** What a column's update-input field offers: arithmetic, list append, or nothing. */
+export type FieldUpdateKind = 'numeric' | 'list' | 'none';
+
+/**
+ * The scalars arithmetic is offered on. Decimal and BigInt transport as strings but are
+ * numbers in the database, so `views: { increment: "1" }` is as meaningful there as on an
+ * `Int`. Identity rather than name: a column an override owns is excluded before this is
+ * consulted, so these are always the built-ins.
+ */
+const NUMERIC_SCALARS = new Set<GraphQLInputType>([
+  GraphQLInt,
+  GraphQLFloat,
+  GraphQLBigIntString,
+  GraphQLDecimalString,
+]);
+
+/**
+ * Column types that convert to a GraphQL list without being a list *in the database* —
+ * a bytea reads as `[Int]`, a vector and a geometry point as `[Float]` — so appending to
+ * them is not the operation `push` means.
+ */
+const NON_LIST_ARRAY_COLUMNS = new Set(['PgVector', 'PgGeometry', 'PgBytea']);
+
+const kindCache = new WeakMap<Column, FieldUpdateKind>();
+
+/**
+ * Whether a column takes an operations input, and which one.
+ *
+ * A column owned by a scalar override is always `'none'`: the override decides what the
+ * column accepts, and wrapping it would overrule that. Everything else is decided by the
+ * GraphQL type the column already converts to, so the operations follow the same
+ * scalar-mapping rules as the rest of the schema.
+ */
+export const fieldUpdateKind = (column: Column, columnName: string, tableName: string): FieldUpdateKind => {
+  const cached = kindCache.get(column);
+  if (cached) {
+    return cached;
+  }
+
+  let kind: FieldUpdateKind = 'none';
+  if (!getColumnScalarOverride(column, true)) {
+    const { type } = drizzleColumnToGraphQLType(column, columnName, tableName, true, false, true);
+    if (NUMERIC_SCALARS.has(type)) {
+      kind = 'numeric';
+    } else if (type instanceof GraphQLList && !NON_LIST_ARRAY_COLUMNS.has((column as any).columnType)) {
+      kind = 'list';
+    }
+  }
+
+  kindCache.set(column, kind);
+  return kind;
+};
+
+/** `${Scalar}FieldUpdate` / `${Scalar}ListFieldUpdate`, shared by every column of that type. */
+const inputCache = new Map<string, GraphQLInputObjectType>();
+
+const namedFieldUpdateInput = (
+  name: string,
+  fields: () => Record<string, { type: GraphQLInputType; description: string }>,
+  description: string,
+): GraphQLInputObjectType => {
+  const cached = inputCache.get(name);
+  if (cached) {
+    return cached;
+  }
+  const input = new GraphQLInputObjectType({ name, description, fields: fields() });
+  inputCache.set(name, input);
+  return input;
+};
+
+/**
+ * The operations input replacing a column's plain field on the update input, or `undefined`
+ * when the column keeps its plain type.
+ *
+ * The type is named for the scalar, not the column, so every `Int` column in the schema
+ * shares one `IntFieldUpdate` — the operations are the same wherever they appear.
+ */
+export const fieldUpdateInputType = (
+  column: Column,
+  columnName: string,
+  tableName: string,
+): GraphQLInputObjectType | undefined => {
+  const kind = fieldUpdateKind(column, columnName, tableName);
+  if (kind === 'none') {
+    return undefined;
+  }
+
+  const { type } = drizzleColumnToGraphQLType(column, columnName, tableName, true, false, true);
+
+  if (kind === 'numeric') {
+    const scalar = type as GraphQLScalarType;
+    return namedFieldUpdateInput(
+      `${scalar.name}FieldUpdate`,
+      () => ({
+        set: { type: scalar, description: 'Replace the current value with this one' },
+        increment: { type: scalar, description: 'Add this to the current value (SQL `column + value`)' },
+        decrement: { type: scalar, description: 'Subtract this from the current value (SQL `column - value`)' },
+        multiply: { type: scalar, description: 'Multiply the current value by this (SQL `column * value`)' },
+        divide: {
+          type: scalar,
+          description: 'Divide the current value by this (SQL `column / value`), rounding as the database does',
+        },
+      }),
+      `An update to a ${scalar.name} column: exactly one of these operations`,
+    );
+  }
+
+  // The element type carries the list's own non-null wrapper, so `push` and `set` accept
+  // exactly what the plain field accepted.
+  const list = type as GraphQLList<GraphQLInputType>;
+  const element = list.ofType;
+  const elementName = element instanceof GraphQLNonNull ? String(element.ofType) : String(element);
+  return namedFieldUpdateInput(
+    `${elementName}ListFieldUpdate`,
+    () => ({
+      set: { type: list, description: 'Replace the current array with this one' },
+      push: { type: list, description: 'Append these elements to the current array' },
+    }),
+    `An update to a ${elementName} array column: exactly one of these operations`,
+  );
+};
+
+/** The operation keys, in the order they are reported when a caller passes several. */
+const OPERATIONS = ['set', 'increment', 'decrement', 'multiply', 'divide', 'push'] as const;
+
+/**
+ * The single operation an operations input carries. graphql-js has no `@oneOf` on the
+ * version range this library supports, so "exactly one" is enforced here rather than by the
+ * type — and a caller who passes none has written `{}`, which would otherwise update
+ * nothing while looking like it updated something.
+ */
+const singleOperation = (value: Record<string, any>, columnName: string): [string, any] => {
+  const given = OPERATIONS.filter((operation) => value[operation] !== undefined);
+  if (given.length === 1) {
+    return [given[0]!, value[given[0]!]];
+  }
+  throw new GraphQLError(
+    given.length
+      ? `Field '${columnName}' takes exactly one update operation, but ${given.length} were given (${given.join(', ')}).`
+      : `Field '${columnName}' was given no update operation. Pass exactly one of ${OPERATIONS.join(', ')}.`,
+  );
+};
+
+/** An update `set` split into values drizzle assigns directly and ones it assigns from SQL. */
+export type SplitUpdateValues = {
+  /** Column values still to go through `remapFromGraphQLSingleInput`. */
+  columns: Record<string, any>;
+  /** Column-relative expressions, already driver-ready, to merge into the same `.set()`. */
+  expressions: Record<string, SQL>;
+};
+
+/**
+ * Splits an update `set` into plain values and column-relative SQL expressions.
+ *
+ * Only columns the build side gave an operations input to are read as operations, so a JSON
+ * column that happens to hold `{ increment: 1 }` is still just a value. `set` is the
+ * explicit spelling of a plain assignment and stays on the plain side, where the usual
+ * input remapping applies to it.
+ */
+export const splitFieldUpdateOperations = (
+  values: Record<string, any>,
+  table: Table,
+  tableName: string,
+): SplitUpdateValues => {
+  const cols = getColumns(table);
+  const columns: Record<string, any> = {};
+  const expressions: Record<string, SQL> = {};
+
+  for (const [columnName, value] of Object.entries(values)) {
+    const column = cols[columnName];
+    // An unknown key is left for the remapper, whose error names it.
+    if (!column || value === null || value === undefined) {
+      columns[columnName] = value;
+      continue;
+    }
+
+    // The operations arrive as an input object; a plain value is a plain assignment. That
+    // is what makes this safe to run whether or not `features.fieldUpdateOperations` is on —
+    // with it off, a numeric or list column's field is typed as the scalar or the list, so
+    // graphql-js has already ruled out the object shape by the time the value gets here.
+    const isOperations = typeof value === 'object' && !Array.isArray(value) && !(value instanceof Date);
+    if (!isOperations || fieldUpdateKind(column as Column, columnName, tableName) === 'none') {
+      columns[columnName] = value;
+      continue;
+    }
+
+    const [operation, operand] = singleOperation(value, columnName);
+    if (operation === 'set') {
+      columns[columnName] = operand;
+      continue;
+    }
+
+    const param = sql.param(remapFromGraphQLCore(operand, column as Column, columnName), column);
+    expressions[columnName] =
+      operation === 'increment'
+        ? sql`${column} + ${param}`
+        : operation === 'decrement'
+          ? sql`${column} - ${param}`
+          : operation === 'multiply'
+            ? sql`${column} * ${param}`
+            : operation === 'divide'
+              ? sql`${column} / ${param}`
+              : // `push`: array concatenation, which is the only dialect-specific operation
+                // here — and arrays are a PostgreSQL column type to begin with.
+                sql`${column} || ${param}`;
+  }
+
+  return { columns, expressions };
+};
+
+/**
+ * Remaps an update `set` into the values drizzle's `.set()` takes: plain columns through the
+ * usual input remapping, column-relative operations as SQL expressions alongside them.
+ *
+ * Safe to call on every update path regardless of `features.fieldUpdateOperations` — see the
+ * shape check in {@link splitFieldUpdateOperations}.
+ */
+export const remapUpdateInput = (values: Record<string, any>, table: Table, tableName: string): Record<string, any> => {
+  const { columns, expressions } = splitFieldUpdateOperations(values, table, tableName);
+  const remapped = remapFromGraphQLSingleInput(columns, table);
+  return Object.keys(expressions).length ? { ...remapped, ...expressions } : remapped;
+};

--- a/src/util/builders/mysql.ts
+++ b/src/util/builders/mysql.ts
@@ -7,6 +7,7 @@ import {
   GraphQLBoolean,
   GraphQLError,
   type GraphQLInputObjectType,
+  GraphQLInt,
   GraphQLList,
   GraphQLNonNull,
   GraphQLObjectType,
@@ -29,6 +30,7 @@ import {
   generateOnConflictInput,
   generateTableTypes,
   generateUpdateManyInput,
+  generateWriteCount,
   getPrimaryKeyPropNamesFromConfig,
   listFieldComplexity,
   type MutationTxCtx,
@@ -61,6 +63,7 @@ import {
   generateGroupByType,
   generateHavingInput,
 } from './aggregates.ts';
+import { remapUpdateInput } from './field-updates.ts';
 import type {
   CreatedResolver,
   Filters,
@@ -349,7 +352,7 @@ const generateUpdate = (
         return await runMutation(db, context, info, txCtx, async (executor) => {
           const { where, set } = args;
 
-          const input = remapFromGraphQLSingleInput(set, table);
+          const input = remapUpdateInput(set, table, tableName);
           if (!Object.keys(input).length) {
             throw new GraphQLError('Unable to update with no values specified!');
           }
@@ -425,7 +428,7 @@ const generateUpdateMany = (
           // Remap and validate every entry before the transaction opens, so a malformed
           // entry rejects the request instead of rolling back mid-batch.
           const entries = updates.map(({ where, set }) => {
-            const input = remapFromGraphQLSingleInput(set, table);
+            const input = remapUpdateInput(set, table, tableName);
             if (!Object.keys(input).length) {
               throw new GraphQLError('Unable to update with no values specified!');
             }
@@ -564,7 +567,12 @@ export const generateSchemaData = <
 
   const filterCtx: RelationFilterBase = { tables, relationMap: namedRelations };
 
-  const resolverFactory: RelationResolverFactory = createRelationResolverFactory(db, tables, filterCtx);
+  const resolverFactory: RelationResolverFactory = createRelationResolverFactory(
+    db,
+    tables,
+    'nulls-smallest',
+    filterCtx,
+  );
 
   // Fresh cache per generateSchemaData call — prevents type name collisions
   // when buildSchema() is called multiple times.
@@ -582,6 +590,7 @@ export const generateSchemaData = <
     aggregateTypeCache: new Map(),
     complexity,
     docs: options.docs ?? {},
+    features,
   };
 
   // Left undefined when the feature is off — generateTableTypes then emits no
@@ -649,8 +658,10 @@ export const generateSchemaData = <
       updateFieldName,
       updateManyFieldName,
       updateSingleFieldName,
+      updateCountFieldName,
       deleteFieldName,
       deleteSingleFieldName,
+      deleteCountFieldName,
     } = computeResolverFieldNames(tableName, typeNameMapper, prefixes, suffixes);
 
     const selectArrGenerated = generateSelectArray(
@@ -801,6 +812,37 @@ export const generateSchemaData = <
           mutationTxCtx,
         )
       : undefined;
+    // The count variants are the plural write with its payload left off, so each follows the
+    // same feature switch as the write it mirrors.
+    const updateCountGenerated =
+      features.update && features.countMutations
+        ? generateWriteCount({
+            db,
+            tableName,
+            table: schema[tableName] as MySqlTable,
+            kind: 'update',
+            setArgs: updateInput,
+            filterArgs: tableFilters,
+            fieldName: updateCountFieldName,
+            requireWhere: features.requireWhere,
+            filterCtx,
+            txCtx: mutationTxCtx,
+          })
+        : undefined;
+    const deleteCountGenerated =
+      features.delete && features.countMutations
+        ? generateWriteCount({
+            db,
+            tableName,
+            table: schema[tableName] as MySqlTable,
+            kind: 'delete',
+            filterArgs: tableFilters,
+            fieldName: deleteCountFieldName,
+            requireWhere: features.requireWhere,
+            filterCtx,
+            txCtx: mutationTxCtx,
+          })
+        : undefined;
     const aggregateType = features.aggregates
       ? generateAggregateTypes(schema[tableName] as MySqlTable, tableName, typeName, cacheCtx)
       : undefined;
@@ -887,6 +929,26 @@ export const generateSchemaData = <
           resolve: generated.resolver,
         };
       }
+    }
+    // Apart from the loop above: the count mutations are the one pair whose return value is
+    // not MySQL's shared `isSuccess` shape.
+    if (updateCountGenerated) {
+      mutations[updateCountGenerated.name] = {
+        type: new GraphQLNonNull(GraphQLInt),
+        args: updateCountGenerated.args,
+        resolve: updateCountGenerated.resolver,
+        description:
+          'How many rows the update touched. The rows themselves are not read back, which is the point of this mutation.',
+      };
+    }
+    if (deleteCountGenerated) {
+      mutations[deleteCountGenerated.name] = {
+        type: new GraphQLNonNull(GraphQLInt),
+        args: deleteCountGenerated.args,
+        resolve: deleteCountGenerated.resolver,
+        description:
+          'How many rows the delete removed. The rows themselves are not read back, which is the point of this mutation.',
+      };
     }
     // The insert/update inputs are still built (they type the mutations that survive) but
     // only reach the schema's type map when a mutation actually references them.

--- a/src/util/builders/pg.ts
+++ b/src/util/builders/pg.ts
@@ -6,6 +6,7 @@ import type { GraphQLFieldConfig, GraphQLFieldConfigArgumentMap, ThunkObjMap } f
 import {
   GraphQLError,
   type GraphQLInputObjectType,
+  GraphQLInt,
   GraphQLList,
   GraphQLNonNull,
   type GraphQLObjectType,
@@ -38,6 +39,7 @@ import {
   generateOnConflictInput,
   generateTableTypes,
   generateUpdateManyInput,
+  generateWriteCount,
   getPrimaryKeyPropNamesFromConfig,
   getUniqueColumnSets,
   isCursorFieldSelected,
@@ -82,6 +84,7 @@ import {
   generateGroupByType,
   generateHavingInput,
 } from './aggregates.ts';
+import { remapUpdateInput } from './field-updates.ts';
 import {
   buildNestedWritePlans,
   createNestedWriteRuntime,
@@ -508,6 +511,11 @@ const generateInsertSingle = (
             : await runInsert(executor, input);
 
           if (!result[0]) {
+            // Only reachable under `conflictDoNothing`, which is why the field is nullable
+            // there and non-null everywhere else.
+            if (!conflictDoNothing) {
+              throw new GraphQLError(`${fieldName}: the insert returned no row.`);
+            }
             return undefined;
           }
 
@@ -708,7 +716,7 @@ const generateUpdate = (
 
           const entry = nested?.enabled(tableName) ? nested.split(tableName, set) : undefined;
           const nestedOps = entry && nested!.hasOps(entry.ops) ? entry.ops : undefined;
-          const input = remapFromGraphQLSingleInput(entry ? entry.columns : set, table);
+          const input = remapUpdateInput(entry ? entry.columns : set, table, tableName);
           // A `set` that carries only nested operations is a legitimate update — of the
           // relation rather than of the row — so it is only empty when neither is present.
           if (!Object.keys(input).length && !nestedOps) {
@@ -845,7 +853,7 @@ const generateUpdateMany = (
           const entries = updates.map(({ where, set }) => {
             const split = nested?.enabled(tableName) ? nested.split(tableName, set) : undefined;
             const ops = split && nested!.hasOps(split.ops) ? split.ops : undefined;
-            const input = remapFromGraphQLSingleInput(split ? split.columns : set, table);
+            const input = remapUpdateInput(split ? split.columns : set, table, tableName);
             // An entry that only writes through a relation still has work to do.
             if (!Object.keys(input).length && !ops) {
               throw new GraphQLError('Unable to update with no values specified!');
@@ -1055,7 +1063,12 @@ export function generateSchemaData<
 
   const filterCtx: RelationFilterBase = { tables, relationMap: namedRelations };
 
-  const resolverFactory: RelationResolverFactory = createRelationResolverFactory(db, tables, filterCtx);
+  const resolverFactory: RelationResolverFactory = createRelationResolverFactory(
+    db,
+    tables,
+    'nulls-largest',
+    filterCtx,
+  );
 
   // Fresh cache per generateSchemaData call — prevents type name collisions
   // when buildSchema() is called multiple times.
@@ -1073,6 +1086,7 @@ export function generateSchemaData<
     aggregateTypeCache: new Map(),
     complexity,
     docs: options.docs ?? {},
+    features,
   };
 
   // Nested writes: the plans decide which relations are writable at all, the types add their
@@ -1146,8 +1160,10 @@ export function generateSchemaData<
       updateFieldName,
       updateManyFieldName,
       updateSingleFieldName,
+      updateCountFieldName,
       deleteFieldName,
       deleteSingleFieldName,
+      deleteCountFieldName,
     } = computeResolverFieldNames(tableName, typeNameMapper, prefixes, suffixes);
 
     const selectArrGenerated = generateSelectArray(
@@ -1346,6 +1362,38 @@ export function generateSchemaData<
           mutationTxCtx,
         )
       : undefined;
+    // The count variants are the plural write with its payload left off, so each follows the
+    // same feature switch as the write it mirrors.
+    const updateCountGenerated =
+      features.update && features.countMutations
+        ? generateWriteCount({
+            db,
+            tableName,
+            table: schema[tableName] as PgTable,
+            kind: 'update',
+            setArgs: updateInput,
+            filterArgs: tableFilters,
+            fieldName: updateCountFieldName,
+            requireWhere: features.requireWhere,
+            filterCtx,
+            txCtx: mutationTxCtx,
+            nested: nestedRuntime,
+          })
+        : undefined;
+    const deleteCountGenerated =
+      features.delete && features.countMutations
+        ? generateWriteCount({
+            db,
+            tableName,
+            table: schema[tableName] as PgTable,
+            kind: 'delete',
+            filterArgs: tableFilters,
+            fieldName: deleteCountFieldName,
+            requireWhere: features.requireWhere,
+            filterCtx,
+            txCtx: mutationTxCtx,
+          })
+        : undefined;
     const aggregateType = features.aggregates
       ? generateAggregateTypes(schema[tableName] as PgTable, tableName, typeName, cacheCtx)
       : undefined;
@@ -1423,7 +1471,9 @@ export function generateSchemaData<
     }
     if (insertSingleGenerated) {
       mutations[insertSingleGenerated.name] = {
-        type: singleTableItemOutput,
+        // An insert either returns the row it inserted or throws — the one path to `null` is
+        // `conflictDoNothing` swallowing the insert, so the field is nullable only there.
+        type: conflictDoNothing ? singleTableItemOutput : new GraphQLNonNull(singleTableItemOutput),
         args: insertSingleGenerated.args,
         resolve: insertSingleGenerated.resolver,
       };
@@ -1451,10 +1501,14 @@ export function generateSchemaData<
     }
     if (updateManyGenerated) {
       mutations[updateManyGenerated.name] = {
-        // Nullable items: a no-match entry yields `null` in its slot.
         type: new GraphQLNonNull(new GraphQLList(singleTableItemOutput)),
         args: updateManyGenerated.args,
         resolve: updateManyGenerated.resolver,
+        // The nullable element is deliberate, and the reason this mutation's return type
+        // differs from every sibling's: the result is aligned with the input, one slot per
+        // entry, so an entry that matched nothing has to be able to say so.
+        description:
+          "Each entry's updated rows, in entry order. An entry whose `where` matched no rows contributes `null` in its slot; an entry that matched several contributes each of its rows.",
       };
     }
     if (updateSingleGenerated) {
@@ -1476,6 +1530,24 @@ export function generateSchemaData<
         type: singleTableItemOutput,
         args: deleteSingleGenerated.args,
         resolve: deleteSingleGenerated.resolver,
+      };
+    }
+    if (updateCountGenerated) {
+      mutations[updateCountGenerated.name] = {
+        type: new GraphQLNonNull(GraphQLInt),
+        args: updateCountGenerated.args,
+        resolve: updateCountGenerated.resolver,
+        description:
+          'How many rows the update touched. The rows themselves are not read back, which is the point of this mutation.',
+      };
+    }
+    if (deleteCountGenerated) {
+      mutations[deleteCountGenerated.name] = {
+        type: new GraphQLNonNull(GraphQLInt),
+        args: deleteCountGenerated.args,
+        resolve: deleteCountGenerated.resolver,
+        description:
+          'How many rows the delete removed. The rows themselves are not read back, which is the point of this mutation.',
       };
     }
     // The insert/update inputs are still built (they type the mutations that survive) but

--- a/src/util/builders/sqlite.ts
+++ b/src/util/builders/sqlite.ts
@@ -6,6 +6,7 @@ import type { GraphQLFieldConfig, GraphQLFieldConfigArgumentMap, GraphQLResolveI
 import {
   GraphQLError,
   type GraphQLInputObjectType,
+  GraphQLInt,
   GraphQLList,
   GraphQLNonNull,
   type GraphQLObjectType,
@@ -32,6 +33,7 @@ import {
   generateOnConflictInput,
   generateTableTypes,
   generateUpdateManyInput,
+  generateWriteCount,
   getPrimaryKeyPropNamesFromConfig,
   getUniqueColumnSets,
   listFieldComplexity,
@@ -71,6 +73,7 @@ import {
   generateGroupByType,
   generateHavingInput,
 } from './aggregates.ts';
+import { remapUpdateInput } from './field-updates.ts';
 import {
   buildNestedWritePlans,
   createNestedWriteRuntime,
@@ -373,6 +376,11 @@ const generateInsertSingle = (
             : await runInsert(executor, input);
 
           if (!result[0]) {
+            // Only reachable under `conflictDoNothing`, which is why the field is nullable
+            // there and non-null everywhere else.
+            if (!conflictDoNothing) {
+              throw new GraphQLError(`${fieldName}: the insert returned no row.`);
+            }
             return undefined;
           }
 
@@ -573,7 +581,7 @@ const generateUpdate = (
 
           const entry = nested?.enabled(tableName) ? nested.split(tableName, set) : undefined;
           const nestedOps = entry && nested!.hasOps(entry.ops) ? entry.ops : undefined;
-          const input = remapFromGraphQLSingleInput(entry ? entry.columns : set, table);
+          const input = remapUpdateInput(entry ? entry.columns : set, table, tableName);
           // A `set` that carries only nested operations is a legitimate update — of the
           // relation rather than of the row — so it is only empty when neither is present.
           if (!Object.keys(input).length && !nestedOps) {
@@ -710,7 +718,7 @@ const generateUpdateMany = (
           const entries = updates.map(({ where, set }) => {
             const split = nested?.enabled(tableName) ? nested.split(tableName, set) : undefined;
             const ops = split && nested!.hasOps(split.ops) ? split.ops : undefined;
-            const input = remapFromGraphQLSingleInput(split ? split.columns : set, table);
+            const input = remapUpdateInput(split ? split.columns : set, table, tableName);
             // An entry that only writes through a relation still has work to do.
             if (!Object.keys(input).length && !ops) {
               throw new GraphQLError('Unable to update with no values specified!');
@@ -955,7 +963,12 @@ export const generateSchemaData = <
 
   const filterCtx: RelationFilterBase = { tables, relationMap: namedRelations };
 
-  const resolverFactory: RelationResolverFactory = createRelationResolverFactory(db, tables, filterCtx);
+  const resolverFactory: RelationResolverFactory = createRelationResolverFactory(
+    db,
+    tables,
+    'nulls-smallest',
+    filterCtx,
+  );
 
   // Fresh cache per generateSchemaData call — prevents type name collisions
   // when buildSchema() is called multiple times.
@@ -973,6 +986,7 @@ export const generateSchemaData = <
     aggregateTypeCache: new Map(),
     complexity,
     docs: options.docs ?? {},
+    features,
   };
 
   // A nested write interleaves reads and writes inside one transaction, which a synchronous
@@ -1061,8 +1075,10 @@ export const generateSchemaData = <
       updateFieldName,
       updateManyFieldName,
       updateSingleFieldName,
+      updateCountFieldName,
       deleteFieldName,
       deleteSingleFieldName,
+      deleteCountFieldName,
     } = computeResolverFieldNames(tableName, typeNameMapper, prefixes, suffixes);
 
     const selectArrGenerated = generateSelectArray(
@@ -1261,6 +1277,38 @@ export const generateSchemaData = <
           mutationTxCtx,
         )
       : undefined;
+    // The count variants are the plural write with its payload left off, so each follows the
+    // same feature switch as the write it mirrors.
+    const updateCountGenerated =
+      features.update && features.countMutations
+        ? generateWriteCount({
+            db,
+            tableName,
+            table: schema[tableName] as SQLiteTable,
+            kind: 'update',
+            setArgs: updateInput,
+            filterArgs: tableFilters,
+            fieldName: updateCountFieldName,
+            requireWhere: features.requireWhere,
+            filterCtx,
+            txCtx: mutationTxCtx,
+            nested: nestedRuntime,
+          })
+        : undefined;
+    const deleteCountGenerated =
+      features.delete && features.countMutations
+        ? generateWriteCount({
+            db,
+            tableName,
+            table: schema[tableName] as SQLiteTable,
+            kind: 'delete',
+            filterArgs: tableFilters,
+            fieldName: deleteCountFieldName,
+            requireWhere: features.requireWhere,
+            filterCtx,
+            txCtx: mutationTxCtx,
+          })
+        : undefined;
     const aggregateType = features.aggregates
       ? generateAggregateTypes(schema[tableName] as SQLiteTable, tableName, typeName, cacheCtx)
       : undefined;
@@ -1338,7 +1386,9 @@ export const generateSchemaData = <
     }
     if (insertSingleGenerated) {
       mutations[insertSingleGenerated.name] = {
-        type: singleTableItemOutput,
+        // An insert either returns the row it inserted or throws — the one path to `null` is
+        // `conflictDoNothing` swallowing the insert, so the field is nullable only there.
+        type: conflictDoNothing ? singleTableItemOutput : new GraphQLNonNull(singleTableItemOutput),
         args: insertSingleGenerated.args,
         resolve: insertSingleGenerated.resolver,
       };
@@ -1366,10 +1416,14 @@ export const generateSchemaData = <
     }
     if (updateManyGenerated) {
       mutations[updateManyGenerated.name] = {
-        // Nullable items: a no-match entry yields `null` in its slot.
         type: new GraphQLNonNull(new GraphQLList(singleTableItemOutput)),
         args: updateManyGenerated.args,
         resolve: updateManyGenerated.resolver,
+        // The nullable element is deliberate, and the reason this mutation's return type
+        // differs from every sibling's: the result is aligned with the input, one slot per
+        // entry, so an entry that matched nothing has to be able to say so.
+        description:
+          "Each entry's updated rows, in entry order. An entry whose `where` matched no rows contributes `null` in its slot; an entry that matched several contributes each of its rows.",
       };
     }
     if (updateSingleGenerated) {
@@ -1391,6 +1445,24 @@ export const generateSchemaData = <
         type: singleTableItemOutput,
         args: deleteSingleGenerated.args,
         resolve: deleteSingleGenerated.resolver,
+      };
+    }
+    if (updateCountGenerated) {
+      mutations[updateCountGenerated.name] = {
+        type: new GraphQLNonNull(GraphQLInt),
+        args: updateCountGenerated.args,
+        resolve: updateCountGenerated.resolver,
+        description:
+          'How many rows the update touched. The rows themselves are not read back, which is the point of this mutation.',
+      };
+    }
+    if (deleteCountGenerated) {
+      mutations[deleteCountGenerated.name] = {
+        type: new GraphQLNonNull(GraphQLInt),
+        args: deleteCountGenerated.args,
+        resolve: deleteCountGenerated.resolver,
+        description:
+          'How many rows the delete removed. The rows themselves are not read back, which is the point of this mutation.',
       };
     }
     // The insert/update inputs are still built (they type the mutations that survive) but

--- a/src/util/builders/types.ts
+++ b/src/util/builders/types.ts
@@ -38,6 +38,8 @@ export type GeneratorFeatures = {
   delete: boolean;
   upsert: boolean;
   nestedWrites: boolean;
+  fieldUpdateOperations: boolean;
+  countMutations: boolean;
   requireWhere: boolean;
 };
 
@@ -90,7 +92,10 @@ export type TableSelectArgs = {
   where: Filters<Table>;
   orderBy: OrderByArgs<Table>;
   distinct: string[];
-  /** Opaque keyset-pagination cursor — only return rows strictly after it. List queries only. */
+  /**
+   * Opaque keyset-pagination cursor — only return rows strictly after it. List queries and
+   * to-many relation fields.
+   */
   after: string;
 };
 

--- a/tests/mysql.test.ts
+++ b/tests/mysql.test.ts
@@ -39,6 +39,7 @@ interface Context {
   client: mysql.Connection;
   schema: GraphQLSchema;
   upsertSchema: GraphQLSchema;
+  optInSchema: GraphQLSchema;
   entities: GeneratedEntities<MySql2Database<typeof schema>>;
   server: Server;
   gql: GraphQLClient;
@@ -111,6 +112,10 @@ beforeAll(async (_t) => {
   const { schema: gqlSchema, entities } = buildSchema(ctx.db);
   // Upsert is opt-in, so it needs a schema of its own.
   ctx.upsertSchema = buildSchema(ctx.db, { features: { upsert: true } }).schema;
+  // As are the atomic update operations and the count mutations.
+  ctx.optInSchema = buildSchema(ctx.db, {
+    features: { fieldUpdateOperations: true, countMutations: true },
+  }).schema;
   const yoga = createYoga({
     schema: gqlSchema,
   });
@@ -3175,6 +3180,28 @@ describe.sequential('Returned data tests', () => {
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
+            updateUsersSingle: z
+              .object({
+                args: z
+                  .object({
+                    set: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLObjectType),
+              })
+              .strict(),
             deleteUsers: z
               .object({
                 args: z
@@ -3182,6 +3209,23 @@ describe.sequential('Returned data tests', () => {
                     where: z
                       .object({
                         type: z.instanceof(GraphQLInputObjectType),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLObjectType),
+              })
+              .strict(),
+            deleteUsersSingle: z
+              .object({
+                args: z
+                  .object({
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
                       })
                       .strict(),
                   })
@@ -3265,6 +3309,28 @@ describe.sequential('Returned data tests', () => {
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
+            updatePostsSingle: z
+              .object({
+                args: z
+                  .object({
+                    set: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLObjectType),
+              })
+              .strict(),
             deletePosts: z
               .object({
                 args: z
@@ -3272,6 +3338,23 @@ describe.sequential('Returned data tests', () => {
                     where: z
                       .object({
                         type: z.instanceof(GraphQLInputObjectType),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLObjectType),
+              })
+              .strict(),
+            deletePostsSingle: z
+              .object({
+                args: z
+                  .object({
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
                       })
                       .strict(),
                   })
@@ -3355,6 +3438,28 @@ describe.sequential('Returned data tests', () => {
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
+            updateCustomersSingle: z
+              .object({
+                args: z
+                  .object({
+                    set: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLObjectType),
+              })
+              .strict(),
             deleteCustomers: z
               .object({
                 args: z
@@ -3362,6 +3467,23 @@ describe.sequential('Returned data tests', () => {
                     where: z
                       .object({
                         type: z.instanceof(GraphQLInputObjectType),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLObjectType),
+              })
+              .strict(),
+            deleteCustomersSingle: z
+              .object({
+                args: z
+                  .object({
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
                       })
                       .strict(),
                   })
@@ -5029,5 +5151,115 @@ describe.sequential('Group by tests', () => {
 
     expect(res.errors).toBeUndefined();
     expect(res.data!['postsGroupBy']).toStrictEqual([{ group: { authorId: 1 }, count: 3 }]);
+  });
+});
+
+describe.sequential('Atomic column updates and count mutations', () => {
+  const optIn = (source: string) => graphql({ schema: ctx.optInSchema, source, contextValue: {} });
+  const users = () => ctx.db.select().from(schema.Users).orderBy(schema.Users.id);
+
+  it("replaces a numeric column's update field with an operations input", () => {
+    const input = ctx.optInSchema.getType('UpdateUsersInput') as GraphQLInputObjectType;
+
+    expect(String(input.getFields()['bigint']!.type)).toBe('BigIntFieldUpdate');
+    // A text column has no arithmetic, so it keeps its plain field.
+    expect(String(input.getFields()['name']!.type)).toBe('String');
+  });
+
+  it('increments in the database rather than through a read', async () => {
+    const res = await optIn(
+      `mutation { updateUsers(where: { id: { eq: 1 } }, set: { bigint: { increment: "5" } }) { isSuccess } }`,
+    );
+
+    expect(res.errors).toBeUndefined();
+    expect((await users()).find((u) => u.id === 1)?.bigint).toBe(BigInt(15));
+  });
+
+  it('applies the operation per row', async () => {
+    await ctx.db
+      .update(schema.Users)
+      .set({ bigint: BigInt(2) })
+      .where(inArray(schema.Users.id, [2, 5]));
+    await ctx.db
+      .update(schema.Users)
+      .set({ bigint: BigInt(4) })
+      .where(eq(schema.Users.id, 1));
+
+    const res = await optIn(`mutation { updateUsers(set: { bigint: { multiply: "3" } }) { isSuccess } }`);
+
+    expect(res.errors).toBeUndefined();
+    expect((await users()).map((u) => u.bigint)).toStrictEqual([BigInt(12), BigInt(6), BigInt(6)]);
+  });
+
+  it('rejects two operations on one column', async () => {
+    const res = await optIn(
+      `mutation { updateUsers(set: { bigint: { increment: "1", decrement: "1" } }) { isSuccess } }`,
+    );
+
+    expect(res.errors?.[0]?.message).toBe(
+      "Field 'bigint' takes exactly one update operation, but 2 were given (increment, decrement).",
+    );
+  });
+
+  it('carries the operations through updateUsersMany', async () => {
+    const res = await optIn(`mutation {
+			updateUsersMany(updates: [
+				{ where: { id: { eq: 1 } }, set: { bigint: { increment: "1" } } },
+				{ where: { id: { eq: 2 } }, set: { bigint: { set: "100" } } }
+			]) { isSuccess }
+		}`);
+
+    expect(res.errors).toBeUndefined();
+    const rows = await users();
+    expect(rows.find((u) => u.id === 1)?.bigint).toBe(BigInt(11));
+    expect(rows.find((u) => u.id === 2)?.bigint).toBe(BigInt(100));
+  });
+
+  it('returns a row count instead of the shared success flag', () => {
+    const mutations = ctx.optInSchema.getMutationType()!.getFields();
+
+    expect(String(mutations['updateUsersCount']!.type)).toBe('Int!');
+    expect(String(mutations['deleteUsersCount']!.type)).toBe('Int!');
+    // The row-returning siblings still return MySQL's success flag.
+    expect(String(mutations['updateUsers']!.type)).toBe('MutationReturn');
+    expect(ctx.schema.getMutationType()!.getFields()['updateUsersCount']).toBeUndefined();
+  });
+
+  it('counts the rows an update touched', async () => {
+    const res = await optIn(`mutation { updateUsersCount(set: { name: "Renamed" }) }`);
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data?.['updateUsersCount']).toBe(3);
+  });
+
+  it('counts nothing when the filter matches nothing', async () => {
+    const res = await optIn(`mutation { updateUsersCount(where: { id: { eq: 999 } }, set: { name: "x" }) }`);
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data?.['updateUsersCount']).toBe(0);
+  });
+
+  it('counts the rows a delete removed', async () => {
+    const res = await optIn(`mutation { deleteCustomersCount(where: { id: { eq: 1 } }) }`);
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data?.['deleteCustomersCount']).toBe(1);
+    expect((await ctx.db.select().from(schema.Customers)).find((c) => c.id === 1)).toBeUndefined();
+  });
+
+  it('counts a filtered update alongside an atomic operation', async () => {
+    const res = await optIn(
+      `mutation { updateUsersCount(where: { id: { eq: 1 } }, set: { bigint: { increment: "7" } }) }`,
+    );
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data?.['updateUsersCount']).toBe(1);
+    expect((await users()).find((u) => u.id === 1)?.bigint).toBe(BigInt(17));
+  });
+
+  it('rejects an update with no values', async () => {
+    const res = await optIn(`mutation { updateUsersCount(set: {}) }`);
+
+    expect(res.errors?.[0]?.message).toBe('Unable to update with no values specified!');
   });
 });

--- a/tests/pg.test.ts
+++ b/tests/pg.test.ts
@@ -10,6 +10,7 @@ import {
   GraphQLObjectType,
   GraphQLScalarType,
   GraphQLSchema,
+  graphql,
 } from 'graphql';
 import { createYoga } from 'graphql-yoga';
 import postgres, { type Sql } from 'postgres';
@@ -35,6 +36,7 @@ interface Context {
   docker: Docker;
   pgContainer: Docker.Container;
   db: PostgresJsDatabase<typeof schema>;
+  optInSchema: GraphQLSchema;
   client: Sql;
   schema: GraphQLSchema;
   entities: GeneratedEntities<PostgresJsDatabase<typeof schema>>;
@@ -118,6 +120,11 @@ beforeAll(async () => {
   const port = 4002;
   server.listen(port);
   const gql = new GraphQLClient(`http://localhost:${port}/graphql`);
+
+  // The atomic update operations and the count mutations are opt-in.
+  ctx.optInSchema = buildSchema(ctx.db, {
+    features: { fieldUpdateOperations: true, countMutations: true },
+  }).schema;
 
   ctx.schema = gqlSchema;
   ctx.entities = entities;
@@ -2819,7 +2826,7 @@ describe.sequential('Returned data tests', () => {
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
-                type: z.instanceof(GraphQLObjectType),
+                type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
             updateUsersMany: z
@@ -2834,6 +2841,8 @@ describe.sequential('Returned data tests', () => {
                   })
                   .strict(),
                 resolve: z.function(),
+                // Documents the nullable element, the one mutation whose return type differs.
+                description: z.string(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
                 type: z.instanceof(GraphQLNonNull),
@@ -2861,6 +2870,28 @@ describe.sequential('Returned data tests', () => {
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
+            updateUsersSingle: z
+              .object({
+                args: z
+                  .object({
+                    set: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLObjectType),
+              })
+              .strict(),
             deleteUsers: z
               .object({
                 args: z
@@ -2876,6 +2907,23 @@ describe.sequential('Returned data tests', () => {
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
                 type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
+            deleteUsersSingle: z
+              .object({
+                args: z
+                  .object({
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
             createPosts: z
@@ -2909,7 +2957,7 @@ describe.sequential('Returned data tests', () => {
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
-                type: z.instanceof(GraphQLObjectType),
+                type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
             updatePostsMany: z
@@ -2924,6 +2972,8 @@ describe.sequential('Returned data tests', () => {
                   })
                   .strict(),
                 resolve: z.function(),
+                // Documents the nullable element, the one mutation whose return type differs.
+                description: z.string(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
                 type: z.instanceof(GraphQLNonNull),
@@ -2951,6 +3001,28 @@ describe.sequential('Returned data tests', () => {
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
+            updatePostsSingle: z
+              .object({
+                args: z
+                  .object({
+                    set: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLObjectType),
+              })
+              .strict(),
             deletePosts: z
               .object({
                 args: z
@@ -2966,6 +3038,23 @@ describe.sequential('Returned data tests', () => {
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
                 type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
+            deletePostsSingle: z
+              .object({
+                args: z
+                  .object({
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
             createCustomers: z
@@ -2999,7 +3088,7 @@ describe.sequential('Returned data tests', () => {
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
-                type: z.instanceof(GraphQLObjectType),
+                type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
             updateCustomersMany: z
@@ -3014,6 +3103,8 @@ describe.sequential('Returned data tests', () => {
                   })
                   .strict(),
                 resolve: z.function(),
+                // Documents the nullable element, the one mutation whose return type differs.
+                description: z.string(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
                 type: z.instanceof(GraphQLNonNull),
@@ -3041,6 +3132,28 @@ describe.sequential('Returned data tests', () => {
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
+            updateCustomersSingle: z
+              .object({
+                args: z
+                  .object({
+                    set: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLObjectType),
+              })
+              .strict(),
             deleteCustomers: z
               .object({
                 args: z
@@ -3056,6 +3169,23 @@ describe.sequential('Returned data tests', () => {
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
                 type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
+            deleteCustomersSingle: z
+              .object({
+                args: z
+                  .object({
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
             createTags: z
@@ -3089,7 +3219,26 @@ describe.sequential('Returned data tests', () => {
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
-                type: z.instanceof(GraphQLObjectType),
+                type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
+            updateTagsMany: z
+              .object({
+                args: z
+                  .object({
+                    updates: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Documents the nullable element, the one mutation whose return type differs.
+                description: z.string(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
             updateTags: z
@@ -3114,6 +3263,28 @@ describe.sequential('Returned data tests', () => {
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
+            updateTagsSingle: z
+              .object({
+                args: z
+                  .object({
+                    set: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLObjectType),
+              })
+              .strict(),
             deleteTags: z
               .object({
                 args: z
@@ -3129,6 +3300,23 @@ describe.sequential('Returned data tests', () => {
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
                 type: z.instanceof(GraphQLNonNull),
+              })
+              .strict(),
+            deleteTagsSingle: z
+              .object({
+                args: z
+                  .object({
+                    where: z
+                      .object({
+                        type: z.instanceof(GraphQLNonNull),
+                      })
+                      .strict(),
+                  })
+                  .strict(),
+                resolve: z.function(),
+                // Present only on the fields that carry a complexity hint (lists and aggregates).
+                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
           })
@@ -3174,6 +3362,7 @@ describe.sequential('Returned data tests', () => {
             TagsOrderBy: z.instanceof(GraphQLInputObjectType),
             CreateTagsInput: z.instanceof(GraphQLInputObjectType),
             UpdateTagsInput: z.instanceof(GraphQLInputObjectType),
+            UpdateTagsManyInput: z.instanceof(GraphQLInputObjectType),
           })
           .strict(),
         fieldResolvers: z.record(z.string(), z.record(z.string(), z.function())).optional(),
@@ -4873,5 +5062,107 @@ describe('Insert conflict behavior (no onConflictDoNothing by default)', () => {
     // NOT silently return undefined.
     expect(res.errors).toBeDefined();
     expect(res.errors!.length).toBeGreaterThan(0);
+  });
+});
+
+describe.sequential('Atomic column updates, count mutations and relation pagination', () => {
+  const optIn = (source: string, variableValues?: Record<string, any>) =>
+    graphql({ schema: ctx.optInSchema, source, variableValues, contextValue: {} });
+  const run = (source: string, variableValues?: Record<string, any>) =>
+    graphql({ schema: ctx.schema, source, variableValues, contextValue: {} });
+
+  it('appends to an array column in the database', async () => {
+    const res = await optIn(
+      `mutation { updateUsersSingle(where: { id: { eq: 1 } }, set: { a: { push: [99] } }) { id a } }`,
+    );
+
+    expect(res.errors).toBeUndefined();
+    expect((res.data?.['updateUsersSingle'] as any)?.['a']).toStrictEqual([1, 5, 10, 25, 40, 99]);
+  });
+
+  it('replaces an array column when given set instead of push', async () => {
+    const res = await optIn(`mutation { updateUsersSingle(where: { id: { eq: 1 } }, set: { a: { set: [7] } }) { a } }`);
+
+    expect(res.errors).toBeUndefined();
+    expect((res.data?.['updateUsersSingle'] as any)?.['a']).toStrictEqual([7]);
+  });
+
+  it('rejects an operations input with no operation', async () => {
+    const res = await optIn(`mutation { updateUsersSingle(where: { id: { eq: 1 } }, set: { a: {} }) { a } }`);
+
+    expect(res.errors?.[0]?.message).toBe(
+      "Field 'a' was given no update operation. Pass exactly one of set, increment, decrement, multiply, divide, push.",
+    );
+  });
+
+  it('reads the row count out of the postgres.js result shape', async () => {
+    // node-postgres reports `rowCount`, PGlite `affectedRows`, postgres.js `count` — this is
+    // the driver the count mutations would silently return the wrong number for.
+    const res = await optIn(`mutation { updatePostsCount(where: { authorId: { eq: 1 } }, set: { content: "x" }) }`);
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data?.['updatePostsCount']).toBe(4);
+  });
+
+  it('counts a delete and leaves no rows behind', async () => {
+    const res = await optIn(`mutation { deletePostsCount(where: { authorId: { eq: 5 } }) }`);
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data?.['deletePostsCount']).toBe(2);
+    expect((await ctx.db.select().from(schema.Posts)).some((row) => row.authorId === 5)).toBe(false);
+  });
+
+  it('pages a to-many relation with after, per parent', async () => {
+    const first = await run(/* GraphQL */ `
+      {
+        users(where: { id: { eq: 1 } }) {
+          posts(orderBy: { id: { priority: 1, direction: asc } }, limit: 2) {
+            id
+            cursor
+          }
+        }
+      }
+    `);
+
+    expect(first.errors).toBeUndefined();
+    const page = (first.data?.['users'] as any[])[0]!['posts'];
+    expect(page.map((row: any) => row['id'])).toStrictEqual([1, 2]);
+
+    const second = await run(
+      /* GraphQL */ `
+        query ($after: String) {
+          users(where: { id: { eq: 1 } }) {
+            posts(orderBy: { id: { priority: 1, direction: asc } }, after: $after) {
+              id
+            }
+          }
+        }
+      `,
+      { after: page[1]['cursor'] },
+    );
+
+    expect(second.errors).toBeUndefined();
+    expect(((second.data?.['users'] as any[])[0]!['posts'] as any[]).map((row) => row['id'])).toStrictEqual([3, 6]);
+  });
+
+  it('keeps one row per distinct value within each parent', async () => {
+    const res = await run(/* GraphQL */ `
+      {
+        users(orderBy: { id: { priority: 1, direction: asc } }) {
+          id
+          posts(distinct: [content], orderBy: { id: { priority: 1, direction: asc } }) {
+            id
+            content
+          }
+        }
+      }
+    `);
+
+    expect(res.errors).toBeUndefined();
+    const byUser = Object.fromEntries(
+      (res.data?.['users'] as any[]).map((user) => [user['id'], user['posts'].map((post: any) => post['id'])]),
+    );
+    // User 1 wrote 1MESSAGE, 2MESSAGE, 3MESSAGE and 4MESSAGE — all distinct, so all survive.
+    expect(byUser[1]).toStrictEqual([1, 2, 3, 6]);
   });
 });

--- a/tests/pglite/field-updates.test.ts
+++ b/tests/pglite/field-updates.test.ts
@@ -1,0 +1,295 @@
+import { PGlite } from '@electric-sql/pglite';
+import { buildRelations, sql } from 'drizzle-orm';
+import { bigint, integer, numeric, pgTable, real, text } from 'drizzle-orm/pg-core';
+import { drizzle } from 'drizzle-orm/pglite';
+import { type GraphQLInputObjectType, type GraphQLSchema, graphql, printType } from 'graphql';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { buildSchema } from '@/index';
+
+const Items = pgTable('items', {
+  id: integer('id').primaryKey(),
+  name: text('name').notNull(),
+  qty: integer('qty'),
+  ratio: real('ratio'),
+  price: numeric('price'),
+  views: bigint('views', { mode: 'bigint' }),
+  tags: text('tags').array(),
+});
+
+const relations = buildRelations({ Items }, { Items: {} });
+const schema = { Items, relations };
+
+const DATA_DIR = `./tests/.temp/pgdata-field-updates-${Date.now()}`;
+let pglite: PGlite;
+let db: any;
+let gqlSchema: GraphQLSchema;
+let plainSchema: GraphQLSchema;
+
+const run = (source: string, variableValues?: Record<string, any>) =>
+  graphql({ schema: gqlSchema, source, variableValues, contextValue: {} });
+
+const items = () => db.select().from(Items).orderBy(Items.id);
+
+const updateInput = (gql: GraphQLSchema) => gql.getType('UpdateItemsInput') as GraphQLInputObjectType;
+
+const UPDATE = /* GraphQL */ `
+  mutation ($set: UpdateItemsInput!, $where: ItemsFilters) {
+    updateItems(set: $set, where: $where) {
+      id
+      qty
+      ratio
+      price
+      views
+      tags
+    }
+  }
+`;
+
+beforeAll(async () => {
+  const { mkdir } = await import('node:fs/promises');
+  await mkdir(DATA_DIR, { recursive: true });
+  pglite = new PGlite(DATA_DIR);
+  await pglite.waitReady;
+  db = (drizzle as any)({ client: pglite, schema, relations, logger: !!process.env['LOG_SQL'] });
+
+  await db.execute(sql`CREATE TABLE "items" (
+		"id" integer PRIMARY KEY NOT NULL,
+		"name" text NOT NULL,
+		"qty" integer,
+		"ratio" real,
+		"price" numeric,
+		"views" bigint,
+		"tags" text[]
+	);`);
+
+  gqlSchema = buildSchema(db, { features: { fieldUpdateOperations: true } }).schema;
+  plainSchema = buildSchema(db).schema;
+});
+
+afterAll(async () => {
+  await pglite?.close().catch(console.error);
+  const { rm } = await import('node:fs/promises');
+  await rm(DATA_DIR, { recursive: true, force: true }).catch(() => {});
+});
+
+beforeEach(async () => {
+  await db.execute(sql`DELETE FROM "items"`);
+  await db.insert(Items).values([
+    { id: 1, name: 'a', qty: 10, ratio: 1.5, price: '10.50', views: 100n, tags: ['x'] },
+    { id: 2, name: 'b', qty: 20, ratio: 2.5, price: '20.50', views: 200n, tags: ['y', 'z'] },
+  ]);
+});
+
+describe('fieldUpdateOperations: schema shape', () => {
+  it('leaves the update input set-only when the flag is off', () => {
+    const fields = updateInput(plainSchema).getFields();
+
+    expect(String(fields['qty']!.type)).toBe('Int');
+    expect(String(fields['tags']!.type)).toBe('[String!]');
+    expect(plainSchema.getType('IntFieldUpdate')).toBeUndefined();
+    expect(plainSchema.getType('StringListFieldUpdate')).toBeUndefined();
+  });
+
+  it('replaces numeric and array fields with operations inputs when the flag is on', () => {
+    const fields = updateInput(gqlSchema).getFields();
+
+    expect(String(fields['qty']!.type)).toBe('IntFieldUpdate');
+    expect(String(fields['ratio']!.type)).toBe('FloatFieldUpdate');
+    expect(String(fields['price']!.type)).toBe('DecimalFieldUpdate');
+    expect(String(fields['views']!.type)).toBe('BigIntFieldUpdate');
+    expect(String(fields['tags']!.type)).toBe('StringListFieldUpdate');
+    // Non-numeric, non-list columns keep their plain type.
+    expect(String(fields['name']!.type)).toBe('String');
+  });
+
+  it('names the operations input for the scalar so every column of that type shares one', () => {
+    expect(printType(gqlSchema.getType('IntFieldUpdate')!)).toMatchInlineSnapshot(`
+      """"An update to a Int column: exactly one of these operations"""
+      input IntFieldUpdate {
+        """Replace the current value with this one"""
+        set: Int
+
+        """Add this to the current value (SQL \`column + value\`)"""
+        increment: Int
+
+        """Subtract this from the current value (SQL \`column - value\`)"""
+        decrement: Int
+
+        """Multiply the current value by this (SQL \`column * value\`)"""
+        multiply: Int
+
+        """
+        Divide the current value by this (SQL \`column / value\`), rounding as the database does
+        """
+        divide: Int
+      }"
+    `);
+  });
+
+  it('offers only set and push on an array column', () => {
+    expect(Object.keys((gqlSchema.getType('StringListFieldUpdate') as GraphQLInputObjectType).getFields())).toEqual([
+      'set',
+      'push',
+    ]);
+  });
+
+  it('leaves the insert input alone — operations are relative to a current value', () => {
+    const insert = (gqlSchema.getType('CreateItemsInput') as GraphQLInputObjectType).getFields();
+    expect(String(insert['qty']!.type)).toBe('Int');
+  });
+});
+
+describe('fieldUpdateOperations: arithmetic', () => {
+  it('increments in the database rather than from a read value', async () => {
+    const res = await run(UPDATE, { set: { qty: { increment: 5 } } });
+
+    expect(res.errors).toBeUndefined();
+    expect((res.data!['updateItems'] as any[]).map((r) => r['qty'])).toEqual([15, 25]);
+  });
+
+  it('decrements, multiplies and divides', async () => {
+    expect(((await run(UPDATE, { set: { qty: { decrement: 3 } } })).data!['updateItems'] as any[])[0]!['qty']).toBe(7);
+    expect(((await run(UPDATE, { set: { qty: { multiply: 2 } } })).data!['updateItems'] as any[])[0]!['qty']).toBe(14);
+    expect(((await run(UPDATE, { set: { qty: { divide: 2 } } })).data!['updateItems'] as any[])[0]!['qty']).toBe(7);
+  });
+
+  it('applies the operation per row, not once for the batch', async () => {
+    await run(UPDATE, { set: { qty: { multiply: 10 } } });
+    expect((await items()).map((r: any) => r.qty)).toEqual([100, 200]);
+  });
+
+  it('honours where, leaving other rows untouched', async () => {
+    const res = await run(UPDATE, { set: { qty: { increment: 1 } }, where: { id: { eq: 1 } } });
+
+    expect(res.errors).toBeUndefined();
+    expect((await items()).map((r: any) => r.qty)).toEqual([11, 20]);
+  });
+
+  it('works on Float, Decimal and BigInt columns, which transport as strings', async () => {
+    const res = await run(UPDATE, {
+      set: { ratio: { increment: 0.5 }, price: { increment: '1.25' }, views: { multiply: '3' } },
+    });
+
+    expect(res.errors).toBeUndefined();
+    const [first] = res.data!['updateItems'] as any[];
+    expect(first['ratio']).toBe(2);
+    expect(first['price']).toBe('11.75');
+    expect(first['views']).toBe('300');
+  });
+
+  it('accepts set as the explicit spelling of a plain assignment', async () => {
+    const res = await run(UPDATE, { set: { qty: { set: 42 } } });
+
+    expect(res.errors).toBeUndefined();
+    expect((await items()).map((r: any) => r.qty)).toEqual([42, 42]);
+  });
+
+  it('mixes operations, plain fields and set in one update', async () => {
+    const res = await run(
+      /* GraphQL */ `
+        mutation ($set: UpdateItemsInput!) {
+          updateItems(set: $set) {
+            id
+            name
+            qty
+          }
+        }
+      `,
+      { set: { name: 'renamed', qty: { increment: 1 } } },
+    );
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data!['updateItems']).toEqual([
+      { id: 1, name: 'renamed', qty: 11 },
+      { id: 2, name: 'renamed', qty: 21 },
+    ]);
+  });
+
+  it('sets null through set, which arithmetic cannot express', async () => {
+    const res = await run(UPDATE, { set: { qty: { set: null } } });
+
+    expect(res.errors).toBeUndefined();
+    expect((await items()).map((r: any) => r.qty)).toEqual([null, null]);
+  });
+});
+
+describe('fieldUpdateOperations: arrays', () => {
+  it('appends with push, leaving the existing elements in place', async () => {
+    const res = await run(UPDATE, { set: { tags: { push: ['new'] } } });
+
+    expect(res.errors).toBeUndefined();
+    expect((res.data!['updateItems'] as any[]).map((r) => r['tags'])).toEqual([
+      ['x', 'new'],
+      ['y', 'z', 'new'],
+    ]);
+  });
+
+  it('replaces with set', async () => {
+    const res = await run(UPDATE, { set: { tags: { set: ['only'] } } });
+
+    expect(res.errors).toBeUndefined();
+    expect((res.data!['updateItems'] as any[]).map((r) => r['tags'])).toEqual([['only'], ['only']]);
+  });
+});
+
+describe('fieldUpdateOperations: exactly one operation', () => {
+  it('rejects two operations on one column', async () => {
+    const res = await run(UPDATE, { set: { qty: { increment: 1, decrement: 1 } } });
+
+    expect(res.errors?.[0]?.message).toBe(
+      "Field 'qty' takes exactly one update operation, but 2 were given (increment, decrement).",
+    );
+    expect((await items()).map((r: any) => r.qty)).toEqual([10, 20]);
+  });
+
+  it('rejects an empty operations object, which would silently update nothing', async () => {
+    const res = await run(UPDATE, { set: { qty: {} } });
+
+    expect(res.errors?.[0]?.message).toBe(
+      "Field 'qty' was given no update operation. Pass exactly one of set, increment, decrement, multiply, divide, push.",
+    );
+  });
+});
+
+describe('fieldUpdateOperations: single-row and many updates', () => {
+  it('applies operations on updateItemsSingle', async () => {
+    const res = await run(
+      /* GraphQL */ `
+        mutation {
+          updateItemsSingle(set: { qty: { increment: 100 } }, where: { id: { eq: 2 } }) {
+            id
+            qty
+          }
+        }
+      `,
+    );
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data!['updateItemsSingle']).toEqual({ id: 2, qty: 120 });
+  });
+
+  it('applies a different operation per entry on updateItemsMany', async () => {
+    const res = await run(
+      /* GraphQL */ `
+        mutation ($updates: [UpdateItemsManyInput!]!) {
+          updateItemsMany(updates: $updates) {
+            id
+            qty
+          }
+        }
+      `,
+      {
+        updates: [
+          { where: { id: { eq: 1 } }, set: { qty: { increment: 1 } } },
+          { where: { id: { eq: 2 } }, set: { qty: { decrement: 1 } } },
+        ],
+      },
+    );
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data!['updateItemsMany']).toEqual([
+      { id: 1, qty: 11 },
+      { id: 2, qty: 19 },
+    ]);
+  });
+});

--- a/tests/pglite/mutation-return-shapes.test.ts
+++ b/tests/pglite/mutation-return-shapes.test.ts
@@ -1,0 +1,238 @@
+import { PGlite } from '@electric-sql/pglite';
+import { buildRelations, sql } from 'drizzle-orm';
+import { integer, pgTable, text } from 'drizzle-orm/pg-core';
+import { drizzle } from 'drizzle-orm/pglite';
+import { type GraphQLObjectType, type GraphQLSchema, graphql } from 'graphql';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { buildSchema, type SchemaFeatures } from '@/index';
+
+const Items = pgTable('items', {
+  id: integer('id').primaryKey(),
+  name: text('name').notNull(),
+  qty: integer('qty'),
+});
+
+const relations = buildRelations({ Items }, { Items: {} });
+const schema = { Items, relations };
+
+const DATA_DIR = `./tests/.temp/pgdata-mutation-shapes-${Date.now()}`;
+let pglite: PGlite;
+let db: any;
+let gqlSchema: GraphQLSchema;
+
+const build = (features?: SchemaFeatures, extra?: Record<string, any>) =>
+  buildSchema(db, { ...(features ? { features } : {}), ...extra }).schema;
+
+const mutationFields = (gql: GraphQLSchema) => gql.getMutationType()!.getFields();
+
+const run = (source: string, variableValues?: Record<string, any>, target: GraphQLSchema = gqlSchema) =>
+  graphql({ schema: target, source, variableValues, contextValue: {} });
+
+const items = () => db.select().from(Items).orderBy(Items.id);
+
+beforeAll(async () => {
+  const { mkdir } = await import('node:fs/promises');
+  await mkdir(DATA_DIR, { recursive: true });
+  pglite = new PGlite(DATA_DIR);
+  await pglite.waitReady;
+  db = (drizzle as any)({ client: pglite, schema, relations, logger: !!process.env['LOG_SQL'] });
+
+  await db.execute(sql`CREATE TABLE "items" (
+		"id" integer PRIMARY KEY NOT NULL,
+		"name" text NOT NULL,
+		"qty" integer
+	);`);
+
+  gqlSchema = build({ countMutations: true });
+});
+
+afterAll(async () => {
+  await pglite?.close().catch(console.error);
+  const { rm } = await import('node:fs/promises');
+  await rm(DATA_DIR, { recursive: true, force: true }).catch(() => {});
+});
+
+beforeEach(async () => {
+  await db.execute(sql`DELETE FROM "items"`);
+  await db.insert(Items).values([
+    { id: 1, name: 'a', qty: 10 },
+    { id: 2, name: 'b', qty: 20 },
+    { id: 3, name: 'c', qty: 30 },
+  ]);
+});
+
+describe('single insert nullability', () => {
+  it('is non-null, because an insert either returns its row or throws', () => {
+    expect(String(mutationFields(build())['createItemsSingle']!.type)).toBe('Items!');
+  });
+
+  it('is nullable under conflictDoNothing, the one setting that can swallow the insert', () => {
+    expect(String(mutationFields(build(undefined, { conflictDoNothing: true }))['createItemsSingle']!.type)).toBe(
+      'Items',
+    );
+  });
+
+  it('returns the inserted row rather than null', async () => {
+    const res = await run(/* GraphQL */ `
+      mutation {
+        createItemsSingle(values: { id: 9, name: "z" }) {
+          id
+        }
+      }
+    `);
+
+    expect(res.errors?.[0]?.message).toBeUndefined();
+  });
+});
+
+describe('updateMany return shape', () => {
+  it('documents why its element is nullable where every sibling mutation is not', () => {
+    const description = mutationFields(build())['updateItemsMany']!.description;
+
+    expect(String(mutationFields(build())['updateItemsMany']!.type)).toBe('[Items]!');
+    expect(description).toContain('entry order');
+    expect(description).toContain('matched no rows');
+  });
+});
+
+describe('countMutations: schema shape', () => {
+  it('is off by default', () => {
+    expect(mutationFields(build())['updateItemsCount']).toBeUndefined();
+    expect(mutationFields(build())['deleteItemsCount']).toBeUndefined();
+  });
+
+  it('generates Int!-returning update and delete counters when on', () => {
+    const fields = mutationFields(gqlSchema);
+
+    expect(String(fields['updateItemsCount']!.type)).toBe('Int!');
+    expect(String(fields['deleteItemsCount']!.type)).toBe('Int!');
+    expect(fields['updateItemsCount']!.args.map((a) => `${a.name}: ${a.type}`)).toEqual([
+      'set: UpdateItemsInput!',
+      'where: ItemsFilters',
+    ]);
+    expect(fields['deleteItemsCount']!.args.map((a) => `${a.name}: ${a.type}`)).toEqual(['where: ItemsFilters']);
+  });
+
+  it('follows the feature switch of the write it mirrors', () => {
+    const noUpdate = mutationFields(build({ countMutations: true, update: false }));
+    expect(noUpdate['updateItemsCount']).toBeUndefined();
+    expect(noUpdate['deleteItemsCount']).toBeDefined();
+
+    const noDelete = mutationFields(build({ countMutations: true, delete: false }));
+    expect(noDelete['updateItemsCount']).toBeDefined();
+    expect(noDelete['deleteItemsCount']).toBeUndefined();
+  });
+
+  it('requires a where when requireWhere is on', () => {
+    const fields = mutationFields(build({ countMutations: true, requireWhere: true }));
+
+    expect(fields['updateItemsCount']!.args.find((a) => a.name === 'where')!.type.toString()).toBe('ItemsFilters!');
+    expect(fields['deleteItemsCount']!.args.find((a) => a.name === 'where')!.type.toString()).toBe('ItemsFilters!');
+  });
+
+  it('does not add an output type — Int is already in the schema', () => {
+    expect((gqlSchema.getType('Items') as GraphQLObjectType).name).toBe('Items');
+    expect(gqlSchema.getType('ItemsCount')).toBeUndefined();
+  });
+});
+
+describe('countMutations: behaviour', () => {
+  it('counts the rows an unfiltered update touched without returning them', async () => {
+    const res = await run(/* GraphQL */ `
+      mutation {
+        updateItemsCount(set: { name: "renamed" })
+      }
+    `);
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data).toEqual({ updateItemsCount: 3 });
+    expect((await items()).map((r: any) => r.name)).toEqual(['renamed', 'renamed', 'renamed']);
+  });
+
+  it('counts only the rows the where matched', async () => {
+    const res = await run(/* GraphQL */ `
+      mutation {
+        updateItemsCount(set: { name: "x" }, where: { qty: { gt: 15 } })
+      }
+    `);
+
+    expect(res.data).toEqual({ updateItemsCount: 2 });
+    expect((await items()).map((r: any) => r.name)).toEqual(['a', 'x', 'x']);
+  });
+
+  it('reports zero when nothing matched, rather than erroring', async () => {
+    const res = await run(/* GraphQL */ `
+      mutation {
+        updateItemsCount(set: { name: "x" }, where: { id: { eq: 99 } })
+      }
+    `);
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data).toEqual({ updateItemsCount: 0 });
+  });
+
+  it('counts deleted rows and leaves the rest in place', async () => {
+    const res = await run(/* GraphQL */ `
+      mutation {
+        deleteItemsCount(where: { id: { lt: 3 } })
+      }
+    `);
+
+    expect(res.data).toEqual({ deleteItemsCount: 2 });
+    expect((await items()).map((r: any) => r.id)).toEqual([3]);
+  });
+
+  it('deletes every row when given no where', async () => {
+    const res = await run(/* GraphQL */ `
+      mutation {
+        deleteItemsCount
+      }
+    `);
+
+    expect(res.data).toEqual({ deleteItemsCount: 3 });
+    expect(await items()).toEqual([]);
+  });
+
+  it('refuses an update with nothing to set', async () => {
+    const res = await run(/* GraphQL */ `
+      mutation {
+        updateItemsCount(set: {})
+      }
+    `);
+
+    expect(res.errors?.[0]?.message).toBe('Unable to update with no values specified!');
+  });
+
+  it('rejects a missing where under requireWhere before touching a row', async () => {
+    const strict = build({ countMutations: true, requireWhere: true });
+    const res = await run(
+      /* GraphQL */ `
+        mutation {
+          deleteItemsCount(where: {})
+        }
+      `,
+      undefined,
+      strict,
+    );
+
+    expect(res.errors?.[0]?.message).toContain("requires a 'where' argument");
+    expect((await items()).length).toBe(3);
+  });
+
+  it('applies field update operations, like the write it mirrors', async () => {
+    const withOps = build({ countMutations: true, fieldUpdateOperations: true });
+    const res = await run(
+      /* GraphQL */ `
+        mutation {
+          updateItemsCount(set: { qty: { increment: 5 } })
+        }
+      `,
+      undefined,
+      withOps,
+    );
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data).toEqual({ updateItemsCount: 3 });
+    expect((await items()).map((r: any) => r.qty)).toEqual([15, 25, 35]);
+  });
+});

--- a/tests/pglite/mysql-schema.test.ts
+++ b/tests/pglite/mysql-schema.test.ts
@@ -68,6 +68,27 @@ const upsertEntities = generateMySQL(mockDb, tableSchema, schema.relations, {
   },
 }) as any;
 
+// The two flags this file's main generation leaves off, so their shapes can be inspected
+// against MySQL's otherwise uniform mutation return type.
+const optInEntities = generateMySQL(mockDb, tableSchema, schema.relations, {
+  relationsDepthLimit: undefined,
+  prefixes,
+  suffixes,
+  conflictDoNothing: false,
+  shouldEagerLoad: () => true,
+  features: {
+    aggregates: true,
+    relationAggregates: true,
+    distinct: true,
+    insert: true,
+    update: true,
+    delete: true,
+    upsert: false,
+    fieldUpdateOperations: true,
+    countMutations: true,
+  },
+}) as any;
+
 // ── query structure ───────────────────────────────────────────────────────────
 
 describe('MySQL generated queries', () => {
@@ -328,5 +349,40 @@ describe('MySQL complexity hints', () => {
 
   it('leaves single queries flat', () => {
     expect(entities.queries['usersSingle'].extensions).toBeUndefined();
+  });
+});
+
+// ── the two opt-in mutation shapes ────────────────────────────────────────────
+
+describe('MySQL count mutations', () => {
+  it('are absent unless the feature is on', () => {
+    expect(entities.mutations['updateUsersCount']).toBeUndefined();
+    expect(entities.mutations['deleteUsersCount']).toBeUndefined();
+  });
+
+  it('return Int! — the one mutation pair that is not MutationReturn', () => {
+    expect(String(optInEntities.mutations['updateUsersCount'].type)).toBe('Int!');
+    expect(String(optInEntities.mutations['deleteUsersCount'].type)).toBe('Int!');
+    // Which is the point: MySQL's writes report nothing but success, so a count is the only
+    // way to learn how many rows a bulk write touched.
+    expect(optInEntities.mutations['updateUsers'].type).toBe(optInEntities.types['MutationReturn']);
+  });
+
+  it('take the same arguments as the writes they mirror', () => {
+    expect(Object.keys(optInEntities.mutations['updateUsersCount'].args)).toEqual(['set', 'where']);
+    expect(Object.keys(optInEntities.mutations['deleteUsersCount'].args)).toEqual(['where']);
+  });
+});
+
+describe('MySQL field update operations', () => {
+  it("replaces a numeric column's update field with an operations input", () => {
+    const fields = optInEntities.inputs['UpdateUsersInput'].getFields();
+
+    expect(String(fields['id'].type)).toBe('IntFieldUpdate');
+    expect(String(fields['name'].type)).toBe('String');
+  });
+
+  it('leaves the update input set-only when the flag is off', () => {
+    expect(String(entities.inputs['UpdateUsersInput'].getFields()['id'].type)).toBe('Int');
   });
 });

--- a/tests/pglite/relation-pagination.test.ts
+++ b/tests/pglite/relation-pagination.test.ts
@@ -1,0 +1,538 @@
+import { PGlite } from '@electric-sql/pglite';
+import { buildRelations, createRelationsHelper, sql } from 'drizzle-orm';
+import { integer, pgTable, text } from 'drizzle-orm/pg-core';
+import { drizzle } from 'drizzle-orm/pglite';
+import { type GraphQLObjectType, type GraphQLSchema, graphql } from 'graphql';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildSchema } from '@/index';
+
+const Authors = pgTable('authors', {
+  id: integer('id').primaryKey(),
+  name: text('name').notNull(),
+});
+const Posts = pgTable('posts', {
+  id: integer('id').primaryKey(),
+  authorId: integer('author_id'),
+  title: text('title').notNull(),
+  status: text('status').notNull(),
+  rank: integer('rank'),
+});
+
+const r = createRelationsHelper({ Authors, Posts });
+const relations = buildRelations(
+  { Authors, Posts },
+  {
+    Authors: { posts: r.many.Posts({ from: r.Authors.id, to: r.Posts.authorId }) },
+    Posts: { author: r.one.Authors({ from: r.Posts.authorId, to: r.Authors.id }) },
+  },
+);
+const schema = { Authors, Posts, relations };
+
+const DATA_DIR = `./tests/.temp/pgdata-relation-pagination-${Date.now()}`;
+let pglite: PGlite;
+let db: any;
+let gqlSchema: GraphQLSchema;
+let queryCount = 0;
+
+const run = (source: string, variableValues?: Record<string, any>) =>
+  graphql({ schema: gqlSchema, source, variableValues, contextValue: {} });
+
+/** The posts of one author, in the order the response returned them. */
+const titles = (data: any, authorIndex = 0): string[] =>
+  data['authors'][authorIndex]['posts'].map((post: any) => post['title']);
+
+beforeAll(async () => {
+  const { mkdir } = await import('node:fs/promises');
+  await mkdir(DATA_DIR, { recursive: true });
+  pglite = new PGlite(DATA_DIR);
+  await pglite.waitReady;
+  db = (drizzle as any)({
+    client: pglite,
+    schema,
+    relations,
+    logger: { logQuery: () => queryCount++ },
+  });
+
+  await db.execute(sql`CREATE TABLE "authors" (
+		"id" integer PRIMARY KEY NOT NULL,
+		"name" text NOT NULL
+	);`);
+  await db.execute(sql`CREATE TABLE "posts" (
+		"id" integer PRIMARY KEY NOT NULL,
+		"author_id" integer,
+		"title" text NOT NULL,
+		"status" text NOT NULL,
+		"rank" integer
+	);`);
+
+  await db.insert(Authors).values([
+    { id: 1, name: 'ann' },
+    { id: 2, name: 'bob' },
+  ]);
+  await db.insert(Posts).values([
+    { id: 1, authorId: 1, title: 'a1', status: 'draft', rank: 1 },
+    { id: 2, authorId: 1, title: 'a2', status: 'draft', rank: null },
+    { id: 3, authorId: 1, title: 'a3', status: 'published', rank: 2 },
+    { id: 4, authorId: 1, title: 'a4', status: 'published', rank: null },
+    { id: 5, authorId: 2, title: 'b1', status: 'draft', rank: 1 },
+    { id: 6, authorId: 2, title: 'b2', status: 'published', rank: null },
+    { id: 7, authorId: 2, title: 'b3', status: 'published', rank: 3 },
+  ]);
+
+  gqlSchema = buildSchema(db).schema;
+});
+
+afterAll(async () => {
+  await pglite?.close().catch(console.error);
+  const { rm } = await import('node:fs/promises');
+  await rm(DATA_DIR, { recursive: true, force: true }).catch(() => {});
+});
+
+describe('to-many relation arguments', () => {
+  it('takes the same pagination surface a root list of the target does', () => {
+    const authors = (gqlSchema.getType('Authors') as GraphQLObjectType).getFields();
+    const rootArgs = gqlSchema
+      .getQueryType()!
+      .getFields()
+      ['posts']!.args.map((a) => a.name);
+
+    expect(authors['posts']!.args.map((a) => a.name).sort()).toEqual(
+      ['where', 'orderBy', 'offset', 'limit', 'after', 'distinct'].sort(),
+    );
+    // Every argument the relation field takes is one the root list takes too.
+    for (const name of authors['posts']!.args.map((a) => a.name)) {
+      expect(rootArgs).toContain(name);
+    }
+  });
+
+  it("shares the target table's distinct enum with the root list", () => {
+    const authors = (gqlSchema.getType('Authors') as GraphQLObjectType).getFields();
+    const relationDistinct = authors['posts']!.args.find((a) => a.name === 'distinct')!;
+
+    expect(String(relationDistinct.type)).toBe('[PostsDistinctColumn!]');
+    expect((relationDistinct.type as any).ofType.ofType).toBe(gqlSchema.getType('PostsDistinctColumn'));
+  });
+
+  it('leaves to-one relation fields with where alone', () => {
+    const posts = (gqlSchema.getType('Posts') as GraphQLObjectType).getFields();
+    expect(posts['author']!.args.map((a) => a.name)).toEqual(['where']);
+  });
+
+  it('omits distinct when the feature is off', () => {
+    const noDistinct = buildSchema(db, { features: { distinct: false } }).schema;
+    const authors = (noDistinct.getType('Authors') as GraphQLObjectType).getFields();
+
+    expect(authors['posts']!.args.map((a) => a.name)).not.toContain('distinct');
+    expect(authors['posts']!.args.map((a) => a.name)).toContain('after');
+  });
+});
+
+describe('relation cursors', () => {
+  it('resolves a cursor for each related row', async () => {
+    const res = await run(/* GraphQL */ `
+      {
+        authors(orderBy: { id: { priority: 1, direction: asc } }) {
+          id
+          posts(orderBy: { id: { priority: 1, direction: asc } }) {
+            title
+            cursor
+          }
+        }
+      }
+    `);
+
+    expect(res.errors).toBeUndefined();
+    const posts = (res.data!['authors'] as any[])[0]!['posts'];
+    expect(posts.map((p: any) => p['title'])).toEqual(['a1', 'a2', 'a3', 'a4']);
+    for (const post of posts) {
+      expect(typeof post['cursor']).toBe('string');
+      expect(post['cursor'].length).toBeGreaterThan(0);
+    }
+  });
+
+  it('pages each parent independently from its own cursor', async () => {
+    const first = await run(/* GraphQL */ `
+      {
+        authors(orderBy: { id: { priority: 1, direction: asc } }) {
+          id
+          posts(orderBy: { id: { priority: 1, direction: asc } }, limit: 2) {
+            title
+            cursor
+          }
+        }
+      }
+    `);
+
+    expect(first.errors).toBeUndefined();
+    expect(titles(first.data, 0)).toEqual(['a1', 'a2']);
+    expect(titles(first.data, 1)).toEqual(['b1', 'b2']);
+
+    // Ann's second page. Bob's rows are a different parent, so his cursor differs — but the
+    // predicate is on the post's own columns, so each parent is filtered by the same rule.
+    const annCursor = (first.data!['authors'] as any[])[0]!['posts'][1]!['cursor'];
+    const second = await run(
+      /* GraphQL */ `
+        query ($after: String) {
+          authors(orderBy: { id: { priority: 1, direction: asc } }) {
+            id
+            posts(orderBy: { id: { priority: 1, direction: asc } }, after: $after) {
+              title
+            }
+          }
+        }
+      `,
+      { after: annCursor },
+    );
+
+    expect(second.errors).toBeUndefined();
+    expect(titles(second.data, 0)).toEqual(['a3', 'a4']);
+    // Bob's posts are ids 5-7, all after the cursor's id 2.
+    expect(titles(second.data, 1)).toEqual(['b1', 'b2', 'b3']);
+  });
+
+  it('combines after with limit for a fixed page size', async () => {
+    const first = await run(/* GraphQL */ `
+      {
+        authors(where: { id: { eq: 1 } }) {
+          posts(orderBy: { id: { priority: 1, direction: asc } }, limit: 2) {
+            title
+            cursor
+          }
+        }
+      }
+    `);
+    const cursor = (first.data!['authors'] as any[])[0]!['posts'][1]!['cursor'];
+
+    const second = await run(
+      /* GraphQL */ `
+        query ($after: String) {
+          authors(where: { id: { eq: 1 } }) {
+            posts(orderBy: { id: { priority: 1, direction: asc } }, after: $after, limit: 2) {
+              title
+            }
+          }
+        }
+      `,
+      { after: cursor },
+    );
+
+    expect(second.errors).toBeUndefined();
+    expect(titles(second.data)).toEqual(['a3', 'a4']);
+  });
+
+  it('walks a descending relation ordering', async () => {
+    const first = await run(/* GraphQL */ `
+      {
+        authors(where: { id: { eq: 1 } }) {
+          posts(orderBy: { id: { priority: 1, direction: desc } }, limit: 1) {
+            title
+            cursor
+          }
+        }
+      }
+    `);
+    const cursor = (first.data!['authors'] as any[])[0]!['posts'][0]!['cursor'];
+
+    const second = await run(
+      /* GraphQL */ `
+        query ($after: String) {
+          authors(where: { id: { eq: 1 } }) {
+            posts(orderBy: { id: { priority: 1, direction: desc } }, after: $after, limit: 2) {
+              title
+            }
+          }
+        }
+      `,
+      { after: cursor },
+    );
+
+    expect(titles(first.data)).toEqual(['a4']);
+    expect(titles(second.data)).toEqual(['a3', 'a2']);
+  });
+
+  it('honours where alongside after', async () => {
+    const first = await run(/* GraphQL */ `
+      {
+        authors(where: { id: { eq: 1 } }) {
+          posts(where: { status: { eq: "published" } }, orderBy: { id: { priority: 1, direction: asc } }, limit: 1) {
+            title
+            cursor
+          }
+        }
+      }
+    `);
+    const cursor = (first.data!['authors'] as any[])[0]!['posts'][0]!['cursor'];
+
+    const second = await run(
+      /* GraphQL */ `
+        query ($after: String) {
+          authors(where: { id: { eq: 1 } }) {
+            posts(where: { status: { eq: "published" } }, orderBy: { id: { priority: 1, direction: asc } }, after: $after) {
+              title
+            }
+          }
+        }
+      `,
+      { after: cursor },
+    );
+
+    expect(titles(first.data)).toEqual(['a3']);
+    expect(titles(second.data)).toEqual(['a4']);
+  });
+
+  it('rejects a cursor taken under a different ordering', async () => {
+    const first = await run(/* GraphQL */ `
+      {
+        authors(where: { id: { eq: 1 } }) {
+          posts(orderBy: { id: { priority: 1, direction: asc } }, limit: 1) {
+            cursor
+          }
+        }
+      }
+    `);
+    const cursor = (first.data!['authors'] as any[])[0]!['posts'][0]!['cursor'];
+
+    const second = await run(
+      /* GraphQL */ `
+        query ($after: String) {
+          authors(where: { id: { eq: 1 } }) {
+            posts(orderBy: { title: { priority: 1, direction: desc } }, after: $after) {
+              title
+            }
+          }
+        }
+      `,
+      { after: cursor },
+    );
+
+    expect(second.errors?.[0]?.message).toBeDefined();
+  });
+
+  it('pages across the NULL group without skipping a row', async () => {
+    // PostgreSQL sorts NULLs largest, so ascending puts ranks 1, 2 first and the two NULL
+    // ranks last — the keyset predicate has to agree, or the NULL rows fall out of the walk.
+    const seen: string[] = [];
+    let after: string | null = null;
+    for (let page = 0; page < 4; page++) {
+      const res: any = await run(
+        /* GraphQL */ `
+          query ($after: String) {
+            authors(where: { id: { eq: 1 } }) {
+              posts(orderBy: { rank: { priority: 1, direction: asc } }, limit: 1, after: $after) {
+                title
+                cursor
+              }
+            }
+          }
+        `,
+        { after },
+      );
+      expect(res.errors).toBeUndefined();
+      const posts = res.data['authors'][0]['posts'];
+      if (!posts.length) break;
+      seen.push(posts[0]['title']);
+      after = posts[0]['cursor'];
+    }
+
+    expect(seen).toEqual(['a1', 'a3', 'a2', 'a4']);
+  });
+
+  it('honours an explicit nulls placement on a relation ordering', async () => {
+    const res = await run(/* GraphQL */ `
+      {
+        authors(where: { id: { eq: 1 } }) {
+          posts(orderBy: { rank: { priority: 1, direction: asc, nulls: first } }, limit: 2) {
+            title
+          }
+        }
+      }
+    `);
+
+    expect(res.errors).toBeUndefined();
+    expect(titles(res.data)).toEqual(['a2', 'a4']);
+  });
+
+  it('refuses after together with distinct', async () => {
+    const res = await run(/* GraphQL */ `
+      {
+        authors {
+          posts(after: "x", distinct: [status]) {
+            title
+          }
+        }
+      }
+    `);
+
+    expect(res.errors?.[0]?.message).toBe("'after' cannot be combined with 'distinct'.");
+  });
+});
+
+describe('relation distinct', () => {
+  it('keeps one row per distinct value within each parent, not across the batch', async () => {
+    const res = await run(/* GraphQL */ `
+      {
+        authors(orderBy: { id: { priority: 1, direction: asc } }) {
+          id
+          posts(distinct: [status], orderBy: { id: { priority: 1, direction: asc } }) {
+            title
+            status
+          }
+        }
+      }
+    `);
+
+    expect(res.errors).toBeUndefined();
+    // Each author keeps their own first draft and first published post.
+    expect(titles(res.data, 0)).toEqual(['a1', 'a3']);
+    expect(titles(res.data, 1)).toEqual(['b1', 'b2']);
+  });
+
+  it('picks the last row of each group under a descending ordering', async () => {
+    const res = await run(/* GraphQL */ `
+      {
+        authors(where: { id: { eq: 1 } }) {
+          posts(distinct: [status], orderBy: { id: { priority: 1, direction: desc } }) {
+            title
+          }
+        }
+      }
+    `);
+
+    expect(titles(res.data)).toEqual(['a4', 'a2']);
+  });
+
+  it('applies where before the distinct pass', async () => {
+    const res = await run(/* GraphQL */ `
+      {
+        authors(where: { id: { eq: 1 } }) {
+          posts(distinct: [status], where: { status: { eq: "published" } }, orderBy: { id: { priority: 1, direction: asc } }) {
+            title
+          }
+        }
+      }
+    `);
+
+    expect(titles(res.data)).toEqual(['a3']);
+  });
+
+  it('applies limit per parent to what the distinct pass left', async () => {
+    const res = await run(/* GraphQL */ `
+      {
+        authors(orderBy: { id: { priority: 1, direction: asc } }) {
+          posts(distinct: [status], orderBy: { id: { priority: 1, direction: asc } }, limit: 1) {
+            title
+          }
+        }
+      }
+    `);
+
+    expect(titles(res.data, 0)).toEqual(['a1']);
+    expect(titles(res.data, 1)).toEqual(['b1']);
+  });
+
+  it('returns an empty list per parent when nothing survives the where', async () => {
+    const res = await run(/* GraphQL */ `
+      {
+        authors {
+          posts(distinct: [status], where: { status: { eq: "archived" } }) {
+            title
+          }
+        }
+      }
+    `);
+
+    expect(res.errors).toBeUndefined();
+    expect((res.data!['authors'] as any[]).every((a) => a['posts'].length === 0)).toBe(true);
+  });
+});
+
+describe('eager loading and the fallback', () => {
+  it('stays on the eager path for a plain relation selection', async () => {
+    queryCount = 0;
+    const res = await run(/* GraphQL */ `
+      {
+        authors {
+          posts {
+            title
+          }
+        }
+      }
+    `);
+
+    expect(res.errors).toBeUndefined();
+    expect(queryCount).toBe(1);
+  });
+
+  it('falls back to one batched query when after is passed', async () => {
+    queryCount = 0;
+    const res = await run(/* GraphQL */ `
+      {
+        authors {
+          posts(orderBy: { id: { priority: 1, direction: asc } }, after: null) {
+            title
+          }
+        }
+      }
+    `);
+
+    expect(res.errors).toBeUndefined();
+    // The explicit null is not a cursor, so this is still the eager path.
+    expect(queryCount).toBe(1);
+  });
+
+  it('falls back once — not once per parent — when the cursor field is selected', async () => {
+    queryCount = 0;
+    const res = await run(/* GraphQL */ `
+      {
+        authors {
+          posts {
+            title
+            cursor
+          }
+        }
+      }
+    `);
+
+    expect(res.errors).toBeUndefined();
+    // One query for the authors, one batched query for every author's posts.
+    expect(queryCount).toBe(2);
+  });
+
+  it('falls back once when distinct is passed', async () => {
+    queryCount = 0;
+    const res = await run(/* GraphQL */ `
+      {
+        authors {
+          posts(distinct: [status]) {
+            title
+          }
+        }
+      }
+    `);
+
+    expect(res.errors).toBeUndefined();
+    // Authors, the distinct key pass, and the batched posts query.
+    expect(queryCount).toBe(3);
+  });
+
+  it('follows the cursor field through a fragment spread', async () => {
+    queryCount = 0;
+    const res = await run(/* GraphQL */ `
+      {
+        authors {
+          posts {
+            ...page
+          }
+        }
+      }
+      fragment page on Posts {
+        title
+        cursor
+      }
+    `);
+
+    expect(res.errors).toBeUndefined();
+    expect(queryCount).toBe(2);
+    expect((res.data!['authors'] as any[])[0]!['posts'][0]!['cursor']).toBeTypeOf('string');
+  });
+});

--- a/tests/pglite/returned-data.test.ts
+++ b/tests/pglite/returned-data.test.ts
@@ -536,7 +536,7 @@ describe.sequential('Returned data tests', () => {
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
-                type: z.instanceof(GraphQLObjectType),
+                type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
             updateUsersMany: z
@@ -551,6 +551,8 @@ describe.sequential('Returned data tests', () => {
                   })
                   .strict(),
                 resolve: z.function(),
+                // Documents the nullable element, the one mutation whose return type differs.
+                description: z.string(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
                 type: z.instanceof(GraphQLNonNull),
@@ -665,7 +667,7 @@ describe.sequential('Returned data tests', () => {
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
-                type: z.instanceof(GraphQLObjectType),
+                type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
             updatePostsMany: z
@@ -680,6 +682,8 @@ describe.sequential('Returned data tests', () => {
                   })
                   .strict(),
                 resolve: z.function(),
+                // Documents the nullable element, the one mutation whose return type differs.
+                description: z.string(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
                 type: z.instanceof(GraphQLNonNull),
@@ -794,7 +798,7 @@ describe.sequential('Returned data tests', () => {
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
-                type: z.instanceof(GraphQLObjectType),
+                type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
             updateCustomersMany: z
@@ -809,6 +813,8 @@ describe.sequential('Returned data tests', () => {
                   })
                   .strict(),
                 resolve: z.function(),
+                // Documents the nullable element, the one mutation whose return type differs.
+                description: z.string(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
                 type: z.instanceof(GraphQLNonNull),
@@ -923,7 +929,7 @@ describe.sequential('Returned data tests', () => {
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
-                type: z.instanceof(GraphQLObjectType),
+                type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
             updateTagsMany: z
@@ -938,6 +944,8 @@ describe.sequential('Returned data tests', () => {
                   })
                   .strict(),
                 resolve: z.function(),
+                // Documents the nullable element, the one mutation whose return type differs.
+                description: z.string(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
                 type: z.instanceof(GraphQLNonNull),
@@ -1026,12 +1034,8 @@ describe.sequential('Returned data tests', () => {
         types: z
           .object({
             User: z.instanceof(GraphQLObjectType),
-            User: z.instanceof(GraphQLObjectType),
-            Post: z.instanceof(GraphQLObjectType),
             Post: z.instanceof(GraphQLObjectType),
             Customer: z.instanceof(GraphQLObjectType),
-            Customer: z.instanceof(GraphQLObjectType),
-            Tag: z.instanceof(GraphQLObjectType),
             Tag: z.instanceof(GraphQLObjectType),
             UserAggregate: z.instanceof(GraphQLObjectType),
             UserGroupBy: z.instanceof(GraphQLObjectType),

--- a/tests/sqlite-update-ops-counts.test.ts
+++ b/tests/sqlite-update-ops-counts.test.ts
@@ -1,0 +1,139 @@
+import { type Client, createClient } from '@libsql/client';
+import { buildRelations, sql } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/libsql';
+import { integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { type GraphQLInputObjectType, type GraphQLSchema, graphql } from 'graphql';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { buildSchema } from '@/index';
+
+const Items = sqliteTable('items', {
+  id: integer('id').primaryKey(),
+  name: text('name').notNull(),
+  qty: integer('qty'),
+  ratio: real('ratio'),
+});
+
+const relations = buildRelations({ Items }, { Items: {} });
+const schema = { Items, relations };
+
+let client: Client;
+let db: any;
+let gqlSchema: GraphQLSchema;
+
+const run = (source: string, variableValues?: Record<string, any>) =>
+  graphql({ schema: gqlSchema, source, variableValues, contextValue: {} });
+
+const items = () => db.select().from(Items).orderBy(Items.id);
+
+beforeAll(async () => {
+  client = createClient({ url: 'file::memory:?cache=shared' });
+  db = (drizzle as any)({ client, schema, relations });
+
+  await db.run(sql`CREATE TABLE "items" (
+		"id" integer PRIMARY KEY NOT NULL,
+		"name" text NOT NULL,
+		"qty" integer,
+		"ratio" real
+	);`);
+
+  gqlSchema = buildSchema(db, { features: { fieldUpdateOperations: true, countMutations: true } }).schema;
+});
+
+afterAll(() => {
+  client.close();
+});
+
+beforeEach(async () => {
+  await db.run(sql`DELETE FROM "items"`);
+  await db.insert(Items).values([
+    { id: 1, name: 'a', qty: 10, ratio: 1.5 },
+    { id: 2, name: 'b', qty: 20, ratio: 2.5 },
+  ]);
+});
+
+describe('sqlite: field update operations', () => {
+  it('gives numeric columns an operations input', () => {
+    const fields = (gqlSchema.getType('UpdateItemsInput') as GraphQLInputObjectType).getFields();
+
+    expect(String(fields['qty']!.type)).toBe('IntFieldUpdate');
+    expect(String(fields['ratio']!.type)).toBe('FloatFieldUpdate');
+    expect(String(fields['name']!.type)).toBe('String');
+  });
+
+  it('increments in the database', async () => {
+    const res = await run(/* GraphQL */ `
+      mutation {
+        updateItems(set: { qty: { increment: 5 } }) {
+          id
+          qty
+        }
+      }
+    `);
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data!['updateItems']).toEqual([
+      { id: 1, qty: 15 },
+      { id: 2, qty: 25 },
+    ]);
+  });
+
+  it('multiplies a real column', async () => {
+    await run(/* GraphQL */ `
+      mutation {
+        updateItems(set: { ratio: { multiply: 2 } }) {
+          id
+        }
+      }
+    `);
+
+    expect((await items()).map((r: any) => r.ratio)).toEqual([3, 5]);
+  });
+
+  it('still rejects two operations on one column', async () => {
+    const res = await run(/* GraphQL */ `
+      mutation {
+        updateItems(set: { qty: { increment: 1, multiply: 2 } }) {
+          id
+        }
+      }
+    `);
+
+    expect(res.errors?.[0]?.message).toContain('takes exactly one update operation');
+  });
+});
+
+describe('sqlite: count mutations', () => {
+  it('reports the rows an update touched', async () => {
+    const res = await run(/* GraphQL */ `
+      mutation {
+        updateItemsCount(set: { qty: { increment: 1 } })
+      }
+    `);
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data).toEqual({ updateItemsCount: 2 });
+    expect((await items()).map((r: any) => r.qty)).toEqual([11, 21]);
+  });
+
+  it('reports the rows a delete removed', async () => {
+    const res = await run(/* GraphQL */ `
+      mutation {
+        deleteItemsCount(where: { id: { eq: 1 } })
+      }
+    `);
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data).toEqual({ deleteItemsCount: 1 });
+    expect((await items()).map((r: any) => r.id)).toEqual([2]);
+  });
+
+  it('reports zero for a where that matched nothing', async () => {
+    const res = await run(/* GraphQL */ `
+      mutation {
+        deleteItemsCount(where: { id: { eq: 99 } })
+      }
+    `);
+
+    expect(res.data).toEqual({ deleteItemsCount: 0 });
+  });
+});

--- a/tests/sqlite.test.ts
+++ b/tests/sqlite.test.ts
@@ -2947,7 +2947,7 @@ describe.sequential('Returned data tests', () => {
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
-                type: z.instanceof(GraphQLObjectType),
+                type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
             updateUsersMany: z
@@ -2962,6 +2962,8 @@ describe.sequential('Returned data tests', () => {
                   })
                   .strict(),
                 resolve: z.function(),
+                // Documents the nullable element, the one mutation whose return type differs.
+                description: z.string(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
                 type: z.instanceof(GraphQLNonNull),
@@ -3076,7 +3078,7 @@ describe.sequential('Returned data tests', () => {
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
-                type: z.instanceof(GraphQLObjectType),
+                type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
             updatePostsMany: z
@@ -3091,6 +3093,8 @@ describe.sequential('Returned data tests', () => {
                   })
                   .strict(),
                 resolve: z.function(),
+                // Documents the nullable element, the one mutation whose return type differs.
+                description: z.string(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
                 type: z.instanceof(GraphQLNonNull),
@@ -3205,7 +3209,7 @@ describe.sequential('Returned data tests', () => {
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
-                type: z.instanceof(GraphQLObjectType),
+                type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
             updateCustomersMany: z
@@ -3220,6 +3224,8 @@ describe.sequential('Returned data tests', () => {
                   })
                   .strict(),
                 resolve: z.function(),
+                // Documents the nullable element, the one mutation whose return type differs.
+                description: z.string(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
                 extensions: z.object({ complexity: z.function() }).strict().optional(),
                 type: z.instanceof(GraphQLNonNull),


### PR DESCRIPTION
Closes #57, closes #58, closes #62.

## #57 — Atomic column updates

`features.fieldUpdateOperations` (off by default) replaces a qualifying column's update field with an operations input, so `views: { increment: 1 }` compiles to `SET views = views + 1` instead of a read followed by a write of the value the read returned.

- Numeric columns (`Int`, `Float`, `BigInt`, `Decimal`) take `set` / `increment` / `decrement` / `multiply` / `divide`; array columns take `set` / `push`.
- Exactly one operation per column — enforced at resolve time, since graphql-js has no `@oneOf` on the supported version range. Two operations or `{}` is a `GraphQLError` naming the column.
- Input types are named for the **scalar**, not the column, so every `Int` column shares one `IntFieldUpdate`. A column claimed by a `scalarOverrides` entry keeps its plain field.
- Integer rounding and division by zero follow the database rather than being guarded, and are documented — as the issue asked.
- Insert inputs are untouched.

## #58 — Relation-field pagination parity

To-many relation fields now take `after` and `distinct`, matching a root list of the target table, and their rows carry a working `cursor`.

Drizzle's `with:` clause can express none of the three: keyset needs a predicate over the request's own total order, `distinct` needs a window pass, and a cursor has to be computed from the raw row. So this takes the fallback the issue offered — a relation passed `after` or `distinct`, or selecting `cursor`, drops out of the eager fetch and resolves through the request-scoped batch loader, which implements all three.

- Still **one query per relation** across the whole batch, never one per parent. Covered by query-count assertions in `tests/pglite/relation-pagination.test.ts`.
- `distinct` partitions by the foreign key as well as the requested columns, so it means one row per distinct value *per parent* — the same meaning it has on a root list.
- The keyset predicate is a plain condition on the target's own columns, so ANDing it into the batch's `WHERE fk IN (…)` filters each parent independently.
- `NULL`s in an ordered relation column page through rather than being skipped, verified on both null-ordering conventions.
- A plain relation selection still eager-loads; a to-one relation selecting `cursor` keeps its eager fetch.

## #62 — Mutation return shapes

1. `create<Table>Single` is now `Table!` except under `conflictDoNothing`, the one argument that can make it yield nothing.
2. `update<Table>Many` keeps `[Table]!` and gains a description explaining the nullable element: an entry whose `where` matched nothing contributes `null` in its slot, which is what keeps the response positionally aligned with the request.
3. `features.countMutations` (off by default) adds `update<Table>Count` / `delete<Table>Count`, returning `Int!` with the plural mutation's arguments and no `RETURNING *`. They follow the feature switch of the write they mirror, honour `requireWhere`, add no new output type, and reject nested writes with a clear error (a nested write needs the parent rows the count mutation deliberately does not read back). MySQL gets them too, where they are arguably most useful — its other mutations return only `MutationReturn { isSuccess }`.

The row count is probed across the shapes the drivers actually use (`rowCount`, `affectedRows`, `rowsAffected`, `changes`, `count`); a driver reporting none raises rather than silently returning `0`. The three PostgreSQL drivers in the test matrix each report it differently, and each is covered.

## Found along the way

- **MySQL's update paths never called the new update remapper**, so the atomic operations would have been silently ignored there. Caught by running the Docker MySQL suite.
- The `entities` zod schemas in `tests/pg.test.ts` and `tests/mysql.test.ts` had gone stale against the single-row update/delete mutations and against `Tags`' batch update — both suites need Docker, so this only surfaced when they were run. Fixed.

## Breaking changes

- `createRelationResolverFactory` takes the dialect's null ordering as its **third** argument, before `filterCtx`: `'nulls-largest'` for PostgreSQL, `'nulls-smallest'` for MySQL and SQLite. The keyset predicate has to agree with the dialect's native `ORDER BY` placement for `NULL` or rows are skipped, and there is no correct default.
- `create<Table>Single` returns `Table!` rather than `Table` unless `conflictDoNothing` is set.

## Verification

`npx vitest run` — **960 tests across 61 files**, all passing, against PGlite, real PostgreSQL via postgres.js, libsql, and real MySQL 8. `npx tsc --noEmit` clean; `npm run build` clean.

Note that `src/util/builders/common.ts` carries `// @ts-nocheck`, so the runtime tests are the only verification for the changes there — hence the Docker/PGlite suites rather than schema-shape assertions alone.

Docs updated in `README.md`, `llms.txt` and `TODO.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)