### PR TITLE
fix(types): correct the public type surface and put tests/ under tsc

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,11 +30,16 @@ jobs:
       - name: Lint
         run: npx biome check .
 
-      - name: Type check
+      - name: Type check (src)
         run: npx tsc --noEmit
 
+      # Type-checks tests/ too, which is what makes the `expectTypeOf` assertions
+      # in the dialect suites actually fail the build when the public types drift.
+      - name: Type check (tests)
+        run: npx tsc --noEmit -p tests/tsconfig.json
+
       - name: Test (PGlite + SQLite — no Docker required)
-        run: mkdir -p tests/.temp && npx vitest run tests/pglite tests/sqlite.test.ts tests/sqlite-custom.test.ts
+        run: npx vitest run tests/pglite tests/sqlite.test.ts tests/sqlite-conflict.test.ts tests/sqlite-custom.test.ts tests/sqlite-groupby.test.ts tests/sqlite-nested-writes.test.ts tests/sqlite-on-write.test.ts tests/sqlite-soft-delete.test.ts tests/sqlite-tenancy.test.ts tests/sqlite-update-ops-counts.test.ts tests/sqlite-upsert.test.ts
 
       - name: Release
         run: npx semantic-release

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "prepare": "npm run build",
     "pack": "(cd dist && npm pack --pack-destination ..) && rm -f package.tgz && mv *.tgz package.tgz",
     "test": "vitest run",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tests/tsconfig.json",
     "server-test:pg": "DB_TYPE=pg tsx watch server/server.ts",
     "server-test:mysql": "DB_TYPE=mysql tsx watch server/server.ts",
     "server-test:sqlite": "DB_TYPE=sqlite tsx watch server/server.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import {
   GraphQLSchema,
   type GraphQLSchemaConfig,
 } from 'graphql';
