### PR TITLE
fix(types): remove @ts-nocheck from src and repair the drizzle 1.0 type drift

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck — vendored file, drizzle-orm 1.0 type compat not guaranteed
 import type { Many, One, Relation, Table, TableRelationalConfig, TablesRelationalConfig } from 'drizzle-orm';
 
 // Relations class was removed in drizzle-orm 1.0; stub for type compatibility
@@ -52,7 +51,7 @@ export type AnyDrizzleDB<TSchema extends Record<string, any>> =
 export type AnyQueryBuiler<TConfig extends TablesRelationalConfig = any, TFields extends TableRelationalConfig = any> =
   | PgQuery<TConfig, TFields>
   | MySqlQuery<any, TConfig, TFields>
-  | SQLiteQuery<any, any, TConfig, TFields>;
+  | SQLiteQuery<any, TConfig, TFields>;
 
 export type ExtractTables<TSchema extends Record<string, Table | unknown>> = {
   [K in keyof TSchema as TSchema[K] extends Table ? K : never]: TSchema[K] extends Table ? TSchema[K] : never;
@@ -169,14 +168,14 @@ export type SelectResolver<
     ? RelKey extends string
       ? Array<
           GetRemappedTableDataType<TTable> & {
-            [K in RelKey]: TRelations[K] extends One<string>
+            [K in RelKey]: TRelations[K] extends One<infer TTargetName, any>
               ? GetRemappedTableDataType<
-                  ExtractTableByName<TTables, TRelations[K]['referencedTableName']> extends infer T ? T[keyof T] : never
+                  ExtractTableByName<TTables, TTargetName> extends infer T ? T[keyof T] : never
                 > | null
-              : TRelations[K] extends Many<string>
+              : TRelations[K] extends Many<infer TTargetName>
                 ? Array<
                     GetRemappedTableDataType<
-                      ExtractTableByName<TTables, TRelations[K]['referencedTableName']> extends infer T
+                      ExtractTableByName<TTables, TTargetName> extends infer T
                         ? T[keyof T]
                         : never
                     >
@@ -201,14 +200,14 @@ export type SelectSingleResolver<
   | (keyof TRelations extends infer RelKey
       ? RelKey extends string
         ? GetRemappedTableDataType<TTable> & {
-            [K in RelKey]: TRelations[K] extends One<string>
+            [K in RelKey]: TRelations[K] extends One<infer TTargetName, any>
               ? GetRemappedTableDataType<
-                  ExtractTableByName<TTables, TRelations[K]['referencedTableName']> extends infer T ? T[keyof T] : never
+                  ExtractTableByName<TTables, TTargetName> extends infer T ? T[keyof T] : never
                 > | null
-              : TRelations[K] extends Many<string>
+              : TRelations[K] extends Many<infer TTargetName>
                 ? Array<
                     GetRemappedTableDataType<
-                      ExtractTableByName<TTables, TRelations[K]['referencedTableName']> extends infer T
+                      ExtractTableByName<TTables, TTargetName> extends infer T
                         ? T[keyof T]
                         : never
                     >

--- a/src/util/batch-loader/index.ts
+++ b/src/util/batch-loader/index.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 const DRIZZLE_LOADERS_KEY = Symbol('drizzle-graphql-loaders');
 
 type BatchFn<K, V> = (keys: readonly K[]) => Promise<readonly V[]>;

--- a/src/util/builders/aggregates.ts
+++ b/src/util/builders/aggregates.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck — vendored file, drizzle-orm 1.0 type compat not guaranteed
 import {
   and,
   avg,
@@ -279,7 +278,7 @@ const parseAggregateRequest = (
   for (const field of Object.values(selectionTree) as ResolveTree[]) {
     if (field.name === 'count') {
       request.count = true;
-      request.selection.count = count();
+      request.selection['count'] = count();
       continue;
     }
 
@@ -312,7 +311,7 @@ const assembleAggregateRow = (row: Record<string, any>, request: AggregateReques
 
   if (request.count) {
     // drizzle's count() maps to number already; guard for drivers returning strings.
-    result.count = row.count == null ? 0 : Number(row.count);
+    result['count'] = row['count'] == null ? 0 : Number(row['count']);
   }
 
   for (const op of AGGREGATE_OPS) {
@@ -335,7 +334,9 @@ const assembleAggregateRow = (row: Record<string, any>, request: AggregateReques
         // the value (`min`/`max` are `mapWith(column)`), so all that's left is coercing a
         // leftover raw date string (PG decodes timestamps in driver-level codecs, which raw
         // select expressions bypass) and remapping for GraphQL output.
-        const column = target.columns[columnName];
+        // Present by construction: a name only reaches `request.ops` after the same lookup
+        // succeeded in `buildAggregateRequest`.
+        const column = target.columns[columnName]!;
         const decoded =
           typeof value === 'string' && target.dateTimeColumns.has(columnName) ? parseDriverDateTime(value) : value;
         opResult[columnName] = remapToGraphQLCore(columnName, decoded, target.tableName, column);

--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -14,7 +14,6 @@
 //    - Insert input: ${capitalize(insertPrefix)}${toTypeName(tableName)}Input (e.g. CreateUsersInput)
 //    - Update input: ${capitalize(updatePrefix)}${toTypeName(tableName)}Input (e.g. UpdateUsersInput)
 // =============================================================================
-// @ts-nocheck — vendored file, drizzle-orm 1.0 type compat not guaranteed
 import type { Column, Relation, Table } from 'drizzle-orm';
 import {
   aliasedTable,
@@ -91,7 +90,6 @@ import type {
   FilterColumnOperators,
   FilterColumnOperatorsCore,
   Filters,
-  FiltersCore,
   GeneratedTableTypes,
   GeneratedTableTypesOutputs,
   OrderByArgs,
@@ -1651,7 +1649,7 @@ const resolveGenericFilterDescriptor = (
  * Postgres `@>` / MySQL `JSON_CONTAINS`. SQLite stores json as text and has no containment
  * operator, so `contains` is omitted there (same precedent as dialect-specific ops like ilike).
  */
-const jsonFilterFields = (column: Column, colType: ReturnType<typeof drizzleColumnToGraphQLType>['type']) => {
+const jsonFilterFields = (column: Column, colType: ConvertedColumn<true>['type']) => {
   const dialect = columnDialect(column);
   return {
     eq: { type: colType, description: 'JSON equality on the whole value' },
@@ -3585,7 +3583,10 @@ export const extractFilters = <TTable extends Table>(
   // filter type itself, so the tree nests arbitrarily.
   const { OR, AND, NOT, ...fieldFilters } = filters;
 
-  const entries = Object.entries(fieldFilters as FiltersCore<TTable>);
+  // `Omit`-ing the boolean keys off a generic `Filters<TTable>` leaves a type the checker
+  // can no longer relate to `FiltersCore<TTable>`. Each key is dispatched on its own below
+  // — as a column or as a relation — so the entries are typed for that dispatch instead.
+  const entries = Object.entries(fieldFilters) as [string, FilterColumnOperatorsCore<any> | undefined][];
 
   const columns = getColumns(table);
   const relations = relationCtx?.relationMap[relationCtx.tableKey];
@@ -4274,9 +4275,9 @@ export const withPrimaryKeyColumns = <T extends Record<string, any>>(
  * Each dialect builder binds this with its own getTableConfig and reuses the binding for
  * both relation pagination and mutation re-fetch keying.
  */
-export const getPrimaryKeyPropNamesFromConfig = (
-  table: Table,
-  getTableConfig: (table: Table) => { primaryKeys: { columns: { name: string }[] }[] },
+export const getPrimaryKeyPropNamesFromConfig = <TTable extends Table>(
+  table: TTable,
+  getTableConfig: (table: TTable) => { primaryKeys: { columns: { name: string }[] }[] },
 ): string[] => {
   const compositePkColumnNames = getTableConfig(table).primaryKeys.flatMap((pk) => pk.columns.map((c) => c.name));
   return getPrimaryKeyPropNames(table, compositePkColumnNames);
@@ -4600,9 +4601,9 @@ export const rowCursorResolver = (source: any): string | null => source?.[ROW_CU
  * column enum. Deduplicated, order-insensitive — a column that is both the primary key and
  * a unique constraint yields one set.
  */
-export const getUniqueColumnSets = (
-  table: Table,
-  getTableConfig: (table: Table) => {
+export const getUniqueColumnSets = <TTable extends Table>(
+  table: TTable,
+  getTableConfig: (table: TTable) => {
     primaryKeys: { columns: { name: string }[] }[];
     uniqueConstraints?: { columns: { name: string }[] }[];
     indexes?: { config: { unique?: boolean; columns: any[] } }[];

--- a/src/util/builders/field-updates.ts
+++ b/src/util/builders/field-updates.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck — drizzle-orm 1.0 type compat not guaranteed, same as its sibling builders
 /**
  * Atomic column operations on the update `set` (`features.fieldUpdateOperations`).
  *

--- a/src/util/builders/mysql.ts
+++ b/src/util/builders/mysql.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck — vendored file, drizzle-orm 1.0 type compat not guaranteed
 import { is, One, type Table } from 'drizzle-orm';
 import { getTableConfig, type MySqlDatabase, MySqlTable } from 'drizzle-orm/mysql-core';
 import type { RelationalQueryBuilder } from 'drizzle-orm/mysql-core/query-builders/query';
@@ -102,7 +101,7 @@ const generateSelectArray = (
   limits?: LimitPolicyFor,
   policies?: ResolverPolicies,
 ): CreatedResolver => {
-  const queryBase = db.query[tableName as keyof typeof db.query] as unknown as
+  const queryBase = db.query[tableName as keyof typeof db.query & string] as unknown as
     | RelationalQueryBuilder<any, any, any>
     | undefined;
   if (!queryBase) {
@@ -175,7 +174,7 @@ const generateSelectSingle = (
   limits?: LimitPolicyFor,
   policies?: ResolverPolicies,
 ): CreatedResolver => {
-  const queryBase = db.query[tableName as keyof typeof db.query] as unknown as
+  const queryBase = db.query[tableName as keyof typeof db.query & string] as unknown as
     | RelationalQueryBuilder<any, any, any>
     | undefined;
   if (!queryBase) {
@@ -941,7 +940,7 @@ export const generateSchemaData = <
   // Every MySQL mutation returns it, so it only belongs in the type map when at least one
   // mutation is generated.
   if ((['insert', 'upsert', 'update', 'delete'] as const).some((feature) => anyTable(feature))) {
-    outputs.MutationReturn = mutationReturnType;
+    outputs['MutationReturn'] = mutationReturnType;
   }
 
   for (const [tableName, tableTypes] of Object.entries(gqlSchemaTypes)) {

--- a/src/util/builders/nested-writes.ts
+++ b/src/util/builders/nested-writes.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck — drizzle-orm 1.0 type compat not guaranteed, same as its sibling builders
 // =============================================================================
 // Nested writes — `create` / `connect` / `disconnect` / `set` on the relation
 // fields of a table's create and update inputs.

--- a/src/util/builders/pg.ts
+++ b/src/util/builders/pg.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck — vendored file, drizzle-orm 1.0 type compat not guaranteed
 import { and, getColumns, is, One, type Table, type View } from 'drizzle-orm';
 import type { RelationalQueryBuilder } from 'drizzle-orm/mysql-core/query-builders/query';
 import { getTableConfig, type PgAsyncDatabase, type PgColumn, PgTable } from 'drizzle-orm/pg-core';
@@ -119,7 +118,7 @@ import type {
 } from './types.ts';
 
 const generateSelectArray = (
-  db: PgAsyncDatabase<any, any, any>,
+  db: PgAsyncDatabase<any, any>,
   tableName: string,
   tables: Record<string, Table>,
   relationMap: Record<string, Record<string, TableNamedRelations>>,
@@ -133,7 +132,7 @@ const generateSelectArray = (
   limits?: LimitPolicyFor,
   policies?: ResolverPolicies,
 ): CreatedResolver => {
-  const queryBase = db.query[tableName as keyof typeof db.query] as unknown as
+  const queryBase = db.query[tableName as keyof typeof db.query & string] as unknown as
     | RelationalQueryBuilder<any, any, any>
     | undefined;
   // Tables without relations won't have db.query support — fall back to basic select.
@@ -304,7 +303,7 @@ const generateSelectArray = (
 };
 
 const generateSelectSingle = (
-  db: PgAsyncDatabase<any, any, any>,
+  db: PgAsyncDatabase<any, any>,
   tableName: string,
   tables: Record<string, Table>,
   relationMap: Record<string, Record<string, TableNamedRelations>>,
@@ -317,7 +316,7 @@ const generateSelectSingle = (
   limits?: LimitPolicyFor,
   policies?: ResolverPolicies,
 ): CreatedResolver => {
-  const queryBase = db.query[tableName as keyof typeof db.query] as unknown as
+  const queryBase = db.query[tableName as keyof typeof db.query & string] as unknown as
     | RelationalQueryBuilder<any, any, any>
     | undefined;
   // Tables without relations won't have db.query support — fall back to basic select.
@@ -402,7 +401,7 @@ const generateSelectSingle = (
 const pgPrimaryKeyPropNames = (table: PgTable): string[] => getPrimaryKeyPropNamesFromConfig(table, getTableConfig);
 
 const generateInsertArray = (
-  db: PgAsyncDatabase<any, any, any>,
+  db: PgAsyncDatabase<any, any>,
   tableName: string,
   table: PgTable,
   tables: Record<string, Table>,
@@ -538,7 +537,7 @@ const generateInsertArray = (
 };
 
 const generateInsertSingle = (
-  db: PgAsyncDatabase<any, any, any>,
+  db: PgAsyncDatabase<any, any>,
   tableName: string,
   table: PgTable,
   tables: Record<string, Table>,
@@ -680,7 +679,7 @@ const generateInsertSingle = (
  * Shares the insert input: an upsert supplies a whole row, same as a create.
  */
 const generateUpsert = (
-  db: PgAsyncDatabase<any, any, any>,
+  db: PgAsyncDatabase<any, any>,
   tableName: string,
   table: PgTable,
   tables: Record<string, Table>,
@@ -849,7 +848,7 @@ const generateUpsert = (
 };
 
 const generateUpdate = (
-  db: PgAsyncDatabase<any, any, any>,
+  db: PgAsyncDatabase<any, any>,
   tableName: string,
   table: PgTable,
   tables: Record<string, Table>,
@@ -1028,7 +1027,7 @@ const generateUpdate = (
  * case stays aligned with the input.
  */
 const generateUpdateMany = (
-  db: PgAsyncDatabase<any, any, any>,
+  db: PgAsyncDatabase<any, any>,
   tableName: string,
   table: PgTable,
   tables: Record<string, Table>,
@@ -1216,7 +1215,7 @@ const generateUpdateMany = (
  * the restored value.
  */
 const generateDelete = (
-  db: PgAsyncDatabase<any, any, any>,
+  db: PgAsyncDatabase<any, any>,
   tableName: string,
   table: PgTable,
   filterArgs: GraphQLInputObjectType,
@@ -1404,7 +1403,7 @@ export function generateSchemaData<
   // Record each relation target's primary key (composite-aware) so paginated relations
   // default to a deterministic PK order. Must run before pruning / type generation, which
   // share these entry objects.
-  attachTargetPrimaryKeys(namedRelations, tables, pgPrimaryKeyPropNames);
+  attachTargetPrimaryKeys(namedRelations, tables, (table) => pgPrimaryKeyPropNames(table as PgTable));
   // Relations to eager-load via `with:`. Query/mutation resolvers use this pruned map so
   // opted-out relations never overfetch; type generation keeps the full map so their
   // fields still exist and resolve lazily.

--- a/src/util/builders/sqlite.ts
+++ b/src/util/builders/sqlite.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck — vendored file, drizzle-orm 1.0 type compat not guaranteed
 import { is, One, type Table } from 'drizzle-orm';
 import type { RelationalQueryBuilder } from 'drizzle-orm/mysql-core/query-builders/query';
 import { type BaseSQLiteDatabase, getTableConfig, type SQLiteColumn, SQLiteTable } from 'drizzle-orm/sqlite-core';
@@ -121,7 +120,7 @@ const generateSelectArray = (
   limits?: LimitPolicyFor,
   policies?: ResolverPolicies,
 ): CreatedResolver => {
-  const queryBase = db.query[tableName as keyof typeof db.query] as unknown as
+  const queryBase = db.query[tableName as keyof typeof db.query & string] as unknown as
     | RelationalQueryBuilder<any, any, any>
     | undefined;
   if (!queryBase) {
@@ -194,7 +193,7 @@ const generateSelectSingle = (
   limits?: LimitPolicyFor,
   policies?: ResolverPolicies,
 ): CreatedResolver => {
-  const queryBase = db.query[tableName as keyof typeof db.query] as unknown as
+  const queryBase = db.query[tableName as keyof typeof db.query & string] as unknown as
     | RelationalQueryBuilder<any, any, any>
     | undefined;
   if (!queryBase) {

--- a/src/util/builders/types.ts
+++ b/src/util/builders/types.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck — vendored file, drizzle-orm 1.0 type compat not guaranteed
 import type { Column, Relation, SQL, Table } from 'drizzle-orm';
 import type {
   GraphQLFieldConfigArgumentMap,
@@ -130,8 +129,14 @@ export type ProcessedTableSelectArgs = {
   columns: Record<string, true>;
   offset: number;
   limit: number;
-  where: SQL;
-  orderBy: SQL[];
+  /**
+   * A filter, or drizzle's `{ RAW: … }` escape hatch. The RQB calls `RAW` with the aliased
+   * table proxy, which is the only way to reference the alias the generated CTE actually
+   * uses — an unaliased column reference would not match it.
+   */
+  where: SQL | { RAW: (aliasedTable: Table) => SQL | undefined };
+  /** Expressions, or a callback the RQB hands the aliased table proxy for the same reason. */
+  orderBy: SQL[] | ((aliasedTable: Table) => SQL[]);
   with?: Record<string, Partial<ProcessedTableSelectArgs>>;
 };
 
@@ -176,7 +181,7 @@ export type ColTypeIsNullOrUndefinedWithDefault<TColumn extends Column, TColType
 export type GetColumnGqlDataType<TColumn extends Column> = TColumn['dataType'] extends 'boolean'
   ? ColTypeIsNull<TColumn, boolean>
   : TColumn['dataType'] extends 'json'
-    ? TColumn['_']['columnType'] extends 'PgGeometryObject'
+    ? TColumn['columnType'] extends 'PgGeometryObject'
       ? ColTypeIsNull<
           TColumn,
           {
@@ -215,7 +220,7 @@ export type GetColumnGqlDataType<TColumn extends Column> = TColumn['dataType'] e
 export type GetColumnGqlInsertDataType<TColumn extends Column> = TColumn['dataType'] extends 'boolean'
   ? ColTypeIsNullOrUndefinedWithDefault<TColumn, boolean>
   : TColumn['dataType'] extends 'json'
-    ? TColumn['_']['columnType'] extends 'PgGeometryObject'
+    ? TColumn['columnType'] extends 'PgGeometryObject'
       ? ColTypeIsNullOrUndefinedWithDefault<
           TColumn,
           {
@@ -254,7 +259,7 @@ export type GetColumnGqlInsertDataType<TColumn extends Column> = TColumn['dataTy
 export type GetColumnGqlUpdateDataType<TColumn extends Column> = TColumn['dataType'] extends 'boolean'
   ? boolean | null | undefined
   : TColumn['dataType'] extends 'json'
-    ? TColumn['_']['columnType'] extends 'PgGeometryObject'
+    ? TColumn['columnType'] extends 'PgGeometryObject'
       ?
           | {
               x: number;

--- a/src/util/data-mappers/index.ts
+++ b/src/util/data-mappers/index.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck — vendored file, drizzle-orm 1.0 type compat not guaranteed
 import { type Column, getTableColumns, is, One, type Table } from 'drizzle-orm';
 import { GraphQLError } from 'graphql';
 import type { TableNamedRelations } from '../builders/index.ts';
@@ -13,7 +12,8 @@ export const remapToGraphQLCore = (
   key: string,
   value: any,
   tableName: string,
-  column: Column,
+  // Relation keys have no column; the guard below is what handles them.
+  column: Column | undefined,
   relationMap?: Record<string, Record<string, TableNamedRelations>>,
 ): any => {
   // Check for relation fields BEFORE the column check.
@@ -101,6 +101,8 @@ export const remapToGraphQLSingleOutput = (
   table: Table,
   relationMap?: Record<string, Record<string, TableNamedRelations>>,
 ) => {
+  const columns = getTableColumns(table);
+
   for (const [key, value] of Object.entries(queryOutput)) {
     if (value === undefined || value === null) {
       // Preserve an explicitly-null TO-ONE relation field (eager-loaded with no related
@@ -117,7 +119,7 @@ export const remapToGraphQLSingleOutput = (
       continue;
     }
 
-    const column = table[key as keyof Table] as Column | undefined;
+    const column = columns[key];
 
     // SQLite blob(bigint) returns 0n for null DB values — treat as absent when nullable.
     if (value === 0n && column && (column as any).columnType === 'SQLiteBigInt' && !(column as any).notNull) {
@@ -125,7 +127,7 @@ export const remapToGraphQLSingleOutput = (
       continue;
     }
 
-    queryOutput[key] = remapToGraphQLCore(key, value, tableName, column!, relationMap);
+    queryOutput[key] = remapToGraphQLCore(key, value, tableName, column, relationMap);
   }
 
   return queryOutput;

--- a/src/util/type-converter/index.ts
+++ b/src/util/type-converter/index.ts
@@ -364,7 +364,7 @@ export const registerScalarOverrides = (
   }
 };
 
-export const drizzleColumnToGraphQLType = <TColumn extends Column, TIsInput extends boolean>(
+export const drizzleColumnToGraphQLType = <TColumn extends Column, TIsInput extends boolean = false>(
   column: TColumn,
   columnName: string,
   tableName: string,


### PR DESCRIPTION
## Why

Every one of the eleven files in `src/` opened with:

```ts
// @ts-nocheck — vendored file, drizzle-orm 1.0 type compat not guaranteed
```

`npx tsc --noEmit` passed on `main`, but only because it was checking almost nothing. Removing all eleven surfaces **39 errors**. Three of those files (`util/batch-loader`, `util/builders/nested-writes`, `util/builders/field-updates`) had **zero** errors — they were suppressed purely by association with their siblings.

The other 36 are real drift left over from the drizzle-orm 0.x → 1.0 upgrade.

## The drift

**`Relation` lost `referencedTableName`** — in 1.0 the target table name lives in the type parameter (`One<TTargetTableName, TOptional>`, `Many<TTargetTableName>`); the property is gone. `SelectResolver` and `SelectSingleResolver` now capture it with `infer`:

```ts
- [K in RelKey]: TRelations[K] extends One<string>
-   ? …ExtractTableByName<TTables, TRelations[K]['referencedTableName']>…
+ [K in RelKey]: TRelations[K] extends One<infer TTargetName, any>
+   ? …ExtractTableByName<TTables, TTargetName>…
```

Worth noting the old spelling could not have worked even in 0.x: TypeScript does not narrow `TRelations[K]` inside a conditional's own true branch, so the index was unresolvable either way.

**`ColumnBaseConfig` lost `columnType`** — it is a property on the column now, not on its `_` config. `TColumn['_']['columnType']` → `TColumn['columnType']` in the three `GetColumnGql*DataType` types. This matches the sibling `PgVector`/`PgGeometry` branches *in the same conditional*, which had already been migrated — these were simply the ones that got missed.

**Type-argument arities** — SQLite's `RelationalQueryBuilder` takes 3 in 1.0, not 4; `PgAsyncDatabase` takes 2, not 3 (8 call sites, and `pg.ts:1342` was already using 2).

**Contravariance on the dialect `getTableConfig`** — `getPrimaryKeyPropNamesFromConfig` and `getUniqueColumnSets` declared their callback as `(table: Table) => …`, so a dialect could not pass its own `<T extends PgTable>(t: T) => …`. Both are now generic in the table type, and the arity infers from the `table` argument.

**`TIsInput` had no default** — `drizzleColumnToGraphQLType<TColumn, TIsInput extends boolean>` with `isInput: TIsInput = false as TIsInput`. Omitting the argument gave TypeScript no inference candidate, so `TIsInput` widened to its constraint `boolean` and `ConvertedColumn<boolean>['type']` leaked `GraphQLObjectType` into input positions. Defaulted to `false`, matching the runtime default. `jsonFilterFields` — which genuinely wants the input variant — now says `ConvertedColumn<true>['type']` instead of `ReturnType<typeof drizzleColumnToGraphQLType>['type']`.

**`ProcessedTableSelectArgs` described the wrong shape** — `where: SQL` and `orderBy: SQL[]`, but the eager relation path passes drizzle's `{ RAW: (aliasedTable) => … }` escape hatch and an orderBy callback. Both need the aliased table proxy (`d0`, `d1`, …) because an unaliased column reference would not match the generated CTE. Typed as what is actually passed.

**`remapToGraphQLCore`'s `column` parameter** is now `Column | undefined` — which is exactly what its own `if (!column) return value;` guard already assumed. The caller was asserting non-null over a lookup that legitimately misses on relation keys. That caller also switched from `table[key as keyof Table] as Column | undefined` (no longer typechecks — `keyof Table` includes `'_'`) to `getTableColumns(table)`, hoisted out of the loop.

**The remainder** are one-line and mechanical: index-signature access under `noPropertyAccessFromIndexSignature`, a `& string` narrow on `db.query[…]` (SQLite's `query` map carries symbol keys), and one non-null assertion on an aggregate column that `buildAggregateRequest` has already proven present — with a comment saying so.

## Blast radius

The generated `dist/index.d.ts` differs from the pre-change build by **5 lines**, every one of them a repair listed above. No other public type moved.

## Verification

- `npx tsc --noEmit` — clean, with **zero** `@ts-nocheck` remaining in `src/`
- `npm run build` — succeeds
- `npx vitest run tests/pglite tests/sqlite*.test.ts` — 70 files, **1044 tests passed**

## Note on lint

`npm run lint` reports 44 `complexity/useLiteralKeys` on this branch against 39 on `main` — the 5 new ones are the index-signature accesses this PR adds, and the rule is unsatisfiable alongside tsconfig's `noPropertyAccessFromIndexSignature`. #84 turns it off. Merging that one first makes lint green here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
