### PR TITLE
test(pg,mysql): accept `extensions.drizzle` in the entity-shape assertion

### DIFF
--- a/tests/mysql.test.ts
+++ b/tests/mysql.test.ts
@@ -2791,7 +2791,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -2818,7 +2820,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
@@ -2861,7 +2865,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -2888,7 +2894,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
@@ -2931,7 +2939,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -2958,7 +2968,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
@@ -2975,7 +2987,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -3005,7 +3019,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -3022,7 +3038,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -3052,7 +3070,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -3069,7 +3089,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -3099,7 +3121,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -3120,7 +3144,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
@@ -3137,7 +3163,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
@@ -3154,7 +3182,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
@@ -3176,7 +3206,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
@@ -3198,7 +3230,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
@@ -3215,7 +3249,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
@@ -3232,7 +3268,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
@@ -3249,7 +3287,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
@@ -3266,7 +3306,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
@@ -3283,7 +3325,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
@@ -3305,7 +3349,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
@@ -3327,7 +3373,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
@@ -3344,7 +3392,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
@@ -3361,7 +3411,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
@@ -3378,7 +3430,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
@@ -3395,7 +3449,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
@@ -3412,7 +3468,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
@@ -3434,7 +3492,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
@@ -3456,7 +3516,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
@@ -3473,7 +3535,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
@@ -3490,7 +3554,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),

--- a/tests/pg.test.ts
+++ b/tests/pg.test.ts
@@ -2362,7 +2362,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -2389,7 +2391,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
@@ -2432,7 +2436,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -2459,7 +2465,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
@@ -2502,7 +2510,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -2529,7 +2539,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
@@ -2572,7 +2584,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -2599,7 +2613,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
@@ -2616,7 +2632,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -2646,7 +2664,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -2663,7 +2683,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -2693,7 +2715,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -2710,7 +2734,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -2740,7 +2766,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -2757,7 +2785,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -2787,7 +2817,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -2808,7 +2840,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -2825,7 +2859,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -2844,7 +2880,9 @@ describe.sequential('Returned data tests', () => {
                 // Documents the nullable element, the one mutation whose return type differs.
                 description: z.string(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -2866,7 +2904,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -2888,7 +2928,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
@@ -2905,7 +2947,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -2922,7 +2966,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
@@ -2939,7 +2985,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -2956,7 +3004,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -2975,7 +3025,9 @@ describe.sequential('Returned data tests', () => {
                 // Documents the nullable element, the one mutation whose return type differs.
                 description: z.string(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -2997,7 +3049,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -3019,7 +3073,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
@@ -3036,7 +3092,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -3053,7 +3111,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
@@ -3070,7 +3130,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -3087,7 +3149,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -3106,7 +3170,9 @@ describe.sequential('Returned data tests', () => {
                 // Documents the nullable element, the one mutation whose return type differs.
                 description: z.string(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -3128,7 +3194,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -3150,7 +3218,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
@@ -3167,7 +3237,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -3184,7 +3256,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
@@ -3201,7 +3275,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -3218,7 +3294,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -3237,7 +3315,9 @@ describe.sequential('Returned data tests', () => {
                 // Documents the nullable element, the one mutation whose return type differs.
                 description: z.string(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -3259,7 +3339,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -3281,7 +3363,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),
@@ -3298,7 +3382,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLNonNull),
               })
               .strict(),
@@ -3315,7 +3401,9 @@ describe.sequential('Returned data tests', () => {
                   .strict(),
                 resolve: z.function(),
                 // Present only on the fields that carry a complexity hint (lists and aggregates).
-                extensions: z.object({ complexity: z.function() }).strict().optional(),
+                extensions: z
+                  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
+                  .strict(),
                 type: z.instanceof(GraphQLObjectType),
               })
               .strict(),


### PR DESCRIPTION
## What

`Returned data tests > Entities` fails on `main` in both `tests/pg.test.ts` and `tests/mysql.test.ts`. These are the Docker-backed suites, so they don't run in the pglite/sqlite fast path and the drift went unnoticed.

The zod schema the test parses `ctx.entities` with is `.strict()`, and it still describes `extensions` as it looked before generated fields started publishing their identity:

```ts
extensions: z.object({ complexity: z.function() }).strict().optional(),
```

Two things about that are wrong now:

- **Every** generated field carries `extensions.drizzle` (`src/util/extensions.ts`), so the strict object rejects it — 33 `unrecognized_keys` errors on the pg run: `Unrecognized key(s) in object: 'drizzle'`.
- `extensions` is consequently never absent; `complexity` is the conditional part (only lists and aggregates carry a hint — see `pg.ts:1879` vs `pg.ts:1888`). The old shape had the optionality on the wrong level, giving 24 further `expected "function", received "undefined"` errors on the `…Single` fields.

## Fix

`tests/sqlite.test.ts` was already updated when the extension landed. This brings the other two dialect suites to the byte-identical shape:

```ts
extensions: z
  .object({ drizzle: z.object({}).passthrough(), complexity: z.function().optional() })
  .strict(),
```

`drizzle` is asserted as present-and-an-object rather than field by field — its per-field contents already have dedicated coverage.

44 occurrences in `tests/pg.test.ts`, 33 in `tests/mysql.test.ts`. Test-only; no source change.

## Verification

Run with Docker available:

| suite | before | after |
| --- | --- | --- |
| `tests/pg.test.ts` | 1 failed \| 57 passed | **58 passed** |
| `tests/mysql.test.ts` | 1 failed \| 72 passed | **73 passed** |

`tests/pg-custom.test.ts` (24) and `tests/mysql-custom.test.ts` (25) were already passing and are untouched.

## Note

Lines are written pre-wrapped in the form `biome format` produces, matching what #84 does to `tests/sqlite.test.ts`, so the two don't fight over formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)