-import type { AnyDrizzleDB, BuildSchemaConfig, GeneratedData, TableLimitPolicy } from './types.ts';
+import type { AnyDrizzleDB, BuildSchemaConfig, GeneratedData, GeneratedEntities, TableLimitPolicy } from './types.ts';
 import {
   applyErrorMapper,
   DEFAULT_TRANSACTION_TIMEOUT_MS,
@@ -597,5 +597,8 @@ export const buildSchema = <TDbClient extends AnyDrizzleDB<any>>(
 
   const outputSchema = new GraphQLSchema(graphQLSchemaConfig);
 
-  return { schema: outputSchema, entities: generatorOutput };
+  // The three dialect generators are typed on their own dialect's database, so their union
+  // does not structurally match `GeneratedEntities<TDbClient>` for a still-generic TDbClient.
+  // The runtime branch above is what guarantees the right one was built.
+  return { schema: outputSchema, entities: generatorOutput as unknown as GeneratedEntities<TDbClient> };
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,9 +53,23 @@ export type AnyQueryBuiler<TConfig extends TablesRelationalConfig = any, TFields
   | MySqlQuery<any, TConfig, TFields>
   | SQLiteQuery<any, TConfig, TFields>;
 
-export type ExtractTables<TSchema extends Record<string, Table | unknown>> = {
-  [K in keyof TSchema as TSchema[K] extends Table ? K : never]: TSchema[K] extends Table ? TSchema[K] : never;
-};
+/**
+ * The tables a database handle knows about, keyed by their schema key.
+ *
+ * Two shapes reach this type, because drizzle-orm v1 changed what a database's generic slot
+ * holds. SQLite and MySQL handles still carry the schema module itself, so the tables are
+ * picked out of it directly. PostgreSQL handles carry only the relations config built by
+ * `buildRelations` — a `Record<string, { table; name; relations }>` — so the tables are read
+ * off its `table` members instead. Without the second branch every PG-derived type collapses
+ * to `never`.
+ */
+export type ExtractTables<TSchema extends Record<string, Table | unknown>> = TSchema extends TablesRelationalConfig
+  ? {
+      [K in keyof TSchema]: TSchema[K]['table'] extends infer TTable extends Table ? TTable : never;
+    }
+  : {
+      [K in keyof TSchema as TSchema[K] extends Table ? K : never]: TSchema[K] extends Table ? TSchema[K] : never;
+    };
 
 export type ExtractRelations<TSchema extends Record<string, Table | unknown>> = {
   [K in keyof TSchema as TSchema[K] extends Relations ? K : never]: TSchema[K] extends Relations ? TSchema[K] : never;
@@ -316,7 +330,7 @@ export type QueriesCore<
 > = {
   [TName in keyof TSchemaTables as TName extends string ? `${Uncapitalize<TName>}` : never]: TName extends string
     ? {
-        type: GraphQLNonNull<GraphQLList<GraphQLNonNull<TOutputs[`${Capitalize<TName>}SelectItem`]>>>;
+        type: GraphQLNonNull<GraphQLList<GraphQLNonNull<TOutputs[Capitalize<TName>]>>>;
         args: {
           offset: {
             type: GraphQLScalarType<number, number>;
@@ -348,7 +362,7 @@ export type QueriesCore<
 } & {
   [TName in keyof TSchemaTables as TName extends string ? `${Uncapitalize<TName>}Single` : never]: TName extends string
     ? {
-        type: TOutputs[`${Capitalize<TName>}SelectItem`];
+        type: TOutputs[Capitalize<TName>];
         args: {
           offset: {
             type: GraphQLScalarType<number, number>;
@@ -405,10 +419,10 @@ export type MutationsCore<
           ? TOutputs['MutationReturn'] extends GraphQLObjectType
             ? TOutputs['MutationReturn']
             : never
-          : GraphQLNonNull<GraphQLList<GraphQLNonNull<TOutputs[`${Capitalize<TName>}Item`]>>>;
+          : GraphQLNonNull<GraphQLList<GraphQLNonNull<TOutputs[Capitalize<TName>]>>>;
         args: {
           values: {
-            type: GraphQLNonNull<GraphQLList<GraphQLNonNull<TInputs[`${Capitalize<TName>}InsertInput`]>>>;
+            type: GraphQLNonNull<GraphQLList<GraphQLNonNull<TInputs[`Create${Capitalize<TName>}Input`]>>>;
           };
         };
         resolve: InsertArrResolver<TSchemaTables[TName], IsReturnless>;
@@ -423,11 +437,11 @@ export type MutationsCore<
           ? TOutputs['MutationReturn'] extends GraphQLObjectType
             ? TOutputs['MutationReturn']
             : never
-          : TOutputs[`${Capitalize<TName>}Item`];
+          : TOutputs[Capitalize<TName>];
 
         args: {
           values: {
-            type: GraphQLNonNull<TInputs[`${Capitalize<TName>}InsertInput`]>;
+            type: GraphQLNonNull<TInputs[`Create${Capitalize<TName>}Input`]>;
           };
         };
         resolve: InsertResolver<TSchemaTables[TName], IsReturnless>;
@@ -442,10 +456,10 @@ export type MutationsCore<
           ? TOutputs['MutationReturn'] extends GraphQLObjectType
             ? TOutputs['MutationReturn']
             : never
-          : GraphQLNonNull<GraphQLList<GraphQLNonNull<TOutputs[`${Capitalize<TName>}Item`]>>>;
+          : GraphQLNonNull<GraphQLList<GraphQLNonNull<TOutputs[Capitalize<TName>]>>>;
         args: {
           values: {
-            type: GraphQLNonNull<GraphQLList<GraphQLNonNull<TInputs[`${Capitalize<TName>}InsertInput`]>>>;
+            type: GraphQLNonNull<GraphQLList<GraphQLNonNull<TInputs[`Create${Capitalize<TName>}Input`]>>>;
           };
           onConflict: {
             type: GraphQLInputObjectType;
@@ -463,10 +477,10 @@ export type MutationsCore<
           ? TOutputs['MutationReturn'] extends GraphQLObjectType
             ? TOutputs['MutationReturn']
             : never
-          : TOutputs[`${Capitalize<TName>}Item`];
+          : TOutputs[Capitalize<TName>];
         args: {
           values: {
-            type: GraphQLNonNull<TInputs[`${Capitalize<TName>}InsertInput`]>;
+            type: GraphQLNonNull<TInputs[`Create${Capitalize<TName>}Input`]>;
           };
           onConflict: {
             type: GraphQLInputObjectType;
@@ -482,10 +496,10 @@ export type MutationsCore<
           ? TOutputs['MutationReturn'] extends GraphQLObjectType
             ? TOutputs['MutationReturn']
             : never
-          : GraphQLNonNull<GraphQLList<GraphQLNonNull<TOutputs[`${Capitalize<TName>}Item`]>>>;
+          : GraphQLNonNull<GraphQLList<GraphQLNonNull<TOutputs[Capitalize<TName>]>>>;
         args: {
           set: {
-            type: GraphQLNonNull<TInputs[`${Capitalize<TName>}UpdateInput`]>;
+            type: GraphQLNonNull<TInputs[`Update${Capitalize<TName>}Input`]>;
           };
           where: {
             type: TInputs[`${Capitalize<TName>}Filters`] extends GraphQLInputObjectType
@@ -507,10 +521,10 @@ export type MutationsCore<
             : never
           : // The list items are nullable: an entry whose `where` matched no rows
             // yields `null` in its slot, keeping the result aligned with the input.
-            GraphQLNonNull<GraphQLList<TOutputs[`${Capitalize<TName>}Item`]>>;
+            GraphQLNonNull<GraphQLList<TOutputs[Capitalize<TName>]>>;
         args: {
           updates: {
-            type: GraphQLNonNull<GraphQLList<GraphQLNonNull<TInputs[`${Capitalize<TName>}UpdateManyInput`]>>>;
+            type: GraphQLNonNull<GraphQLList<GraphQLNonNull<TInputs[`Update${Capitalize<TName>}ManyInput`]>>>;
           };
         };
         resolve: UpdateManyResolver<TSchemaTables[TName], IsReturnless>;
@@ -525,10 +539,10 @@ export type MutationsCore<
           ? TOutputs['MutationReturn'] extends GraphQLObjectType
             ? TOutputs['MutationReturn']
             : never
-          : TOutputs[`${Capitalize<TName>}Item`];
+          : TOutputs[Capitalize<TName>];
         args: {
           set: {
-            type: GraphQLNonNull<TInputs[`${Capitalize<TName>}UpdateInput`]>;
+            type: GraphQLNonNull<TInputs[`Update${Capitalize<TName>}Input`]>;
           };
           where: {
             type: GraphQLNonNull<
@@ -548,7 +562,7 @@ export type MutationsCore<
           ? TOutputs['MutationReturn'] extends GraphQLObjectType
             ? TOutputs['MutationReturn']
             : never
-          : GraphQLNonNull<GraphQLList<GraphQLNonNull<TOutputs[`${Capitalize<TName>}Item`]>>>;
+          : GraphQLNonNull<GraphQLList<GraphQLNonNull<TOutputs[Capitalize<TName>]>>>;
         args: {
           where: {
             type: TInputs[`${Capitalize<TName>}Filters`] extends GraphQLInputObjectType
@@ -568,7 +582,7 @@ export type MutationsCore<
           ? TOutputs['MutationReturn'] extends GraphQLObjectType
             ? TOutputs['MutationReturn']
             : never
-          : TOutputs[`${Capitalize<TName>}Item`];
+          : TOutputs[Capitalize<TName>];
         args: {
           where: {
             type: GraphQLNonNull<
@@ -583,13 +597,22 @@ export type MutationsCore<
     : never;
 };
 
+/**
+ * Keys of `entities.inputs`, which is keyed by generated GraphQL input type name.
+ *
+ * The write inputs are named from the configured `prefixes`, so these keys describe a build
+ * that uses the defaults (`insert: 'create'`, `update: 'update'`); a build that overrides a
+ * prefix produces correspondingly different keys. Inputs that only exist when a feature is
+ * enabled — `${Table}OnConflict` for upsert, `${Table}Having` for group-by — are not listed,
+ * since whether they were generated is a runtime decision.
+ */
 export type GeneratedInputs<TSchema extends Record<string, Table>> = {
-  [TName in keyof TSchema as TName extends string ? `${Capitalize<TName>}InsertInput` : never]: GraphQLInputObjectType;
+  [TName in keyof TSchema as TName extends string ? `Create${Capitalize<TName>}Input` : never]: GraphQLInputObjectType;
 } & {
-  [TName in keyof TSchema as TName extends string ? `${Capitalize<TName>}UpdateInput` : never]: GraphQLInputObjectType;
+  [TName in keyof TSchema as TName extends string ? `Update${Capitalize<TName>}Input` : never]: GraphQLInputObjectType;
 } & {
   [TName in keyof TSchema as TName extends string
-    ? `${Capitalize<TName>}UpdateManyInput`
+    ? `Update${Capitalize<TName>}ManyInput`
     : never]: GraphQLInputObjectType;
 } & {
   [TName in keyof TSchema as TName extends string ? `${Capitalize<TName>}OrderBy` : never]: GraphQLInputObjectType;
@@ -597,8 +620,16 @@ export type GeneratedInputs<TSchema extends Record<string, Table>> = {
   [TName in keyof TSchema as TName extends string ? `${Capitalize<TName>}Filters` : never]: GraphQLInputObjectType;
 };
 
+/**
+ * Keys of `entities.types`, which is keyed by generated GraphQL type name.
+ *
+ * This build emits ONE object type per table (`Users`) used for both selects and mutation
+ * returns — upstream drizzle-graphql emitted two (`UsersSelectItem` / `UsersItem`), and this
+ * type kept those names long after the generator stopped producing them. MySQL still has a
+ * shared `MutationReturn` instead of per-table return types, because its writes return no rows.
+ */
 export type GeneratedOutputs<TSchema extends Record<string, Table>, IsReturnless extends boolean> = {
-  [TName in keyof TSchema as TName extends string ? `${Capitalize<TName>}SelectItem` : never]: GraphQLObjectType;
+  [TName in keyof TSchema as TName extends string ? Capitalize<TName> : never]: GraphQLObjectType;
 } & {
   [TName in keyof TSchema as TName extends string ? `${Capitalize<TName>}Aggregate` : never]: GraphQLObjectType;
 } & (IsReturnless extends true
@@ -606,7 +637,7 @@ export type GeneratedOutputs<TSchema extends Record<string, Table>, IsReturnless
         MutationReturn: GraphQLObjectType;
       }
     : {
-        [TName in keyof TSchema as TName extends string ? `${Capitalize<TName>}Item` : never]: GraphQLObjectType;
+        [TName in keyof TSchema as TName extends string ? Capitalize<TName> : never]: GraphQLObjectType;
       });
 
 export type GeneratedEntities<

--- a/tests/mysql-custom.test.ts
+++ b/tests/mysql-custom.test.ts
@@ -84,7 +84,7 @@ beforeAll(async (_t) => {
     client: ctx.client,
     schema,
     relations: schema.relations,
-    logger: !!process.env.LOG_SQL,
+    logger: !!process.env['LOG_SQL'],
     mode: 'default',
   });
 

--- a/tests/mysql.test.ts
+++ b/tests/mysql.test.ts
@@ -1,9 +1,10 @@
 import { createServer, type Server } from 'node:http';
 import Docker from 'dockerode';
-import { eq, inArray, type Relations, sql } from 'drizzle-orm';
+import { eq, inArray, sql } from 'drizzle-orm';
 import { drizzle, type MySql2Database } from 'drizzle-orm/mysql2';
 import getPort from 'get-port';
 import {
+  type GraphQLEnumType,
   GraphQLInputObjectType,
   GraphQLList,
   GraphQLNonNull,
@@ -18,8 +19,10 @@ import { v4 as uuid } from 'uuid';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, expectTypeOf, it } from 'vitest';
 import z from 'zod';
 import {
+  type AggregateResolver,
   buildSchema,
   type DeleteResolver,
+  type DeleteSingleResolver,
   type ExtractTables,
   type GeneratedEntities,
   type InsertArrResolver,
@@ -28,6 +31,9 @@ import {
   type SelectSingleResolver,
   type UpdateManyResolver,
   type UpdateResolver,
+  type UpdateSingleResolver,
+  type UpsertArrResolver,
+  type UpsertResolver,
 } from '@/index';
 import * as schema from './schema/mysql';
 import { GraphQLClient } from './util/query';
@@ -106,7 +112,7 @@ beforeAll(async (_t) => {
     client: ctx.client,
     schema,
     relations: schema.relations,
-    logger: !!process.env.LOG_SQL,
+    logger: !!process.env['LOG_SQL'],
     mode: 'default',
   });
 
@@ -3624,84 +3630,85 @@ describe.sequential('Type tests', () => {
         readonly customers: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
-            orderBy: { type: GraphQLInputObjectType };
             offset: { type: GraphQLScalarType<number, number> };
             limit: { type: GraphQLScalarType<number, number> };
+            orderBy: { type: GraphQLInputObjectType };
             where: { type: GraphQLInputObjectType };
+            distinct: { type: GraphQLList<GraphQLNonNull<GraphQLEnumType>> };
           };
-          resolve: SelectResolver<
-            typeof schema.Customers,
-            ExtractTables<typeof schema>,
-            typeof schema.customersRelations extends Relations<any, infer RelConf> ? RelConf : never
-          >;
+          resolve: SelectResolver<typeof schema.Customers, ExtractTables<typeof schema>, never>;
         };
         readonly posts: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
-            orderBy: { type: GraphQLInputObjectType };
             offset: { type: GraphQLScalarType<number, number> };
             limit: { type: GraphQLScalarType<number, number> };
+            orderBy: { type: GraphQLInputObjectType };
             where: { type: GraphQLInputObjectType };
+            distinct: { type: GraphQLList<GraphQLNonNull<GraphQLEnumType>> };
           };
-          resolve: SelectResolver<
-            typeof schema.Posts,
-            ExtractTables<typeof schema>,
-            typeof schema.postsRelations extends Relations<any, infer RelConf> ? RelConf : never
-          >;
+          resolve: SelectResolver<typeof schema.Posts, ExtractTables<typeof schema>, never>;
         };
         readonly users: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
-            orderBy: { type: GraphQLInputObjectType };
             offset: { type: GraphQLScalarType<number, number> };
             limit: { type: GraphQLScalarType<number, number> };
+            orderBy: { type: GraphQLInputObjectType };
             where: { type: GraphQLInputObjectType };
+            distinct: { type: GraphQLList<GraphQLNonNull<GraphQLEnumType>> };
           };
-          resolve: SelectResolver<
-            typeof schema.Users,
-            ExtractTables<typeof schema>,
-            typeof schema.usersRelations extends Relations<any, infer RelConf> ? RelConf : never
-          >;
+          resolve: SelectResolver<typeof schema.Users, ExtractTables<typeof schema>, never>;
         };
       } & {
         readonly customersSingle: {
           type: GraphQLObjectType;
           args: {
-            orderBy: { type: GraphQLInputObjectType };
             offset: { type: GraphQLScalarType<number, number> };
+            orderBy: { type: GraphQLInputObjectType };
             where: { type: GraphQLInputObjectType };
           };
-          resolve: SelectSingleResolver<
-            typeof schema.Customers,
-            ExtractTables<typeof schema>,
-            typeof schema.customersRelations extends Relations<any, infer RelConf> ? RelConf : never
-          >;
+          resolve: SelectSingleResolver<typeof schema.Customers, ExtractTables<typeof schema>, never>;
         };
         readonly postsSingle: {
           type: GraphQLObjectType;
           args: {
-            orderBy: { type: GraphQLInputObjectType };
             offset: { type: GraphQLScalarType<number, number> };
+            orderBy: { type: GraphQLInputObjectType };
             where: { type: GraphQLInputObjectType };
           };
-          resolve: SelectSingleResolver<
-            typeof schema.Posts,
-            ExtractTables<typeof schema>,
-            typeof schema.postsRelations extends Relations<any, infer RelConf> ? RelConf : never
-          >;
+          resolve: SelectSingleResolver<typeof schema.Posts, ExtractTables<typeof schema>, never>;
         };
         readonly usersSingle: {
           type: GraphQLObjectType;
           args: {
-            orderBy: { type: GraphQLInputObjectType };
             offset: { type: GraphQLScalarType<number, number> };
+            orderBy: { type: GraphQLInputObjectType };
             where: { type: GraphQLInputObjectType };
           };
-          resolve: SelectSingleResolver<
-            typeof schema.Users,
-            ExtractTables<typeof schema>,
-            typeof schema.usersRelations extends Relations<any, infer RelConf> ? RelConf : never
-          >;
+          resolve: SelectSingleResolver<typeof schema.Users, ExtractTables<typeof schema>, never>;
+        };
+      } & {
+        readonly customersAggregate: {
+          type: GraphQLNonNull<GraphQLObjectType>;
+          args: {
+            where: { type: GraphQLInputObjectType };
+          };
+          resolve: AggregateResolver<typeof schema.Customers>;
+        };
+        readonly postsAggregate: {
+          type: GraphQLNonNull<GraphQLObjectType>;
+          args: {
+            where: { type: GraphQLInputObjectType };
+          };
+          resolve: AggregateResolver<typeof schema.Posts>;
+        };
+        readonly usersAggregate: {
+          type: GraphQLNonNull<GraphQLObjectType>;
+          args: {
+            where: { type: GraphQLInputObjectType };
+          };
+          resolve: AggregateResolver<typeof schema.Users>;
         };
       }
     >();
@@ -3766,6 +3773,68 @@ describe.sequential('Type tests', () => {
           resolve: InsertResolver<typeof schema.Users, true>;
         };
       } & {
+        readonly upsertCustomers?: {
+          type: GraphQLObjectType;
+          args: {
+            values: {
+              type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLInputObjectType>>>;
+            };
+            onConflict: { type: GraphQLInputObjectType };
+          };
+          resolve: UpsertArrResolver<typeof schema.Customers, true>;
+        };
+        readonly upsertPosts?: {
+          type: GraphQLObjectType;
+          args: {
+            values: {
+              type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLInputObjectType>>>;
+            };
+            onConflict: { type: GraphQLInputObjectType };
+          };
+          resolve: UpsertArrResolver<typeof schema.Posts, true>;
+        };
+        readonly upsertUsers?: {
+          type: GraphQLObjectType;
+          args: {
+            values: {
+              type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLInputObjectType>>>;
+            };
+            onConflict: { type: GraphQLInputObjectType };
+          };
+          resolve: UpsertArrResolver<typeof schema.Users, true>;
+        };
+      } & {
+        readonly upsertCustomersSingle?: {
+          type: GraphQLObjectType;
+          args: {
+            values: {
+              type: GraphQLNonNull<GraphQLInputObjectType>;
+            };
+            onConflict: { type: GraphQLInputObjectType };
+          };
+          resolve: UpsertResolver<typeof schema.Customers, true>;
+        };
+        readonly upsertPostsSingle?: {
+          type: GraphQLObjectType;
+          args: {
+            values: {
+              type: GraphQLNonNull<GraphQLInputObjectType>;
+            };
+            onConflict: { type: GraphQLInputObjectType };
+          };
+          resolve: UpsertResolver<typeof schema.Posts, true>;
+        };
+        readonly upsertUsersSingle?: {
+          type: GraphQLObjectType;
+          args: {
+            values: {
+              type: GraphQLNonNull<GraphQLInputObjectType>;
+            };
+            onConflict: { type: GraphQLInputObjectType };
+          };
+          resolve: UpsertResolver<typeof schema.Users, true>;
+        };
+      } & {
         readonly updateCustomers: {
           type: GraphQLObjectType;
           args: {
@@ -3825,6 +3894,37 @@ describe.sequential('Type tests', () => {
           resolve: UpdateManyResolver<typeof schema.Users, true>;
         };
       } & {
+        readonly updateCustomersSingle: {
+          type: GraphQLObjectType;
+          args: {
+            set: {
+              type: GraphQLNonNull<GraphQLInputObjectType>;
+            };
+            where: { type: GraphQLNonNull<GraphQLInputObjectType> };
+          };
+          resolve: UpdateSingleResolver<typeof schema.Customers, true>;
+        };
+        readonly updatePostsSingle: {
+          type: GraphQLObjectType;
+          args: {
+            set: {
+              type: GraphQLNonNull<GraphQLInputObjectType>;
+            };
+            where: { type: GraphQLNonNull<GraphQLInputObjectType> };
+          };
+          resolve: UpdateSingleResolver<typeof schema.Posts, true>;
+        };
+        readonly updateUsersSingle: {
+          type: GraphQLObjectType;
+          args: {
+            set: {
+              type: GraphQLNonNull<GraphQLInputObjectType>;
+            };
+            where: { type: GraphQLNonNull<GraphQLInputObjectType> };
+          };
+          resolve: UpdateSingleResolver<typeof schema.Users, true>;
+        };
+      } & {
         readonly deleteCustomers: {
           type: GraphQLObjectType;
           args: {
@@ -3846,6 +3946,28 @@ describe.sequential('Type tests', () => {
           };
           resolve: DeleteResolver<typeof schema.Users, true>;
         };
+      } & {
+        readonly deleteCustomersSingle: {
+          type: GraphQLObjectType;
+          args: {
+            where: { type: GraphQLNonNull<GraphQLInputObjectType> };
+          };
+          resolve: DeleteSingleResolver<typeof schema.Customers, true>;
+        };
+        readonly deletePostsSingle: {
+          type: GraphQLObjectType;
+          args: {
+            where: { type: GraphQLNonNull<GraphQLInputObjectType> };
+          };
+          resolve: DeleteSingleResolver<typeof schema.Posts, true>;
+        };
+        readonly deleteUsersSingle: {
+          type: GraphQLObjectType;
+          args: {
+            where: { type: GraphQLNonNull<GraphQLInputObjectType> };
+          };
+          resolve: DeleteSingleResolver<typeof schema.Users, true>;
+        };
       }
     >();
   });
@@ -3853,11 +3975,15 @@ describe.sequential('Type tests', () => {
   it('Types', () => {
     expectTypeOf(ctx.entities.types).toEqualTypeOf<
       {
-        MutationReturn: GraphQLObjectType;
-      } & {
         readonly Customers: GraphQLObjectType;
         readonly Posts: GraphQLObjectType;
         readonly Users: GraphQLObjectType;
+      } & {
+        readonly CustomersAggregate: GraphQLObjectType;
+        readonly PostsAggregate: GraphQLObjectType;
+        readonly UsersAggregate: GraphQLObjectType;
+      } & {
+        MutationReturn: GraphQLObjectType;
       }
     >();
   });
@@ -3865,25 +3991,25 @@ describe.sequential('Type tests', () => {
   it('Inputs', () => {
     expectTypeOf(ctx.entities.inputs).toEqualTypeOf<
       {
-        readonly UsersFilters: GraphQLInputObjectType;
-        readonly CustomersFilters: GraphQLInputObjectType;
-        readonly PostsFilters: GraphQLInputObjectType;
-      } & {
-        readonly UsersOrderBy: GraphQLInputObjectType;
-        readonly CustomersOrderBy: GraphQLInputObjectType;
-        readonly PostsOrderBy: GraphQLInputObjectType;
-      } & {
-        readonly CreateUsersInput: GraphQLInputObjectType;
         readonly CreateCustomersInput: GraphQLInputObjectType;
         readonly CreatePostsInput: GraphQLInputObjectType;
+        readonly CreateUsersInput: GraphQLInputObjectType;
       } & {
-        readonly UpdateUsersInput: GraphQLInputObjectType;
         readonly UpdateCustomersInput: GraphQLInputObjectType;
         readonly UpdatePostsInput: GraphQLInputObjectType;
+        readonly UpdateUsersInput: GraphQLInputObjectType;
       } & {
-        readonly UpdateUsersManyInput: GraphQLInputObjectType;
         readonly UpdateCustomersManyInput: GraphQLInputObjectType;
         readonly UpdatePostsManyInput: GraphQLInputObjectType;
+        readonly UpdateUsersManyInput: GraphQLInputObjectType;
+      } & {
+        readonly CustomersOrderBy: GraphQLInputObjectType;
+        readonly PostsOrderBy: GraphQLInputObjectType;
+        readonly UsersOrderBy: GraphQLInputObjectType;
+      } & {
+        readonly CustomersFilters: GraphQLInputObjectType;
+        readonly PostsFilters: GraphQLInputObjectType;
+        readonly UsersFilters: GraphQLInputObjectType;
       }
     >();
   });

--- a/tests/pg-custom.test.ts
+++ b/tests/pg-custom.test.ts
@@ -16,10 +16,10 @@ import { GraphQLClient } from './util/query';
 interface Context {
   docker: Docker;
   pgContainer: Docker.Container;
-  db: PostgresJsDatabase<typeof schema>;
+  db: PostgresJsDatabase<typeof schema.relations>;
   client: Sql;
   schema: GraphQLSchema;
-  entities: GeneratedEntities<PostgresJsDatabase<typeof schema>>;
+  entities: GeneratedEntities<PostgresJsDatabase<typeof schema.relations>>;
   server: Server;
   gql: GraphQLClient;
 }
@@ -88,9 +88,8 @@ beforeAll(async () => {
 
   ctx.db = drizzle({
     client: ctx.client,
-    schema,
     relations: schema.relations,
-    logger: !!process.env.LOG_SQL,
+    logger: !!process.env['LOG_SQL'],
   });
 
   const { entities } = buildSchema(ctx.db);

--- a/tests/pg.test.ts
+++ b/tests/pg.test.ts
@@ -1,9 +1,10 @@
 import { createServer, type Server } from 'node:http';
 import Docker from 'dockerode';
-import { type Relations, sql } from 'drizzle-orm';
+import { sql } from 'drizzle-orm';
 import { drizzle, type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import getPort from 'get-port';
 import {
+  type GraphQLEnumType,
   GraphQLInputObjectType,
   GraphQLList,
   GraphQLNonNull,
@@ -18,8 +19,10 @@ import { v4 as uuid } from 'uuid';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, expectTypeOf, it } from 'vitest';
 import z from 'zod';
 import {
+  type AggregateResolver,
   buildSchema,
   type DeleteResolver,
+  type DeleteSingleResolver,
   type ExtractTables,
   type GeneratedEntities,
   type InsertArrResolver,
@@ -28,6 +31,9 @@ import {
   type SelectSingleResolver,
   type UpdateManyResolver,
   type UpdateResolver,
+  type UpdateSingleResolver,
+  type UpsertArrResolver,
+  type UpsertResolver,
 } from '@/index';
 import * as schema from './schema/pg';
 import { GraphQLClient } from './util/query';
@@ -35,11 +41,11 @@ import { GraphQLClient } from './util/query';
 interface Context {
   docker: Docker;
   pgContainer: Docker.Container;
-  db: PostgresJsDatabase<typeof schema>;
+  db: PostgresJsDatabase<typeof schema.relations>;
   optInSchema: GraphQLSchema;
   client: Sql;
   schema: GraphQLSchema;
-  entities: GeneratedEntities<PostgresJsDatabase<typeof schema>>;
+  entities: GeneratedEntities<PostgresJsDatabase<typeof schema.relations>>;
   server: Server;
   gql: GraphQLClient;
 }
@@ -108,9 +114,8 @@ beforeAll(async () => {
 
   ctx.db = drizzle({
     client: ctx.client,
-    schema,
     relations: schema.relations,
-    logger: !!process.env.LOG_SQL,
+    logger: !!process.env['LOG_SQL'],
   });
 
   const { schema: gqlSchema, entities } = buildSchema(ctx.db);
@@ -3469,6 +3474,12 @@ describe.sequential('Returned data tests', () => {
   });
 });
 
+// The generated-entity keys below are written WITHOUT `readonly`, unlike the SQLite and
+// MySQL suites. `ExtractTables` maps homomorphically over whatever the database handle's
+// generic slot holds, so the modifier is inherited from there: SQLite/MySQL still carry the
+// schema module, and a namespace import's properties are readonly, while a PostgreSQL handle
+// carries `typeof schema.relations` — a plain object type — whose properties are mutable.
+// `toEqualTypeOf` compares modifiers, so the two dialects genuinely differ here.
 describe.sequential('Type tests', () => {
   it('Schema', () => {
     expectTypeOf(ctx.schema).toEqualTypeOf<GraphQLSchema>();
@@ -3477,87 +3488,115 @@ describe.sequential('Type tests', () => {
   it('Queries', () => {
     expectTypeOf(ctx.entities.queries).toEqualTypeOf<
       {
-        readonly customers: {
+        customers: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
-            orderBy: { type: GraphQLInputObjectType };
             offset: { type: GraphQLScalarType<number, number> };
             limit: { type: GraphQLScalarType<number, number> };
+            orderBy: { type: GraphQLInputObjectType };
             where: { type: GraphQLInputObjectType };
+            distinct: { type: GraphQLList<GraphQLNonNull<GraphQLEnumType>> };
           };
-          resolve: SelectResolver<
-            typeof schema.Customers,
-            ExtractTables<typeof schema>,
-            typeof schema.customersRelations extends Relations<any, infer RelConf> ? RelConf : never
-          >;
+          resolve: SelectResolver<typeof schema.Customers, ExtractTables<typeof schema>, never>;
         };
-        readonly posts: {
+        posts: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
-            orderBy: { type: GraphQLInputObjectType };
             offset: { type: GraphQLScalarType<number, number> };
             limit: { type: GraphQLScalarType<number, number> };
+            orderBy: { type: GraphQLInputObjectType };
             where: { type: GraphQLInputObjectType };
+            distinct: { type: GraphQLList<GraphQLNonNull<GraphQLEnumType>> };
           };
-          resolve: SelectResolver<
-            typeof schema.Posts,
-            ExtractTables<typeof schema>,
-            typeof schema.postsRelations extends Relations<any, infer RelConf> ? RelConf : never
-          >;
+          resolve: SelectResolver<typeof schema.Posts, ExtractTables<typeof schema>, never>;
         };
-        readonly users: {
+        tags: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
-            orderBy: { type: GraphQLInputObjectType };
             offset: { type: GraphQLScalarType<number, number> };
             limit: { type: GraphQLScalarType<number, number> };
+            orderBy: { type: GraphQLInputObjectType };
             where: { type: GraphQLInputObjectType };
+            distinct: { type: GraphQLList<GraphQLNonNull<GraphQLEnumType>> };
           };
-          resolve: SelectResolver<
-            typeof schema.Users,
-            ExtractTables<typeof schema>,
-            typeof schema.usersRelations extends Relations<any, infer RelConf> ? RelConf : never
-          >;
+          resolve: SelectResolver<typeof schema.Tags, ExtractTables<typeof schema>, never>;
+        };
+        users: {
+          type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
+          args: {
+            offset: { type: GraphQLScalarType<number, number> };
+            limit: { type: GraphQLScalarType<number, number> };
+            orderBy: { type: GraphQLInputObjectType };
+            where: { type: GraphQLInputObjectType };
+            distinct: { type: GraphQLList<GraphQLNonNull<GraphQLEnumType>> };
+          };
+          resolve: SelectResolver<typeof schema.Users, ExtractTables<typeof schema>, never>;
         };
       } & {
-        readonly customersSingle: {
+        customersSingle: {
           type: GraphQLObjectType;
           args: {
-            orderBy: { type: GraphQLInputObjectType };
             offset: { type: GraphQLScalarType<number, number> };
+            orderBy: { type: GraphQLInputObjectType };
             where: { type: GraphQLInputObjectType };
           };
-          resolve: SelectSingleResolver<
-            typeof schema.Customers,
-            ExtractTables<typeof schema>,
-            typeof schema.customersRelations extends Relations<any, infer RelConf> ? RelConf : never
-          >;
+          resolve: SelectSingleResolver<typeof schema.Customers, ExtractTables<typeof schema>, never>;
         };
-        readonly postsSingle: {
+        postsSingle: {
           type: GraphQLObjectType;
           args: {
-            orderBy: { type: GraphQLInputObjectType };
             offset: { type: GraphQLScalarType<number, number> };
+            orderBy: { type: GraphQLInputObjectType };
             where: { type: GraphQLInputObjectType };
           };
-          resolve: SelectSingleResolver<
-            typeof schema.Posts,
-            ExtractTables<typeof schema>,
-            typeof schema.postsRelations extends Relations<any, infer RelConf> ? RelConf : never
-          >;
+          resolve: SelectSingleResolver<typeof schema.Posts, ExtractTables<typeof schema>, never>;
         };
-        readonly usersSingle: {
+        tagsSingle: {
           type: GraphQLObjectType;
           args: {
-            orderBy: { type: GraphQLInputObjectType };
             offset: { type: GraphQLScalarType<number, number> };
+            orderBy: { type: GraphQLInputObjectType };
             where: { type: GraphQLInputObjectType };
           };
-          resolve: SelectSingleResolver<
-            typeof schema.Users,
-            ExtractTables<typeof schema>,
-            typeof schema.usersRelations extends Relations<any, infer RelConf> ? RelConf : never
-          >;
+          resolve: SelectSingleResolver<typeof schema.Tags, ExtractTables<typeof schema>, never>;
+        };
+        usersSingle: {
+          type: GraphQLObjectType;
+          args: {
+            offset: { type: GraphQLScalarType<number, number> };
+            orderBy: { type: GraphQLInputObjectType };
+            where: { type: GraphQLInputObjectType };
+          };
+          resolve: SelectSingleResolver<typeof schema.Users, ExtractTables<typeof schema>, never>;
+        };
+      } & {
+        customersAggregate: {
+          type: GraphQLNonNull<GraphQLObjectType>;
+          args: {
+            where: { type: GraphQLInputObjectType };
+          };
+          resolve: AggregateResolver<typeof schema.Customers>;
+        };
+        postsAggregate: {
+          type: GraphQLNonNull<GraphQLObjectType>;
+          args: {
+            where: { type: GraphQLInputObjectType };
+          };
+          resolve: AggregateResolver<typeof schema.Posts>;
+        };
+        tagsAggregate: {
+          type: GraphQLNonNull<GraphQLObjectType>;
+          args: {
+            where: { type: GraphQLInputObjectType };
+          };
+          resolve: AggregateResolver<typeof schema.Tags>;
+        };
+        usersAggregate: {
+          type: GraphQLNonNull<GraphQLObjectType>;
+          args: {
+            where: { type: GraphQLInputObjectType };
+          };
+          resolve: AggregateResolver<typeof schema.Users>;
         };
       }
     >();
@@ -3566,7 +3605,7 @@ describe.sequential('Type tests', () => {
   it('Mutations', () => {
     expectTypeOf(ctx.entities.mutations).toEqualTypeOf<
       {
-        readonly createCustomers: {
+        createCustomers: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
             values: {
@@ -3575,7 +3614,7 @@ describe.sequential('Type tests', () => {
           };
           resolve: InsertArrResolver<typeof schema.Customers, false>;
         };
-        readonly createPosts: {
+        createPosts: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
             values: {
@@ -3584,7 +3623,16 @@ describe.sequential('Type tests', () => {
           };
           resolve: InsertArrResolver<typeof schema.Posts, false>;
         };
-        readonly createUsers: {
+        createTags: {
+          type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
+          args: {
+            values: {
+              type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLInputObjectType>>>;
+            };
+          };
+          resolve: InsertArrResolver<typeof schema.Tags, false>;
+        };
+        createUsers: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
             values: {
@@ -3594,7 +3642,7 @@ describe.sequential('Type tests', () => {
           resolve: InsertArrResolver<typeof schema.Users, false>;
         };
       } & {
-        readonly createCustomersSingle: {
+        createCustomersSingle: {
           type: GraphQLObjectType;
           args: {
             values: {
@@ -3603,7 +3651,7 @@ describe.sequential('Type tests', () => {
           };
           resolve: InsertResolver<typeof schema.Customers, false>;
         };
-        readonly createPostsSingle: {
+        createPostsSingle: {
           type: GraphQLObjectType;
           args: {
             values: {
@@ -3612,7 +3660,16 @@ describe.sequential('Type tests', () => {
           };
           resolve: InsertResolver<typeof schema.Posts, false>;
         };
-        readonly createUsersSingle: {
+        createTagsSingle: {
+          type: GraphQLObjectType;
+          args: {
+            values: {
+              type: GraphQLNonNull<GraphQLInputObjectType>;
+            };
+          };
+          resolve: InsertResolver<typeof schema.Tags, false>;
+        };
+        createUsersSingle: {
           type: GraphQLObjectType;
           args: {
             values: {
@@ -3622,7 +3679,89 @@ describe.sequential('Type tests', () => {
           resolve: InsertResolver<typeof schema.Users, false>;
         };
       } & {
-        readonly updateCustomers: {
+        upsertCustomers?: {
+          type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
+          args: {
+            values: {
+              type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLInputObjectType>>>;
+            };
+            onConflict: { type: GraphQLInputObjectType };
+          };
+          resolve: UpsertArrResolver<typeof schema.Customers, false>;
+        };
+        upsertPosts?: {
+          type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
+          args: {
+            values: {
+              type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLInputObjectType>>>;
+            };
+            onConflict: { type: GraphQLInputObjectType };
+          };
+          resolve: UpsertArrResolver<typeof schema.Posts, false>;
+        };
+        upsertTags?: {
+          type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
+          args: {
+            values: {
+              type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLInputObjectType>>>;
+            };
+            onConflict: { type: GraphQLInputObjectType };
+          };
+          resolve: UpsertArrResolver<typeof schema.Tags, false>;
+        };
+        upsertUsers?: {
+          type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
+          args: {
+            values: {
+              type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLInputObjectType>>>;
+            };
+            onConflict: { type: GraphQLInputObjectType };
+          };
+          resolve: UpsertArrResolver<typeof schema.Users, false>;
+        };
+      } & {
+        upsertCustomersSingle?: {
+          type: GraphQLObjectType;
+          args: {
+            values: {
+              type: GraphQLNonNull<GraphQLInputObjectType>;
+            };
+            onConflict: { type: GraphQLInputObjectType };
+          };
+          resolve: UpsertResolver<typeof schema.Customers, false>;
+        };
+        upsertPostsSingle?: {
+          type: GraphQLObjectType;
+          args: {
+            values: {
+              type: GraphQLNonNull<GraphQLInputObjectType>;
+            };
+            onConflict: { type: GraphQLInputObjectType };
+          };
+          resolve: UpsertResolver<typeof schema.Posts, false>;
+        };
+        upsertTagsSingle?: {
+          type: GraphQLObjectType;
+          args: {
+            values: {
+              type: GraphQLNonNull<GraphQLInputObjectType>;
+            };
+            onConflict: { type: GraphQLInputObjectType };
+          };
+          resolve: UpsertResolver<typeof schema.Tags, false>;
+        };
+        upsertUsersSingle?: {
+          type: GraphQLObjectType;
+          args: {
+            values: {
+              type: GraphQLNonNull<GraphQLInputObjectType>;
+            };
+            onConflict: { type: GraphQLInputObjectType };
+          };
+          resolve: UpsertResolver<typeof schema.Users, false>;
+        };
+      } & {
+        updateCustomers: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
             set: {
@@ -3632,7 +3771,7 @@ describe.sequential('Type tests', () => {
           };
           resolve: UpdateResolver<typeof schema.Customers, false>;
         };
-        readonly updatePosts: {
+        updatePosts: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
             set: {
@@ -3642,7 +3781,17 @@ describe.sequential('Type tests', () => {
           };
           resolve: UpdateResolver<typeof schema.Posts, false>;
         };
-        readonly updateUsers: {
+        updateTags: {
+          type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
+          args: {
+            set: {
+              type: GraphQLNonNull<GraphQLInputObjectType>;
+            };
+            where: { type: GraphQLInputObjectType };
+          };
+          resolve: UpdateResolver<typeof schema.Tags, false>;
+        };
+        updateUsers: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
             set: {
@@ -3653,7 +3802,7 @@ describe.sequential('Type tests', () => {
           resolve: UpdateResolver<typeof schema.Users, false>;
         };
       } & {
-        readonly updateCustomersMany: {
+        updateCustomersMany: {
           type: GraphQLNonNull<GraphQLList<GraphQLObjectType>>;
           args: {
             updates: {
@@ -3662,7 +3811,7 @@ describe.sequential('Type tests', () => {
           };
           resolve: UpdateManyResolver<typeof schema.Customers, false>;
         };
-        readonly updatePostsMany: {
+        updatePostsMany: {
           type: GraphQLNonNull<GraphQLList<GraphQLObjectType>>;
           args: {
             updates: {
@@ -3671,7 +3820,16 @@ describe.sequential('Type tests', () => {
           };
           resolve: UpdateManyResolver<typeof schema.Posts, false>;
         };
-        readonly updateUsersMany: {
+        updateTagsMany: {
+          type: GraphQLNonNull<GraphQLList<GraphQLObjectType>>;
+          args: {
+            updates: {
+              type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLInputObjectType>>>;
+            };
+          };
+          resolve: UpdateManyResolver<typeof schema.Tags, false>;
+        };
+        updateUsersMany: {
           type: GraphQLNonNull<GraphQLList<GraphQLObjectType>>;
           args: {
             updates: {
@@ -3681,26 +3839,103 @@ describe.sequential('Type tests', () => {
           resolve: UpdateManyResolver<typeof schema.Users, false>;
         };
       } & {
-        readonly deleteCustomers: {
+        updateCustomersSingle: {
+          type: GraphQLObjectType;
+          args: {
+            set: {
+              type: GraphQLNonNull<GraphQLInputObjectType>;
+            };
+            where: { type: GraphQLNonNull<GraphQLInputObjectType> };
+          };
+          resolve: UpdateSingleResolver<typeof schema.Customers, false>;
+        };
+        updatePostsSingle: {
+          type: GraphQLObjectType;
+          args: {
+            set: {
+              type: GraphQLNonNull<GraphQLInputObjectType>;
+            };
+            where: { type: GraphQLNonNull<GraphQLInputObjectType> };
+          };
+          resolve: UpdateSingleResolver<typeof schema.Posts, false>;
+        };
+        updateTagsSingle: {
+          type: GraphQLObjectType;
+          args: {
+            set: {
+              type: GraphQLNonNull<GraphQLInputObjectType>;
+            };
+            where: { type: GraphQLNonNull<GraphQLInputObjectType> };
+          };
+          resolve: UpdateSingleResolver<typeof schema.Tags, false>;
+        };
+        updateUsersSingle: {
+          type: GraphQLObjectType;
+          args: {
+            set: {
+              type: GraphQLNonNull<GraphQLInputObjectType>;
+            };
+            where: { type: GraphQLNonNull<GraphQLInputObjectType> };
+          };
+          resolve: UpdateSingleResolver<typeof schema.Users, false>;
+        };
+      } & {
+        deleteCustomers: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
             where: { type: GraphQLInputObjectType };
           };
           resolve: DeleteResolver<typeof schema.Customers, false>;
         };
-        readonly deletePosts: {
+        deletePosts: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
             where: { type: GraphQLInputObjectType };
           };
           resolve: DeleteResolver<typeof schema.Posts, false>;
         };
-        readonly deleteUsers: {
+        deleteTags: {
+          type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
+          args: {
+            where: { type: GraphQLInputObjectType };
+          };
+          resolve: DeleteResolver<typeof schema.Tags, false>;
+        };
+        deleteUsers: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
             where: { type: GraphQLInputObjectType };
           };
           resolve: DeleteResolver<typeof schema.Users, false>;
+        };
+      } & {
+        deleteCustomersSingle: {
+          type: GraphQLObjectType;
+          args: {
+            where: { type: GraphQLNonNull<GraphQLInputObjectType> };
+          };
+          resolve: DeleteSingleResolver<typeof schema.Customers, false>;
+        };
+        deletePostsSingle: {
+          type: GraphQLObjectType;
+          args: {
+            where: { type: GraphQLNonNull<GraphQLInputObjectType> };
+          };
+          resolve: DeleteSingleResolver<typeof schema.Posts, false>;
+        };
+        deleteTagsSingle: {
+          type: GraphQLObjectType;
+          args: {
+            where: { type: GraphQLNonNull<GraphQLInputObjectType> };
+          };
+          resolve: DeleteSingleResolver<typeof schema.Tags, false>;
+        };
+        deleteUsersSingle: {
+          type: GraphQLObjectType;
+          args: {
+            where: { type: GraphQLNonNull<GraphQLInputObjectType> };
+          };
+          resolve: DeleteSingleResolver<typeof schema.Users, false>;
         };
       }
     >();
@@ -3709,13 +3944,20 @@ describe.sequential('Type tests', () => {
   it('Types', () => {
     expectTypeOf(ctx.entities.types).toEqualTypeOf<
       {
-        readonly Customers: GraphQLObjectType;
-        readonly Posts: GraphQLObjectType;
-        readonly Users: GraphQLObjectType;
+        Customers: GraphQLObjectType;
+        Posts: GraphQLObjectType;
+        Tags: GraphQLObjectType;
+        Users: GraphQLObjectType;
       } & {
-        readonly Customers: GraphQLObjectType;
-        readonly Posts: GraphQLObjectType;
-        readonly Users: GraphQLObjectType;
+        CustomersAggregate: GraphQLObjectType;
+        PostsAggregate: GraphQLObjectType;
+        TagsAggregate: GraphQLObjectType;
+        UsersAggregate: GraphQLObjectType;
+      } & {
+        Customers: GraphQLObjectType;
+        Posts: GraphQLObjectType;
+        Tags: GraphQLObjectType;
+        Users: GraphQLObjectType;
       }
     >();
   });
@@ -3723,25 +3965,30 @@ describe.sequential('Type tests', () => {
   it('Inputs', () => {
     expectTypeOf(ctx.entities.inputs).toEqualTypeOf<
       {
-        readonly UsersFilters: GraphQLInputObjectType;
-        readonly CustomersFilters: GraphQLInputObjectType;
-        readonly PostsFilters: GraphQLInputObjectType;
+        CreateCustomersInput: GraphQLInputObjectType;
+        CreatePostsInput: GraphQLInputObjectType;
+        CreateTagsInput: GraphQLInputObjectType;
+        CreateUsersInput: GraphQLInputObjectType;
       } & {
-        readonly UsersOrderBy: GraphQLInputObjectType;
-        readonly CustomersOrderBy: GraphQLInputObjectType;
-        readonly PostsOrderBy: GraphQLInputObjectType;
+        UpdateCustomersInput: GraphQLInputObjectType;
+        UpdatePostsInput: GraphQLInputObjectType;
+        UpdateTagsInput: GraphQLInputObjectType;
+        UpdateUsersInput: GraphQLInputObjectType;
       } & {
-        readonly CreateUsersInput: GraphQLInputObjectType;
-        readonly CreateCustomersInput: GraphQLInputObjectType;
-        readonly CreatePostsInput: GraphQLInputObjectType;
+        UpdateCustomersManyInput: GraphQLInputObjectType;
+        UpdatePostsManyInput: GraphQLInputObjectType;
+        UpdateTagsManyInput: GraphQLInputObjectType;
+        UpdateUsersManyInput: GraphQLInputObjectType;
       } & {
-        readonly UpdateUsersInput: GraphQLInputObjectType;
-        readonly UpdateCustomersInput: GraphQLInputObjectType;
-        readonly UpdatePostsInput: GraphQLInputObjectType;
+        CustomersOrderBy: GraphQLInputObjectType;
+        PostsOrderBy: GraphQLInputObjectType;
+        TagsOrderBy: GraphQLInputObjectType;
+        UsersOrderBy: GraphQLInputObjectType;
       } & {
-        readonly UpdateUsersManyInput: GraphQLInputObjectType;
-        readonly UpdateCustomersManyInput: GraphQLInputObjectType;
-        readonly UpdatePostsManyInput: GraphQLInputObjectType;
+        CustomersFilters: GraphQLInputObjectType;
+        PostsFilters: GraphQLInputObjectType;
+        TagsFilters: GraphQLInputObjectType;
+        UsersFilters: GraphQLInputObjectType;
       }
     >();
   });

--- a/tests/pglite/common.ts
+++ b/tests/pglite/common.ts
@@ -11,20 +11,28 @@ import { GraphQLClient } from '../util/query';
 
 export { sql, schema };
 
+/**
+ * drizzle-orm v1's database generic is the relations config produced by `buildRelations`,
+ * not the schema module — `PgliteDatabase<typeof schema>` silently degraded every derived
+ * entity type to `never`, which is why the `expectTypeOf` assertions below were meaningless
+ * until the suite was brought under `tsc`.
+ */
+export type TestDatabase = PgliteDatabase<typeof schema.relations>;
+
 export interface Context {
   pglite: PGlite;
-  db: PgliteDatabase<typeof schema>;
+  db: TestDatabase;
   schema: GraphQLSchema;
-  entities: GeneratedEntities<PgliteDatabase<typeof schema>>;
+  entities: GeneratedEntities<TestDatabase>;
   server: Server;
   gql: GraphQLClient;
 }
 
 export interface MinimalContext {
   pglite: PGlite;
-  db: PgliteDatabase<typeof schema>;
+  db: TestDatabase;
   schema: GraphQLSchema;
-  entities: GeneratedEntities<PgliteDatabase<typeof schema>>;
+  entities: GeneratedEntities<TestDatabase>;
 }
 
 export const createCtx = (): Context => ({}) as any;
@@ -36,9 +44,8 @@ export const setupServer = async (ctx: Context, port: number, dataDir: string): 
 
   ctx.db = drizzle({
     client: ctx.pglite,
-    schema,
     relations: schema.relations,
-    logger: !!process.env.LOG_SQL,
+    logger: !!process.env['LOG_SQL'],
   });
 
   const { schema: gqlSchema, entities } = buildSchema(ctx.db, {
@@ -88,7 +95,6 @@ export const setupMinimal = async (ctx: MinimalContext, dataDir: string): Promis
 
   ctx.db = drizzle({
     client: ctx.pglite,
-    schema,
     relations: schema.relations,
     logger: !!process.env['LOG_SQL'],
   });

--- a/tests/pglite/complexity.test.ts
+++ b/tests/pglite/complexity.test.ts
@@ -7,7 +7,7 @@ import * as schema from '../schema/pg';
 
 // buildSchema only reads the drizzle metadata, so these tests never touch the database.
 let pglite: PGlite;
-let db: PgliteDatabase<typeof schema>;
+let db: PgliteDatabase<typeof schema.relations>;
 
 const build = (config?: BuildSchemaConfig) => buildSchema(db, config).schema;
 
@@ -23,7 +23,7 @@ const estimatorOf = (field: GraphQLField<any, any> | undefined): Estimator | und
 beforeAll(async () => {
   pglite = new PGlite();
   await pglite.waitReady;
-  db = drizzle({ client: pglite, schema, relations: schema.relations });
+  db = drizzle({ client: pglite, relations: schema.relations });
 });
 
 afterAll(async () => {

--- a/tests/pglite/config-options.test.ts
+++ b/tests/pglite/config-options.test.ts
@@ -16,7 +16,7 @@ import { setupTables } from './common';
 const makeDb = async (dataDir: string) => {
   const pglite = new PGlite(dataDir);
   await pglite.waitReady;
-  const db = drizzle({ client: pglite, schema, relations: schema.relations });
+  const db = drizzle({ client: pglite, relations: schema.relations });
   await db.execute(
     sql`DO $$ BEGIN CREATE TYPE "role" AS ENUM('admin','user'); EXCEPTION WHEN duplicate_object THEN null; END $$;`,
   );
@@ -43,7 +43,7 @@ describe('relationsDepthLimit: 0 — no relation fields generated', () => {
   });
 
   it('generated User type has no relation fields', () => {
-    const db = drizzle({ client: pglite, schema, relations: schema.relations });
+    const db = drizzle({ client: pglite, relations: schema.relations });
     const { entities } = buildSchema(db, { relationsDepthLimit: 0 });
     const types = entities.types as Record<string, GraphQLObjectType>;
     const usersType = types['Users'] ?? types['User'];
@@ -57,7 +57,7 @@ describe('relationsDepthLimit: 0 — no relation fields generated', () => {
   });
 
   it('Posts type also has no relation fields with depth limit 0', () => {
-    const db = drizzle({ client: pglite, schema, relations: schema.relations });
+    const db = drizzle({ client: pglite, relations: schema.relations });
     const { entities } = buildSchema(db, { relationsDepthLimit: 0 });
     const types = entities.types as Record<string, GraphQLObjectType>;
     const postsType = types['Posts'] ?? types['Post'];
@@ -81,7 +81,7 @@ describe('relationsDepthLimit: 1 — direct relations present, no additional nes
   });
 
   it('User type has direct relation fields at depth 1', () => {
-    const db = drizzle({ client: pglite, schema, relations: schema.relations });
+    const db = drizzle({ client: pglite, relations: schema.relations });
     const { entities } = buildSchema(db, { relationsDepthLimit: 1 });
     const types = entities.types as Record<string, GraphQLObjectType>;
     const usersType = types['Users'] ?? types['User'];
@@ -102,7 +102,7 @@ describe('custom prefixes and suffixes', () => {
 
   beforeAll(async () => {
     ({ pglite } = await makeDb(dataDir));
-    const db = drizzle({ client: pglite, schema, relations: schema.relations });
+    const db = drizzle({ client: pglite, relations: schema.relations });
     const { schema: gqlSchema } = buildSchema(db, {
       prefixes: { insert: 'add', delete: 'remove', update: 'patch' },
       suffixes: { list: 'List', single: 'One' },
@@ -158,7 +158,7 @@ describe('conflictDoNothing: true', () => {
 
   beforeAll(async () => {
     ({ pglite } = await makeDb(dataDir));
-    const db = drizzle({ client: pglite, schema, relations: schema.relations });
+    const db = drizzle({ client: pglite, relations: schema.relations });
     const { schema: gqlSchema } = buildSchema(db, {
       typeNameMapper: (name) => {
         const map: Record<string, { singular: string; plural: string }> = {
@@ -224,7 +224,7 @@ describe('typeNameMapper — generated query and mutation names', () => {
 
   it('list/single query names use mapped names', () => {
     // With mapper: list='user' + ''='user', single='user' (no suffix since mapper provides singular)
-    const db = drizzle({ client: pglite, schema, relations: schema.relations });
+    const db = drizzle({ client: pglite, relations: schema.relations });
     const { entities } = buildSchema(db, {
       typeNameMapper: (name) => {
         const map: Record<string, { singular: string; plural: string }> = {
@@ -240,7 +240,7 @@ describe('typeNameMapper — generated query and mutation names', () => {
   });
 
   it('insert-single mutation uses mapped singular name', () => {
-    const db = drizzle({ client: pglite, schema, relations: schema.relations });
+    const db = drizzle({ client: pglite, relations: schema.relations });
     const { entities } = buildSchema(db, {
       typeNameMapper: (name) => {
         const map: Record<string, { singular: string; plural: string }> = {
@@ -256,7 +256,7 @@ describe('typeNameMapper — generated query and mutation names', () => {
   });
 
   it('insert-array mutation uses mapped plural name', () => {
-    const db = drizzle({ client: pglite, schema, relations: schema.relations });
+    const db = drizzle({ client: pglite, relations: schema.relations });
     const { entities } = buildSchema(db, {
       typeNameMapper: (name) => {
         const map: Record<string, { singular: string; plural: string }> = {
@@ -269,7 +269,7 @@ describe('typeNameMapper — generated query and mutation names', () => {
   });
 
   it('generated type names use mapped singular', () => {
-    const db = drizzle({ client: pglite, schema, relations: schema.relations });
+    const db = drizzle({ client: pglite, relations: schema.relations });
     const { entities } = buildSchema(db, {
       typeNameMapper: (name) => {
         const map: Record<string, { singular: string; plural: string }> = {
@@ -284,7 +284,7 @@ describe('typeNameMapper — generated query and mutation names', () => {
   });
 
   it('without typeNameMapper (default) names use table key', () => {
-    const db = drizzle({ client: pglite, schema, relations: schema.relations });
+    const db = drizzle({ client: pglite, relations: schema.relations });
     const { entities } = buildSchema(db);
     const queryKeys = Object.keys(entities.queries);
     expect(queryKeys).toContain('users');
@@ -311,7 +311,7 @@ describe("typeNameMapper: 'singularize'", () => {
   });
 
   const built = () => {
-    const db = drizzle({ client: pglite, schema, relations: schema.relations });
+    const db = drizzle({ client: pglite, relations: schema.relations });
     return buildSchema(db, { typeNameMapper: 'singularize' }).entities;
   };
 
@@ -334,7 +334,7 @@ describe("typeNameMapper: 'singularize'", () => {
   });
 
   it('is the same function as the exported singularizeMapper', () => {
-    const db = drizzle({ client: pglite, schema, relations: schema.relations });
+    const db = drizzle({ client: pglite, relations: schema.relations });
     const byPreset = Object.keys(buildSchema(db, { typeNameMapper: 'singularize' }).entities.queries).sort();
     const byExport = Object.keys(buildSchema(db, { typeNameMapper: singularizeMapper }).entities.queries).sort();
 
@@ -342,7 +342,7 @@ describe("typeNameMapper: 'singularize'", () => {
   });
 
   it('can be wrapped to leave one table with its default names', () => {
-    const db = drizzle({ client: pglite, schema, relations: schema.relations });
+    const db = drizzle({ client: pglite, relations: schema.relations });
     const { entities } = buildSchema(db, {
       typeNameMapper: (table) => (table === 'Tags' ? undefined : singularizeMapper(table)),
     });

--- a/tests/pglite/decimal.test.ts
+++ b/tests/pglite/decimal.test.ts
@@ -221,10 +221,13 @@ describe('MySQL decimal columns', () => {
 
   const mysqlEntities = generateMySQL(mockDb, { Products: MysqlProducts }, mysqlRelations, {
     relationsDepthLimit: undefined,
-    prefixes: { insert: 'create', delete: 'delete', update: 'update' },
+    prefixes: { insert: 'create', delete: 'delete', update: 'update', upsert: 'upsert' },
     suffixes: { list: '', single: 'Single' },
     conflictDoNothing: false,
     shouldEagerLoad: () => true,
+    complexity: undefined,
+    transactions: undefined,
+    limits: undefined,
     features: {
       aggregates: true,
       relationAggregates: true,

--- a/tests/pglite/features.test.ts
+++ b/tests/pglite/features.test.ts
@@ -8,7 +8,7 @@ import * as schema from '../schema/pg';
 // buildSchema only reads the drizzle metadata, so these tests never touch the database:
 // one in-memory client is enough to build as many schemas as we like.
 let pglite: PGlite;
-let db: PgliteDatabase<typeof schema>;
+let db: PgliteDatabase<typeof schema.relations>;
 
 const build = (features?: SchemaFeatures) => buildSchema(db, features ? { features } : undefined);
 
@@ -18,7 +18,7 @@ const userFields = (gqlSchema: GraphQLSchema) => (gqlSchema.getType('Users') as 
 beforeAll(async () => {
   pglite = new PGlite();
   await pglite.waitReady;
-  db = drizzle({ client: pglite, schema, relations: schema.relations });
+  db = drizzle({ client: pglite, relations: schema.relations });
 });
 
 afterAll(async () => {
@@ -208,7 +208,7 @@ describe('features: upsert', () => {
     expect(mutations['upsertUsers']).toBeDefined();
     expect(mutations['upsertUsersSingle']).toBeDefined();
     expect(gqlSchema.getType('UsersOnConflict')).toBeDefined();
-    expect(entities.inputs['UsersOnConflict']).toBeDefined();
+    expect((entities.inputs as Record<string, unknown>)['UsersOnConflict']).toBeDefined();
   });
 
   it('keeps the insert input, which types the upsert values, even with insert off', () => {

--- a/tests/pglite/field-extensions.test.ts
+++ b/tests/pglite/field-extensions.test.ts
@@ -9,7 +9,7 @@ import * as schema from '../schema/pg';
 
 // buildSchema only reads drizzle metadata, so these tests never touch the database.
 let pglite: PGlite;
-let db: PgliteDatabase<typeof schema>;
+let db: PgliteDatabase<typeof schema.relations>;
 let gqlSchema: GraphQLSchema;
 
 const queryField = (name: string) => gqlSchema.getQueryType()!.getFields()[name]!;
@@ -19,7 +19,7 @@ const meta = (field: unknown) => drizzleExtension(field as any) as DrizzleFieldE
 beforeAll(async () => {
   pglite = new PGlite();
   await pglite.waitReady;
-  db = drizzle({ client: pglite, schema, relations: schema.relations });
+  db = drizzle({ client: pglite, relations: schema.relations });
   gqlSchema = buildSchema(db, { features: { upsert: true } }).schema;
 });
 
@@ -233,7 +233,7 @@ describe('identifyRows: composite primary keys', () => {
   let compositeGql: GraphQLSchema;
 
   beforeAll(() => {
-    const compositeDb = drizzle({ client: pglite, schema: compositeSchema, relations: compositeSchema.relations });
+    const compositeDb = drizzle({ client: pglite, relations: compositeSchema.relations });
     compositeGql = buildSchema(compositeDb as any).schema;
   });
 

--- a/tests/pglite/print-schema.test.ts
+++ b/tests/pglite/print-schema.test.ts
@@ -22,7 +22,7 @@ afterAll(async () => {
 
 describe('printSchema', () => {
   it('prints a non-empty GraphQL SDL from buildSchema', () => {
-    const db = drizzle({ client: pglite, schema, relations: schema.relations });
+    const db = drizzle({ client: pglite, relations: schema.relations });
     const { schema: gqlSchema } = buildSchema(db, {
       typeNameMapper: (name) => {
         const map: Record<string, { singular: string; plural: string }> = {

--- a/tests/pglite/single-write.test.ts
+++ b/tests/pglite/single-write.test.ts
@@ -251,7 +251,7 @@ describe.sequential('features.requireWhere', () => {
   beforeAll(async () => {
     rwCtx.pglite = new PGlite(dataDir);
     await rwCtx.pglite.waitReady;
-    rwCtx.db = drizzle({ client: rwCtx.pglite, schema, relations: schema.relations });
+    rwCtx.db = drizzle({ client: rwCtx.pglite, relations: schema.relations });
     await rwCtx.db.execute(
       sql`DO $$ BEGIN CREATE TYPE "role" AS ENUM('admin','user'); EXCEPTION WHEN duplicate_object THEN null; END $$;`,
     );

--- a/tests/pglite/through-relation-filters.test.ts
+++ b/tests/pglite/through-relation-filters.test.ts
@@ -102,7 +102,7 @@ describe.sequential('through-relation filters', () => {
     }`);
 
     expect(result.errors).toBeUndefined();
-    expect(result.data?.users).toEqual([{ id: 1 }]);
+    expect(result.data?.['users']).toEqual([{ id: 1 }]);
   });
 
   it('`some: {}` matches rows with at least one related row', async () => {
@@ -111,7 +111,7 @@ describe.sequential('through-relation filters', () => {
     }`);
 
     expect(result.errors).toBeUndefined();
-    expect(result.data?.users).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
+    expect(result.data?.['users']).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
   });
 
   it('filters a table by a through-relation with `none`', async () => {
@@ -122,7 +122,7 @@ describe.sequential('through-relation filters', () => {
     }`);
 
     expect(result.errors).toBeUndefined();
-    expect(result.data?.users).toEqual([{ id: 2 }, { id: 3 }, { id: 4 }]);
+    expect(result.data?.['users']).toEqual([{ id: 2 }, { id: 3 }, { id: 4 }]);
   });
 
   it('`none: {}` matches rows with no related rows at all', async () => {
@@ -131,7 +131,7 @@ describe.sequential('through-relation filters', () => {
     }`);
 
     expect(result.errors).toBeUndefined();
-    expect(result.data?.users).toEqual([{ id: 4 }]);
+    expect(result.data?.['users']).toEqual([{ id: 4 }]);
   });
 
   it('filters a table by a through-relation with `every`', async () => {
@@ -143,7 +143,7 @@ describe.sequential('through-relation filters', () => {
     }`);
 
     expect(result.errors).toBeUndefined();
-    expect(result.data?.users).toEqual([{ id: 2 }, { id: 4 }]);
+    expect(result.data?.['users']).toEqual([{ id: 2 }, { id: 4 }]);
   });
 
   it('combines several match modes on one through-relation', async () => {
@@ -157,7 +157,7 @@ describe.sequential('through-relation filters', () => {
     }`);
 
     expect(result.errors).toBeUndefined();
-    expect(result.data?.users).toEqual([{ id: 2 }]);
+    expect(result.data?.['users']).toEqual([{ id: 2 }]);
   });
 
   it('filters from the reverse side of the junction', async () => {
@@ -168,7 +168,7 @@ describe.sequential('through-relation filters', () => {
     }`);
 
     expect(result.errors).toBeUndefined();
-    expect(result.data?.roles).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(result.data?.['roles']).toEqual([{ id: 1 }, { id: 2 }]);
   });
 
   it('ANDs a through-relation filter with column filters', async () => {
@@ -178,7 +178,7 @@ describe.sequential('through-relation filters', () => {
     }`);
 
     expect(result.errors).toBeUndefined();
-    expect(result.data?.users).toEqual([{ id: 2 }]);
+    expect(result.data?.['users']).toEqual([{ id: 2 }]);
   });
 
   it('supports through-relation filters inside OR', async () => {
@@ -190,7 +190,7 @@ describe.sequential('through-relation filters', () => {
     }`);
 
     expect(result.errors).toBeUndefined();
-    expect(result.data?.users).toEqual([{ id: 1 }, { id: 3 }]);
+    expect(result.data?.['users']).toEqual([{ id: 1 }, { id: 3 }]);
   });
 
   it('nests a through-relation filter inside another through-relation filter', async () => {
@@ -204,7 +204,7 @@ describe.sequential('through-relation filters', () => {
     }`);
 
     expect(result.errors).toBeUndefined();
-    expect(result.data?.users).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(result.data?.['users']).toEqual([{ id: 1 }, { id: 2 }]);
   });
 
   it('applies through-relation filters to aggregate queries', async () => {
@@ -213,7 +213,7 @@ describe.sequential('through-relation filters', () => {
     }`);
 
     expect(result.errors).toBeUndefined();
-    expect(result.data?.usersAggregate).toEqual({ count: 2 });
+    expect(result.data?.['usersAggregate']).toEqual({ count: 2 });
   });
 
   describe('schema shape', () => {

--- a/tests/pglite/type.test.ts
+++ b/tests/pglite/type.test.ts
@@ -1,4 +1,3 @@
-import type { Relations } from 'drizzle-orm';
 import type {
   GraphQLEnumType,
   GraphQLInputObjectType,
@@ -12,12 +11,17 @@ import { afterAll, beforeAll, describe, expectTypeOf, it } from 'vitest';
 import type {
   AggregateResolver,
   DeleteResolver,
+  DeleteSingleResolver,
   ExtractTables,
   InsertArrResolver,
   InsertResolver,
   SelectResolver,
   SelectSingleResolver,
+  UpdateManyResolver,
   UpdateResolver,
+  UpdateSingleResolver,
+  UpsertArrResolver,
+  UpsertResolver,
 } from '@/index';
 import type * as schema from '../schema/pg';
 import { createMinimalCtx, type MinimalContext, setupMinimal, teardownMinimal } from './common';
@@ -34,6 +38,12 @@ afterAll(async () => {
   await teardownMinimal(ctx, DATA_DIR);
 });
 
+// The generated-entity keys below are written WITHOUT `readonly`, unlike the SQLite and
+// MySQL suites. `ExtractTables` maps homomorphically over whatever the database handle's
+// generic slot holds, so the modifier is inherited from there: SQLite/MySQL still carry the
+// schema module, and a namespace import's properties are readonly, while a PostgreSQL handle
+// carries `typeof schema.relations` — a plain object type — whose properties are mutable.
+// `toEqualTypeOf` compares modifiers, so the two dialects genuinely differ here.
 describe.sequential('Type tests', () => {
   it('Schema', () => {
     expectTypeOf(ctx.schema).toEqualTypeOf<GraphQLSchema>();
@@ -42,134 +52,110 @@ describe.sequential('Type tests', () => {
   it('Queries', () => {
     expectTypeOf(ctx.entities.queries).toEqualTypeOf<
       {
-        readonly customers: {
+        customers: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
-            orderBy: { type: GraphQLInputObjectType };
             offset: { type: GraphQLScalarType<number, number> };
             limit: { type: GraphQLScalarType<number, number> };
+            orderBy: { type: GraphQLInputObjectType };
             where: { type: GraphQLInputObjectType };
             distinct: { type: GraphQLList<GraphQLNonNull<GraphQLEnumType>> };
           };
-          resolve: SelectResolver<
-            typeof schema.Customers,
-            ExtractTables<typeof schema>,
-            typeof schema.customersRelations extends Relations<any, infer RelConf> ? RelConf : never
-          >;
+          resolve: SelectResolver<typeof schema.Customers, ExtractTables<typeof schema>, never>;
         };
-        readonly posts: {
+        posts: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
-            orderBy: { type: GraphQLInputObjectType };
             offset: { type: GraphQLScalarType<number, number> };
             limit: { type: GraphQLScalarType<number, number> };
+            orderBy: { type: GraphQLInputObjectType };
             where: { type: GraphQLInputObjectType };
             distinct: { type: GraphQLList<GraphQLNonNull<GraphQLEnumType>> };
           };
-          resolve: SelectResolver<
-            typeof schema.Posts,
-            ExtractTables<typeof schema>,
-            typeof schema.postsRelations extends Relations<any, infer RelConf> ? RelConf : never
-          >;
+          resolve: SelectResolver<typeof schema.Posts, ExtractTables<typeof schema>, never>;
         };
-        readonly tags: {
+        tags: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
-            orderBy: { type: GraphQLInputObjectType };
             offset: { type: GraphQLScalarType<number, number> };
             limit: { type: GraphQLScalarType<number, number> };
+            orderBy: { type: GraphQLInputObjectType };
             where: { type: GraphQLInputObjectType };
             distinct: { type: GraphQLList<GraphQLNonNull<GraphQLEnumType>> };
           };
           resolve: SelectResolver<typeof schema.Tags, ExtractTables<typeof schema>, never>;
         };
-        readonly users: {
+        users: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
-            orderBy: { type: GraphQLInputObjectType };
             offset: { type: GraphQLScalarType<number, number> };
             limit: { type: GraphQLScalarType<number, number> };
+            orderBy: { type: GraphQLInputObjectType };
             where: { type: GraphQLInputObjectType };
             distinct: { type: GraphQLList<GraphQLNonNull<GraphQLEnumType>> };
           };
-          resolve: SelectResolver<
-            typeof schema.Users,
-            ExtractTables<typeof schema>,
-            typeof schema.usersRelations extends Relations<any, infer RelConf> ? RelConf : never
-          >;
+          resolve: SelectResolver<typeof schema.Users, ExtractTables<typeof schema>, never>;
         };
       } & {
-        readonly customersSingle: {
+        customersSingle: {
           type: GraphQLObjectType;
           args: {
-            orderBy: { type: GraphQLInputObjectType };
             offset: { type: GraphQLScalarType<number, number> };
+            orderBy: { type: GraphQLInputObjectType };
             where: { type: GraphQLInputObjectType };
           };
-          resolve: SelectSingleResolver<
-            typeof schema.Customers,
-            ExtractTables<typeof schema>,
-            typeof schema.customersRelations extends Relations<any, infer RelConf> ? RelConf : never
-          >;
+          resolve: SelectSingleResolver<typeof schema.Customers, ExtractTables<typeof schema>, never>;
         };
-        readonly postsSingle: {
+        postsSingle: {
           type: GraphQLObjectType;
           args: {
-            orderBy: { type: GraphQLInputObjectType };
             offset: { type: GraphQLScalarType<number, number> };
+            orderBy: { type: GraphQLInputObjectType };
             where: { type: GraphQLInputObjectType };
           };
-          resolve: SelectSingleResolver<
-            typeof schema.Posts,
-            ExtractTables<typeof schema>,
-            typeof schema.postsRelations extends Relations<any, infer RelConf> ? RelConf : never
-          >;
+          resolve: SelectSingleResolver<typeof schema.Posts, ExtractTables<typeof schema>, never>;
         };
-        readonly tagsSingle: {
+        tagsSingle: {
           type: GraphQLObjectType;
           args: {
-            orderBy: { type: GraphQLInputObjectType };
             offset: { type: GraphQLScalarType<number, number> };
+            orderBy: { type: GraphQLInputObjectType };
             where: { type: GraphQLInputObjectType };
           };
           resolve: SelectSingleResolver<typeof schema.Tags, ExtractTables<typeof schema>, never>;
         };
-        readonly usersSingle: {
+        usersSingle: {
           type: GraphQLObjectType;
           args: {
-            orderBy: { type: GraphQLInputObjectType };
             offset: { type: GraphQLScalarType<number, number> };
+            orderBy: { type: GraphQLInputObjectType };
             where: { type: GraphQLInputObjectType };
           };
-          resolve: SelectSingleResolver<
-            typeof schema.Users,
-            ExtractTables<typeof schema>,
-            typeof schema.usersRelations extends Relations<any, infer RelConf> ? RelConf : never
-          >;
+          resolve: SelectSingleResolver<typeof schema.Users, ExtractTables<typeof schema>, never>;
         };
       } & {
-        readonly customersAggregate: {
+        customersAggregate: {
           type: GraphQLNonNull<GraphQLObjectType>;
           args: {
             where: { type: GraphQLInputObjectType };
           };
           resolve: AggregateResolver<typeof schema.Customers>;
         };
-        readonly postsAggregate: {
+        postsAggregate: {
           type: GraphQLNonNull<GraphQLObjectType>;
           args: {
             where: { type: GraphQLInputObjectType };
           };
           resolve: AggregateResolver<typeof schema.Posts>;
         };
-        readonly tagsAggregate: {
+        tagsAggregate: {
           type: GraphQLNonNull<GraphQLObjectType>;
           args: {
             where: { type: GraphQLInputObjectType };
           };
           resolve: AggregateResolver<typeof schema.Tags>;
         };
-        readonly usersAggregate: {
+        usersAggregate: {
           type: GraphQLNonNull<GraphQLObjectType>;
           args: {
             where: { type: GraphQLInputObjectType };
@@ -183,7 +169,7 @@ describe.sequential('Type tests', () => {
   it('Mutations', () => {
     expectTypeOf(ctx.entities.mutations).toEqualTypeOf<
       {
-        readonly createCustomers: {
+        createCustomers: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
             values: {
@@ -192,7 +178,7 @@ describe.sequential('Type tests', () => {
           };
           resolve: InsertArrResolver<typeof schema.Customers, false>;
         };
-        readonly createPosts: {
+        createPosts: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
             values: {
@@ -201,7 +187,7 @@ describe.sequential('Type tests', () => {
           };
           resolve: InsertArrResolver<typeof schema.Posts, false>;
         };
-        readonly createTags: {
+        createTags: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
             values: {
@@ -210,7 +196,7 @@ describe.sequential('Type tests', () => {
           };
           resolve: InsertArrResolver<typeof schema.Tags, false>;
         };
-        readonly createUsers: {
+        createUsers: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
             values: {
@@ -220,7 +206,7 @@ describe.sequential('Type tests', () => {
           resolve: InsertArrResolver<typeof schema.Users, false>;
         };
       } & {
-        readonly createCustomersSingle: {
+        createCustomersSingle: {
           type: GraphQLObjectType;
           args: {
             values: {
@@ -229,7 +215,7 @@ describe.sequential('Type tests', () => {
           };
           resolve: InsertResolver<typeof schema.Customers, false>;
         };
-        readonly createPostsSingle: {
+        createPostsSingle: {
           type: GraphQLObjectType;
           args: {
             values: {
@@ -238,7 +224,7 @@ describe.sequential('Type tests', () => {
           };
           resolve: InsertResolver<typeof schema.Posts, false>;
         };
-        readonly createTagsSingle: {
+        createTagsSingle: {
           type: GraphQLObjectType;
           args: {
             values: {
@@ -247,7 +233,7 @@ describe.sequential('Type tests', () => {
           };
           resolve: InsertResolver<typeof schema.Tags, false>;
         };
-        readonly createUsersSingle: {
+        createUsersSingle: {
           type: GraphQLObjectType;
           args: {
             values: {
@@ -257,7 +243,89 @@ describe.sequential('Type tests', () => {
           resolve: InsertResolver<typeof schema.Users, false>;
         };
       } & {
-        readonly updateCustomers: {
+        upsertCustomers?: {
+          type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
+          args: {
+            values: {
+              type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLInputObjectType>>>;
+            };
+            onConflict: { type: GraphQLInputObjectType };
+          };
+          resolve: UpsertArrResolver<typeof schema.Customers, false>;
+        };
+        upsertPosts?: {
+          type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
+          args: {
+            values: {
+              type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLInputObjectType>>>;
+            };
+            onConflict: { type: GraphQLInputObjectType };
+          };
+          resolve: UpsertArrResolver<typeof schema.Posts, false>;
+        };
+        upsertTags?: {
+          type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
+          args: {
+            values: {
+              type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLInputObjectType>>>;
+            };
+            onConflict: { type: GraphQLInputObjectType };
+          };
+          resolve: UpsertArrResolver<typeof schema.Tags, false>;
+        };
+        upsertUsers?: {
+          type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
+          args: {
+            values: {
+              type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLInputObjectType>>>;
+            };
+            onConflict: { type: GraphQLInputObjectType };
+          };
+          resolve: UpsertArrResolver<typeof schema.Users, false>;
+        };
+      } & {
+        upsertCustomersSingle?: {
+          type: GraphQLObjectType;
+          args: {
+            values: {
+              type: GraphQLNonNull<GraphQLInputObjectType>;
+            };
+            onConflict: { type: GraphQLInputObjectType };
+          };
+          resolve: UpsertResolver<typeof schema.Customers, false>;
+        };
+        upsertPostsSingle?: {
+          type: GraphQLObjectType;
+          args: {
+            values: {
+              type: GraphQLNonNull<GraphQLInputObjectType>;
+            };
+            onConflict: { type: GraphQLInputObjectType };
+          };
+          resolve: UpsertResolver<typeof schema.Posts, false>;
+        };
+        upsertTagsSingle?: {
+          type: GraphQLObjectType;
+          args: {
+            values: {
+              type: GraphQLNonNull<GraphQLInputObjectType>;
+            };
+            onConflict: { type: GraphQLInputObjectType };
+          };
+          resolve: UpsertResolver<typeof schema.Tags, false>;
+        };
+        upsertUsersSingle?: {
+          type: GraphQLObjectType;
+          args: {
+            values: {
+              type: GraphQLNonNull<GraphQLInputObjectType>;
+            };
+            onConflict: { type: GraphQLInputObjectType };
+          };
+          resolve: UpsertResolver<typeof schema.Users, false>;
+        };
+      } & {
+        updateCustomers: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
             set: {
@@ -267,7 +335,7 @@ describe.sequential('Type tests', () => {
           };
           resolve: UpdateResolver<typeof schema.Customers, false>;
         };
-        readonly updatePosts: {
+        updatePosts: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
             set: {
@@ -277,7 +345,7 @@ describe.sequential('Type tests', () => {
           };
           resolve: UpdateResolver<typeof schema.Posts, false>;
         };
-        readonly updateTags: {
+        updateTags: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
             set: {
@@ -287,7 +355,7 @@ describe.sequential('Type tests', () => {
           };
           resolve: UpdateResolver<typeof schema.Tags, false>;
         };
-        readonly updateUsers: {
+        updateUsers: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
             set: {
@@ -298,33 +366,140 @@ describe.sequential('Type tests', () => {
           resolve: UpdateResolver<typeof schema.Users, false>;
         };
       } & {
-        readonly deleteCustomers: {
+        updateCustomersMany: {
+          type: GraphQLNonNull<GraphQLList<GraphQLObjectType>>;
+          args: {
+            updates: {
+              type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLInputObjectType>>>;
+            };
+          };
+          resolve: UpdateManyResolver<typeof schema.Customers, false>;
+        };
+        updatePostsMany: {
+          type: GraphQLNonNull<GraphQLList<GraphQLObjectType>>;
+          args: {
+            updates: {
+              type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLInputObjectType>>>;
+            };
+          };
+          resolve: UpdateManyResolver<typeof schema.Posts, false>;
+        };
+        updateTagsMany: {
+          type: GraphQLNonNull<GraphQLList<GraphQLObjectType>>;
+          args: {
+            updates: {
+              type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLInputObjectType>>>;
+            };
+          };
+          resolve: UpdateManyResolver<typeof schema.Tags, false>;
+        };
+        updateUsersMany: {
+          type: GraphQLNonNull<GraphQLList<GraphQLObjectType>>;
+          args: {
+            updates: {
+              type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLInputObjectType>>>;
+            };
+          };
+          resolve: UpdateManyResolver<typeof schema.Users, false>;
+        };
+      } & {
+        updateCustomersSingle: {
+          type: GraphQLObjectType;
+          args: {
+            set: {
+              type: GraphQLNonNull<GraphQLInputObjectType>;
+            };
+            where: { type: GraphQLNonNull<GraphQLInputObjectType> };
+          };
+          resolve: UpdateSingleResolver<typeof schema.Customers, false>;
+        };
+        updatePostsSingle: {
+          type: GraphQLObjectType;
+          args: {
+            set: {
+              type: GraphQLNonNull<GraphQLInputObjectType>;
+            };
+            where: { type: GraphQLNonNull<GraphQLInputObjectType> };
+          };
+          resolve: UpdateSingleResolver<typeof schema.Posts, false>;
+        };
+        updateTagsSingle: {
+          type: GraphQLObjectType;
+          args: {
+            set: {
+              type: GraphQLNonNull<GraphQLInputObjectType>;
+            };
+            where: { type: GraphQLNonNull<GraphQLInputObjectType> };
+          };
+          resolve: UpdateSingleResolver<typeof schema.Tags, false>;
+        };
+        updateUsersSingle: {
+          type: GraphQLObjectType;
+          args: {
+            set: {
+              type: GraphQLNonNull<GraphQLInputObjectType>;
+            };
+            where: { type: GraphQLNonNull<GraphQLInputObjectType> };
+          };
+          resolve: UpdateSingleResolver<typeof schema.Users, false>;
+        };
+      } & {
+        deleteCustomers: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
             where: { type: GraphQLInputObjectType };
           };
           resolve: DeleteResolver<typeof schema.Customers, false>;
         };
-        readonly deletePosts: {
+        deletePosts: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
             where: { type: GraphQLInputObjectType };
           };
           resolve: DeleteResolver<typeof schema.Posts, false>;
         };
-        readonly deleteTags: {
+        deleteTags: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
             where: { type: GraphQLInputObjectType };
           };
           resolve: DeleteResolver<typeof schema.Tags, false>;
         };
-        readonly deleteUsers: {
+        deleteUsers: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
             where: { type: GraphQLInputObjectType };
           };
           resolve: DeleteResolver<typeof schema.Users, false>;
+        };
+      } & {
+        deleteCustomersSingle: {
+          type: GraphQLObjectType;
+          args: {
+            where: { type: GraphQLNonNull<GraphQLInputObjectType> };
+          };
+          resolve: DeleteSingleResolver<typeof schema.Customers, false>;
+        };
+        deletePostsSingle: {
+          type: GraphQLObjectType;
+          args: {
+            where: { type: GraphQLNonNull<GraphQLInputObjectType> };
+          };
+          resolve: DeleteSingleResolver<typeof schema.Posts, false>;
+        };
+        deleteTagsSingle: {
+          type: GraphQLObjectType;
+          args: {
+            where: { type: GraphQLNonNull<GraphQLInputObjectType> };
+          };
+          resolve: DeleteSingleResolver<typeof schema.Tags, false>;
+        };
+        deleteUsersSingle: {
+          type: GraphQLObjectType;
+          args: {
+            where: { type: GraphQLNonNull<GraphQLInputObjectType> };
+          };
+          resolve: DeleteSingleResolver<typeof schema.Users, false>;
         };
       }
     >();
@@ -333,20 +508,20 @@ describe.sequential('Type tests', () => {
   it('Types', () => {
     expectTypeOf(ctx.entities.types).toEqualTypeOf<
       {
-        readonly Customers: GraphQLObjectType;
-        readonly Posts: GraphQLObjectType;
-        readonly Tags: GraphQLObjectType;
-        readonly Users: GraphQLObjectType;
+        Customers: GraphQLObjectType;
+        Posts: GraphQLObjectType;
+        Tags: GraphQLObjectType;
+        Users: GraphQLObjectType;
       } & {
-        readonly Customers: GraphQLObjectType;
-        readonly Posts: GraphQLObjectType;
-        readonly Tags: GraphQLObjectType;
-        readonly Users: GraphQLObjectType;
+        CustomersAggregate: GraphQLObjectType;
+        PostsAggregate: GraphQLObjectType;
+        TagsAggregate: GraphQLObjectType;
+        UsersAggregate: GraphQLObjectType;
       } & {
-        readonly CustomersAggregate: GraphQLObjectType;
-        readonly PostsAggregate: GraphQLObjectType;
-        readonly TagsAggregate: GraphQLObjectType;
-        readonly UsersAggregate: GraphQLObjectType;
+        Customers: GraphQLObjectType;
+        Posts: GraphQLObjectType;
+        Tags: GraphQLObjectType;
+        Users: GraphQLObjectType;
       }
     >();
   });
@@ -354,25 +529,30 @@ describe.sequential('Type tests', () => {
   it('Inputs', () => {
     expectTypeOf(ctx.entities.inputs).toEqualTypeOf<
       {
-        readonly UsersFilters: GraphQLInputObjectType;
-        readonly CustomersFilters: GraphQLInputObjectType;
-        readonly PostsFilters: GraphQLInputObjectType;
-        readonly TagsFilters: GraphQLInputObjectType;
+        CreateCustomersInput: GraphQLInputObjectType;
+        CreatePostsInput: GraphQLInputObjectType;
+        CreateTagsInput: GraphQLInputObjectType;
+        CreateUsersInput: GraphQLInputObjectType;
       } & {
-        readonly UsersOrderBy: GraphQLInputObjectType;
-        readonly CustomersOrderBy: GraphQLInputObjectType;
-        readonly PostsOrderBy: GraphQLInputObjectType;
-        readonly TagsOrderBy: GraphQLInputObjectType;
+        UpdateCustomersInput: GraphQLInputObjectType;
+        UpdatePostsInput: GraphQLInputObjectType;
+        UpdateTagsInput: GraphQLInputObjectType;
+        UpdateUsersInput: GraphQLInputObjectType;
       } & {
-        readonly CreateUsersInput: GraphQLInputObjectType;
-        readonly CreateCustomersInput: GraphQLInputObjectType;
-        readonly CreatePostsInput: GraphQLInputObjectType;
-        readonly CreateTagsInput: GraphQLInputObjectType;
+        UpdateCustomersManyInput: GraphQLInputObjectType;
+        UpdatePostsManyInput: GraphQLInputObjectType;
+        UpdateTagsManyInput: GraphQLInputObjectType;
+        UpdateUsersManyInput: GraphQLInputObjectType;
       } & {
-        readonly UpdateUsersInput: GraphQLInputObjectType;
-        readonly UpdateCustomersInput: GraphQLInputObjectType;
-        readonly UpdatePostsInput: GraphQLInputObjectType;
-        readonly UpdateTagsInput: GraphQLInputObjectType;
+        CustomersOrderBy: GraphQLInputObjectType;
+        PostsOrderBy: GraphQLInputObjectType;
+        TagsOrderBy: GraphQLInputObjectType;
+        UsersOrderBy: GraphQLInputObjectType;
+      } & {
+        CustomersFilters: GraphQLInputObjectType;
+        PostsFilters: GraphQLInputObjectType;
+        TagsFilters: GraphQLInputObjectType;
+        UsersFilters: GraphQLInputObjectType;
       }
     >();
   });

--- a/tests/sqlite-custom.test.ts
+++ b/tests/sqlite-custom.test.ts
@@ -12,7 +12,7 @@ import * as schema from './schema/sqlite';
 import { GraphQLClient } from './util/query';
 
 interface Context {
-  db: BaseSQLiteDatabase<'async', any, typeof schema>;
+  db: BaseSQLiteDatabase<'async', any, typeof schema, typeof schema.relations>;
   client: Client;
   schema: GraphQLSchema;
   entities: GeneratedEntities<BaseSQLiteDatabase<'async', any, typeof schema>>;
@@ -51,7 +51,7 @@ beforeAll(async () => {
     client: ctx.client,
     schema,
     relations: schema.relations,
-    logger: !!process.env.LOG_SQL,
+    logger: !!process.env['LOG_SQL'],
   });
 
   const { entities } = buildSchema(ctx.db);

--- a/tests/sqlite-on-write.test.ts
+++ b/tests/sqlite-on-write.test.ts
@@ -34,7 +34,7 @@ let client: Client;
 let db: any;
 
 const buildWith = (config: Partial<BuildSchemaConfig>): GraphQLSchema =>
-  buildSchema(db, { onError: (error) => error as Error, ...config } as any).schema;
+  buildSchema(db, { onError: (error: unknown) => error as Error, ...config } as any).schema;
 
 const run = (gqlSchema: GraphQLSchema, source: string) => graphql({ schema: gqlSchema, source, contextValue: {} });
 

--- a/tests/sqlite-soft-delete.test.ts
+++ b/tests/sqlite-soft-delete.test.ts
@@ -45,7 +45,7 @@ const softDelete: Partial<BuildSchemaConfig> = {
 };
 
 const buildWith = (config: Partial<BuildSchemaConfig>): GraphQLSchema =>
-  buildSchema(db, { onError: (error) => error as Error, ...config } as any).schema;
+  buildSchema(db, { onError: (error: unknown) => error as Error, ...config } as any).schema;
 
 const run = (gqlSchema: GraphQLSchema, source: string, contextValue: Record<string, any> = {}) =>
   graphql({ schema: gqlSchema, source, contextValue: { ...contextValue } });

--- a/tests/sqlite.test.ts
+++ b/tests/sqlite.test.ts
@@ -31,6 +31,8 @@ import {
   type UpdateManyResolver,
   type UpdateResolver,
   type UpdateSingleResolver,
+  type UpsertArrResolver,
+  type UpsertResolver,
 } from '@/index';
 import * as schema from './schema/sqlite';
 import { GraphQLClient } from './util/query';
@@ -75,7 +77,7 @@ beforeAll(async () => {
     client: ctx.client,
     schema,
     relations: schema.relations,
-    logger: !!process.env.LOG_SQL,
+    logger: !!process.env['LOG_SQL'],
   });
 
   const { schema: gqlSchema, entities } = buildSchema(ctx.db);
@@ -3438,87 +3440,63 @@ describe.sequential('Type tests', () => {
         readonly customers: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
-            orderBy: { type: GraphQLInputObjectType };
             offset: { type: GraphQLScalarType<number, number> };
             limit: { type: GraphQLScalarType<number, number> };
+            orderBy: { type: GraphQLInputObjectType };
             where: { type: GraphQLInputObjectType };
             distinct: { type: GraphQLList<GraphQLNonNull<GraphQLEnumType>> };
           };
-          resolve: SelectResolver<
-            typeof schema.Customers,
-            ExtractTables<typeof schema>,
-            typeof schema.customersRelations extends Relations<any, infer RelConf> ? RelConf : never
-          >;
+          resolve: SelectResolver<typeof schema.Customers, ExtractTables<typeof schema>, never>;
         };
         readonly posts: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
-            orderBy: { type: GraphQLInputObjectType };
             offset: { type: GraphQLScalarType<number, number> };
             limit: { type: GraphQLScalarType<number, number> };
+            orderBy: { type: GraphQLInputObjectType };
             where: { type: GraphQLInputObjectType };
             distinct: { type: GraphQLList<GraphQLNonNull<GraphQLEnumType>> };
           };
-          resolve: SelectResolver<
-            typeof schema.Posts,
-            ExtractTables<typeof schema>,
-            typeof schema.postsRelations extends Relations<any, infer RelConf> ? RelConf : never
-          >;
+          resolve: SelectResolver<typeof schema.Posts, ExtractTables<typeof schema>, never>;
         };
         readonly users: {
           type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
           args: {
-            orderBy: { type: GraphQLInputObjectType };
             offset: { type: GraphQLScalarType<number, number> };
             limit: { type: GraphQLScalarType<number, number> };
+            orderBy: { type: GraphQLInputObjectType };
             where: { type: GraphQLInputObjectType };
             distinct: { type: GraphQLList<GraphQLNonNull<GraphQLEnumType>> };
           };
-          resolve: SelectResolver<
-            typeof schema.Users,
-            ExtractTables<typeof schema>,
-            typeof schema.usersRelations extends Relations<any, infer RelConf> ? RelConf : never
-          >;
+          resolve: SelectResolver<typeof schema.Users, ExtractTables<typeof schema>, never>;
         };
       } & {
         readonly customersSingle: {
           type: GraphQLObjectType;
           args: {
-            orderBy: { type: GraphQLInputObjectType };
             offset: { type: GraphQLScalarType<number, number> };
+            orderBy: { type: GraphQLInputObjectType };
             where: { type: GraphQLInputObjectType };
           };
-          resolve: SelectSingleResolver<
-            typeof schema.Customers,
-            ExtractTables<typeof schema>,
-            typeof schema.customersRelations extends Relations<any, infer RelConf> ? RelConf : never
-          >;
+          resolve: SelectSingleResolver<typeof schema.Customers, ExtractTables<typeof schema>, never>;
         };
         readonly postsSingle: {
           type: GraphQLObjectType;
           args: {
-            orderBy: { type: GraphQLInputObjectType };
             offset: { type: GraphQLScalarType<number, number> };
+            orderBy: { type: GraphQLInputObjectType };
             where: { type: GraphQLInputObjectType };
           };
-          resolve: SelectSingleResolver<
-            typeof schema.Posts,
-            ExtractTables<typeof schema>,
-            typeof schema.postsRelations extends Relations<any, infer RelConf> ? RelConf : never
-          >;
+          resolve: SelectSingleResolver<typeof schema.Posts, ExtractTables<typeof schema>, never>;
         };
         readonly usersSingle: {
           type: GraphQLObjectType;
           args: {
-            orderBy: { type: GraphQLInputObjectType };
             offset: { type: GraphQLScalarType<number, number> };
+            orderBy: { type: GraphQLInputObjectType };
             where: { type: GraphQLInputObjectType };
           };
-          resolve: SelectSingleResolver<
-            typeof schema.Users,
-            ExtractTables<typeof schema>,
-            typeof schema.usersRelations extends Relations<any, infer RelConf> ? RelConf : never
-          >;
+          resolve: SelectSingleResolver<typeof schema.Users, ExtractTables<typeof schema>, never>;
         };
       } & {
         readonly customersAggregate: {
@@ -3603,6 +3581,68 @@ describe.sequential('Type tests', () => {
             };
           };
           resolve: InsertResolver<typeof schema.Users, false>;
+        };
+      } & {
+        readonly upsertCustomers?: {
+          type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
+          args: {
+            values: {
+              type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLInputObjectType>>>;
+            };
+            onConflict: { type: GraphQLInputObjectType };
+          };
+          resolve: UpsertArrResolver<typeof schema.Customers, false>;
+        };
+        readonly upsertPosts?: {
+          type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
+          args: {
+            values: {
+              type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLInputObjectType>>>;
+            };
+            onConflict: { type: GraphQLInputObjectType };
+          };
+          resolve: UpsertArrResolver<typeof schema.Posts, false>;
+        };
+        readonly upsertUsers?: {
+          type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLObjectType>>>;
+          args: {
+            values: {
+              type: GraphQLNonNull<GraphQLList<GraphQLNonNull<GraphQLInputObjectType>>>;
+            };
+            onConflict: { type: GraphQLInputObjectType };
+          };
+          resolve: UpsertArrResolver<typeof schema.Users, false>;
+        };
+      } & {
+        readonly upsertCustomersSingle?: {
+          type: GraphQLObjectType;
+          args: {
+            values: {
+              type: GraphQLNonNull<GraphQLInputObjectType>;
+            };
+            onConflict: { type: GraphQLInputObjectType };
+          };
+          resolve: UpsertResolver<typeof schema.Customers, false>;
+        };
+        readonly upsertPostsSingle?: {
+          type: GraphQLObjectType;
+          args: {
+            values: {
+              type: GraphQLNonNull<GraphQLInputObjectType>;
+            };
+            onConflict: { type: GraphQLInputObjectType };
+          };
+          resolve: UpsertResolver<typeof schema.Posts, false>;
+        };
+        readonly upsertUsersSingle?: {
+          type: GraphQLObjectType;
+          args: {
+            values: {
+              type: GraphQLNonNull<GraphQLInputObjectType>;
+            };
+            onConflict: { type: GraphQLInputObjectType };
+          };
+          resolve: UpsertResolver<typeof schema.Users, false>;
         };
       } & {
         readonly updateCustomers: {
@@ -3749,13 +3789,13 @@ describe.sequential('Type tests', () => {
         readonly Posts: GraphQLObjectType;
         readonly Users: GraphQLObjectType;
       } & {
-        readonly Customers: GraphQLObjectType;
-        readonly Posts: GraphQLObjectType;
-        readonly Users: GraphQLObjectType;
-      } & {
         readonly CustomersAggregate: GraphQLObjectType;
         readonly PostsAggregate: GraphQLObjectType;
         readonly UsersAggregate: GraphQLObjectType;
+      } & {
+        readonly Customers: GraphQLObjectType;
+        readonly Posts: GraphQLObjectType;
+        readonly Users: GraphQLObjectType;
       }
     >();
   });
@@ -3763,25 +3803,25 @@ describe.sequential('Type tests', () => {
   it('Inputs', () => {
     expectTypeOf(ctx.entities.inputs).toEqualTypeOf<
       {
-        readonly UsersFilters: GraphQLInputObjectType;
-        readonly CustomersFilters: GraphQLInputObjectType;
-        readonly PostsFilters: GraphQLInputObjectType;
-      } & {
-        readonly UsersOrderBy: GraphQLInputObjectType;
-        readonly CustomersOrderBy: GraphQLInputObjectType;
-        readonly PostsOrderBy: GraphQLInputObjectType;
-      } & {
-        readonly CreateUsersInput: GraphQLInputObjectType;
         readonly CreateCustomersInput: GraphQLInputObjectType;
         readonly CreatePostsInput: GraphQLInputObjectType;
+        readonly CreateUsersInput: GraphQLInputObjectType;
       } & {
-        readonly UpdateUsersInput: GraphQLInputObjectType;
         readonly UpdateCustomersInput: GraphQLInputObjectType;
         readonly UpdatePostsInput: GraphQLInputObjectType;
+        readonly UpdateUsersInput: GraphQLInputObjectType;
       } & {
-        readonly UpdateUsersManyInput: GraphQLInputObjectType;
         readonly UpdateCustomersManyInput: GraphQLInputObjectType;
         readonly UpdatePostsManyInput: GraphQLInputObjectType;
+        readonly UpdateUsersManyInput: GraphQLInputObjectType;
+      } & {
+        readonly CustomersOrderBy: GraphQLInputObjectType;
+        readonly PostsOrderBy: GraphQLInputObjectType;
+        readonly UsersOrderBy: GraphQLInputObjectType;
+      } & {
+        readonly CustomersFilters: GraphQLInputObjectType;
+        readonly PostsFilters: GraphQLInputObjectType;
+        readonly UsersFilters: GraphQLInputObjectType;
       }
     >();
   });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,8 +7,10 @@ export default defineConfig({
     include: ['tests/**/*.test.ts'],
     globalSetup: ['tests/globalSetup.ts'],
     isolate: true,
+    // `expectTypeOf` assertions are compile-time only; `npm run typecheck` is what
+    // actually enforces them (tests/tsconfig.json is the project that includes tests/).
     typecheck: {
-      tsconfig: 'tsconfig.json',
+      tsconfig: 'tests/tsconfig.json',
     },
     testTimeout: 100000,
     hookTimeout: 120000,


### PR DESCRIPTION
Stacked on #94.

## The problem

The dialect suites carry 39 `expectTypeOf` assertions over the exported entity
types. None of them had ever run:

- `tests/**` is not in the root tsconfig's `include`, so `npx tsc --noEmit` never
  looked at them;
- `vitest.config.ts` set `typecheck.tsconfig: 'tsconfig.json'` — the src-only
  project — and never set `typecheck.enabled`.

So the assertions were inert text. Pointing `tsc` at them produced 118 errors.

## What was actually broken

Three of them were real bugs in the **public type surface**, not in the tests:

1. **`ExtractTables` did not understand drizzle-orm v1's PostgreSQL handle.**
   It assumed the database's generic slot holds the schema module. In v1,
   `PgliteDatabase<TRelations>` / `PostgresJsDatabase<TRelations>` carry only the
   relations config from `buildRelations` — a `Record<string, { table; name; relations }>`.
   Filtering that for `extends Table` matches nothing, so **every PG-derived
   entity type resolved to `never`**. It is now dual-mode: it reads the tables off
   the config's `table` members when handed a `TablesRelationalConfig`, and filters
   the module otherwise (SQLite and MySQL still carry the schema).

2. **`GeneratedOutputs` used type names the generator stopped emitting.**
   It keyed on `${Table}SelectItem` and `${Table}Item`; this build emits one object
   type per table (`Users`) used for both selects and mutation returns.

3. **`GeneratedInputs` used write-input names the generator never emitted.**
   The write inputs are built from the configured prefixes, so the keys are
   `Create${Table}Input`, `Update${Table}Input` and `Update${Table}ManyInput`.

Anyone typing against `GeneratedEntities` — indexing `entities.types` or
`entities.inputs`, or annotating a PG database — got `never` or a missing key.

## The rest

The assertions themselves were stale, written before upsert, `updateMany`, the
`*Single` variants, aggregates, the `distinct` argument and the `Tags` table
existed. They were regenerated from `QueriesCore` / `MutationsCore` /
`GeneratedOutputs` / `GeneratedInputs` so they describe what is actually built.

Test-side type fixes that fell out: PG test databases are now spelled
`PostgresJsDatabase<typeof schema.relations>` (v1's generic slot), `db.query` on
the SQLite custom suite needed its relations generic, and a few config literals
had drifted from `SchemaGeneratorOptions`.

One asymmetry is worth knowing about, and is commented at both sites: the PG
suites spell their expected keys **without** `readonly`, unlike SQLite and MySQL.
`ExtractTables` maps homomorphically over the handle's generic slot, so the
modifier is inherited from there — a namespace import's properties are readonly,
`typeof schema.relations` is a plain object type and its are not.

## Keeping it from rotting again

- `npm run typecheck` — `tsc --noEmit` for src **and** `tsc --noEmit -p tests/tsconfig.json`.
- CI gets a dedicated "Type check (tests)" step, so a drifting public type fails the build.
- `vitest.config.ts`'s `typecheck.tsconfig` now points at the project that includes tests/.
- CI's no-Docker test step ran 3 of the 11 SQLite/PGlite files (`tests/pglite`,
  `sqlite.test.ts`, `sqlite-custom.test.ts`); it now runs all of them. Its
  `mkdir -p tests/.temp` is dropped — `tests/globalSetup.ts` does that.

## Verification

- `npx tsc --noEmit` and `npx tsc --noEmit -p tests/tsconfig.json` — clean.
- `npx vitest run tests/pglite tests/sqlite*.test.ts` — 70 files, **1044 passed**.
- `npx vitest run tests/pg.test.ts tests/mysql.test.ts tests/pg-custom.test.ts tests/mysql-custom.test.ts` — **180 passed** (Docker).
- `npx biome check .` — clean.

## Known follow-up

`ExtractRelations`, `ExtractTableRelations` and `AnyDrizzleDB` still model
drizzle-orm v0's removed `Relations` class through a local stub, so relation
generics degrade to `never`. The regenerated assertions spell that `never`
honestly rather than papering over it. Fixing it is a separate, self-contained PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)