### PR TITLE
chore: format src/types.ts

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -175,9 +175,7 @@ export type SelectResolver<
               : TRelations[K] extends Many<infer TTargetName>
                 ? Array<
                     GetRemappedTableDataType<
-                      ExtractTableByName<TTables, TTargetName> extends infer T
-                        ? T[keyof T]
-                        : never
+                      ExtractTableByName<TTables, TTargetName> extends infer T ? T[keyof T] : never
                     >
                   >
                 : never;
@@ -207,9 +205,7 @@ export type SelectSingleResolver<
               : TRelations[K] extends Many<infer TTargetName>
                 ? Array<
                     GetRemappedTableDataType<
-                      ExtractTableByName<TTables, TTargetName> extends infer T
-                        ? T[keyof T]
-                        : never
+                      ExtractTableByName<TTables, TTargetName> extends infer T ? T[keyof T] : never
                     >
                   >
                 : never;


### PR DESCRIPTION
One-line formatting fix. #85 rewrote two conditional types in `src/types.ts` while #84 — which pins Biome to an exact version and adds the VCS block — was still open, so the two nested `extends infer T ? … : never` clauses were left wrapped in a shape the pinned formatter collapses. `npm run lint` on `main` fails on it.

`npx biome check --write src/types.ts` is the whole change; `npm run lint` is green again (111 files, 0 errors) and `tsc --noEmit` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)