### PR TITLE
refactor: share generateUpdateMany between the pg and sqlite builders

### DIFF
--- a/src/util/builders/pg.ts
+++ b/src/util/builders/pg.ts
@@ -1,8 +1,7 @@
 import { and, getColumns, type Table } from 'drizzle-orm';
 import type { RelationalQueryBuilder } from 'drizzle-orm/mysql-core/query-builders/query';
 import { getTableConfig, type PgAsyncDatabase, type PgColumn, PgTable } from 'drizzle-orm/pg-core';
-import type { GraphQLFieldConfigArgumentMap } from 'graphql';
-import { GraphQLError, type GraphQLInputObjectType, GraphQLList, GraphQLNonNull } from 'graphql';
+import { GraphQLError, type GraphQLInputObjectType } from 'graphql';
 import type { ResolveTree } from 'graphql-parse-resolve-info';
 import { parseResolveInfo } from 'graphql-parse-resolve-info';
 import type { GeneratedEntities } from '../../types.ts';
@@ -15,7 +14,6 @@ import {
   cursorOrderingEntries,
   type DeletedMode,
   decodeCursor,
-  eagerLoadMutationRelations,
   extractFilters,
   extractOrderBy,
   extractSelectedColumnsFromTreeSQLFormat,
@@ -23,22 +21,17 @@ import {
   getPrimaryKeyPropNamesFromConfig,
   isCursorFieldSelected,
   type LimitPolicyFor,
-  type MutationTxCtx,
   orderByCursorObstacle,
-  prepareMutationRelationColumns,
   primaryKeyOrderExprs,
   primaryKeyRestriction,
   type RelationFilterBase,
   type ResolverPolicies,
   relationFilterCtx,
   resolveQueryExecutor,
-  runMutation,
   runRelationalSelect,
-  runWriteHook,
   selectArrayArgs,
   selectDistinctKeys,
   selectSingleArgs,
-  stripContextValues,
   type TablesRelationalConfig,
   type TypeNameMapper,
   toGraphQLError,
@@ -46,16 +39,9 @@ import {
   withScope,
 } from '../builders/common.ts';
 import { remapToGraphQLArrayOutput, remapToGraphQLSingleOutput } from '../data-mappers/index.ts';
-import { remapUpdateInput } from './field-updates.ts';
-import { mergedOps, type NestedWriteRuntime } from './nested-writes.ts';
 import { createSchemaDataGenerator } from './schema-data.ts';
-import type {
-  CreatedResolver,
-  Filters,
-  SchemaGeneratorOptions,
-  TableNamedRelations,
-  TableSelectArgs,
-} from './types.ts';
+import type { CreatedResolver, SchemaGeneratorOptions, TableNamedRelations, TableSelectArgs } from './types.ts';
+import { createUpdateManyGenerator } from './update-many.ts';
 
 const generateSelectArray = (
   db: PgAsyncDatabase<any, any>,
@@ -340,195 +326,7 @@ const generateSelectSingle = (
 /** Primary-key property names for a PG table, including table-level composite keys. */
 const pgPrimaryKeyPropNames = (table: PgTable): string[] => getPrimaryKeyPropNamesFromConfig(table, getTableConfig);
 
-/**
- * `update<Table>Many` — batch update with a per-entry `set` and `where`.
- *
- * The entries run as one UPDATE statement each, in input order, inside a single
- * transaction (a savepoint when the request context already carries one), so a failing
- * entry rolls the whole batch back and a row matched by several entries sees them applied
- * in order. The result lists each entry's updated rows in entry order, with `null`
- * standing in for an entry whose `where` matched no rows, so the common one-row-per-entry
- * case stays aligned with the input.
- */
-const generateUpdateMany = (
-  db: PgAsyncDatabase<any, any>,
-  tableName: string,
-  table: PgTable,
-  tables: Record<string, Table>,
-  relationMap: Record<string, Record<string, TableNamedRelations>>,
-  updateManyInput: GraphQLInputObjectType,
-  fieldName: string,
-  typeName: string,
-  typeNameMapper?: TypeNameMapper,
-  filterCtx?: RelationFilterBase,
-  txCtx?: MutationTxCtx,
-  nested?: NestedWriteRuntime,
-  limits?: LimitPolicyFor,
-  policies?: ResolverPolicies,
-): CreatedResolver => {
-  const queryArgs = {
-    updates: {
-      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(updateManyInput))),
-    },
-  } as const satisfies GraphQLFieldConfigArgumentMap;
-
-  // Derived once at build time — PK prop names don't change per request.
-  const pkNames = pgPrimaryKeyPropNames(table);
-  const hooks = policies?.onWrite?.(tableName, 'updateMany');
-
-  return {
-    name: fieldName,
-    resolver: async (
-      _source,
-      args: { updates: { where?: Filters<Table>; set: Record<string, any> }[] },
-      context,
-      info,
-    ) => {
-      try {
-        return await runMutation(
-          db,
-          context,
-          info,
-          txCtx,
-          async (executor) => {
-            const { updates } = args;
-            if (!updates.length) {
-              throw new GraphQLError('No updates were provided!');
-            }
-            await runWriteHook(hooks, 'before', {
-              table: tableName,
-              operation: 'updateMany',
-              single: false,
-              args,
-              context,
-              info,
-              tx: executor,
-            });
-            const scope = policies?.scope?.(context);
-            const contextColumns = policies?.contextValues?.(tableName);
-
-            const parsedInfo = parseResolveInfo(info, {
-              deep: true,
-            }) as ResolveTree;
-
-            const { columns, hasRelations, withParams } = prepareMutationRelationColumns({
-              relationMap,
-              tables,
-              tableName,
-              typeName,
-              typeNameMapper,
-              table,
-              pkNames,
-              parsedInfo,
-              limits,
-              scope,
-              defaultOrderBy: policies?.defaultOrderBy,
-            });
-
-            // Remap and validate every entry before the transaction opens, so a malformed
-            // entry rejects the request instead of rolling back mid-batch.
-            const entries = updates.map(({ where, set }) => {
-              const split = nested?.enabled(tableName) ? nested.split(tableName, set) : undefined;
-              const ops = split && nested!.hasOps(split.ops) ? split.ops : undefined;
-              const input = stripContextValues(
-                remapUpdateInput(split ? split.columns : set, table, tableName),
-                contextColumns,
-              );
-              // An entry that only writes through a relation still has work to do.
-              if (!Object.keys(input).length && !ops) {
-                throw new GraphQLError('Unable to update with no values specified!');
-              }
-              return {
-                set: input,
-                ops,
-                filters: withScope(
-                  scope,
-                  tableName,
-                  table,
-                  where ? extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName)) : undefined,
-                ),
-              };
-            });
-
-            const returning = entries.some((entry) => entry.ops)
-              ? nested!.withJoinColumns(
-                  tableName,
-                  mergedOps(entries.map((entry) => ({ ops: entry.ops ?? {} }))),
-                  {
-                    ...columns,
-                  },
-                  table,
-                )
-              : columns;
-
-            // On a caller-supplied transaction — or the shared multi-mutation transaction
-            // opened by `runMutation` — this opens a savepoint, so the batch stays atomic
-            // without breaking the outer transaction.
-            const perEntry: Record<string, any>[][] = await executor.transaction(async (tx: any) => {
-              const results: Record<string, any>[][] = [];
-              for (const entry of entries) {
-                const values = entry.ops
-                  ? { ...entry.set, ...(await nested!.applyParentSide(tx, tableName, entry.ops, context)) }
-                  : entry.set;
-
-                // Same as the single update: an entry with no column values reads the rows its
-                // `where` matched so the nested operations have something to attach to.
-                const writes = Object.keys(values).length > 0;
-                let query = writes ? tx.update(table).set(values) : tx.select(returning).from(table);
-                if (entry.filters) {
-                  query = query.where(entry.filters) as any;
-                }
-                const rows = (await (writes ? (query.returning(returning) as any) : query)) as Record<string, any>[];
-
-                if (entry.ops) {
-                  await nested!.applyChildSide(tx, tableName, entry.ops, rows, context);
-                }
-                results.push(rows);
-              }
-              return results;
-            });
-
-            const flatRows = perEntry.flat();
-            await runWriteHook(hooks, 'after', {
-              table: tableName,
-              operation: 'updateMany',
-              single: false,
-              args,
-              rows: flatRows,
-              context,
-              info,
-              tx: executor,
-            });
-
-            const enriched = hasRelations
-              ? await eagerLoadMutationRelations(executor, tableName, flatRows, pkNames, withParams)
-              : flatRows;
-
-            // Rebuild the per-entry slots: a no-match entry contributes `null`, a multi-match
-            // entry contributes each of its rows.
-            const output: (Record<string, any> | null)[] = [];
-            let offset = 0;
-            for (const rows of perEntry) {
-              if (!rows.length) {
-                output.push(null);
-                continue;
-              }
-              for (let i = 0; i < rows.length; i++) {
-                output.push(remapToGraphQLSingleOutput(enriched[offset + i], tableName, table, relationMap));
-              }
-              offset += rows.length;
-            }
-            return output;
-          },
-          !!hooks,
-        );
-      } catch (e) {
-        throw toGraphQLError(e);
-      }
-    },
-    args: queryArgs,
-  };
-};
+const generateUpdateMany = createUpdateManyGenerator(pgPrimaryKeyPropNames);
 
 const pgSchemaData = createSchemaDataGenerator({
   tableClass: PgTable,

--- a/src/util/builders/sqlite.ts
+++ b/src/util/builders/sqlite.ts
@@ -1,48 +1,30 @@
 import type { Table } from 'drizzle-orm';
 import type { RelationalQueryBuilder } from 'drizzle-orm/mysql-core/query-builders/query';
 import { type BaseSQLiteDatabase, getTableConfig, SQLiteTable } from 'drizzle-orm/sqlite-core';
-import type { GraphQLFieldConfigArgumentMap, GraphQLResolveInfo } from 'graphql';
-import { GraphQLError, type GraphQLInputObjectType, GraphQLList, GraphQLNonNull } from 'graphql';
+import type { GraphQLInputObjectType, GraphQLResolveInfo } from 'graphql';
 import type { ResolveTree } from 'graphql-parse-resolve-info';
 import { parseResolveInfo } from 'graphql-parse-resolve-info';
 
 import type { GeneratedEntities } from '../../types.ts';
 import {
   applyLimitPolicy,
-  eagerLoadMutationRelations,
-  extractFilters,
   generateDistinctEnum,
   getPrimaryKeyPropNamesFromConfig,
   type LimitPolicyFor,
-  type MutationTxCtx,
-  prepareMutationRelationColumns,
   type RelationFilterBase,
   type ResolverPolicies,
-  relationFilterCtx,
   resolveQueryExecutor,
-  runMutation,
   runRelationalSelect,
-  runWriteHook,
   selectArrayArgs,
   selectSingleArgs,
-  stripContextValues,
   type TablesRelationalConfig,
   type TypeNameMapper,
   toGraphQLError,
   withDefaultOrderBy,
-  withScope,
 } from '../builders/common.ts';
-import { remapToGraphQLSingleOutput } from '../data-mappers/index.ts';
-import { remapUpdateInput } from './field-updates.ts';
-import { mergedOps, type NestedWriteRuntime } from './nested-writes.ts';
 import { createSchemaDataGenerator } from './schema-data.ts';
-import type {
-  CreatedResolver,
-  Filters,
-  SchemaGeneratorOptions,
-  TableNamedRelations,
-  TableSelectArgs,
-} from './types.ts';
+import type { CreatedResolver, SchemaGeneratorOptions, TableNamedRelations, TableSelectArgs } from './types.ts';
+import { createUpdateManyGenerator, type UpdateManyBatchRunner, type UpdateManyEntry } from './update-many.ts';
 
 const generateSelectArray = (
   db: BaseSQLiteDatabase<any, any, any, any>,
@@ -187,235 +169,88 @@ const sqlitePrimaryKeyPropNames = (table: SQLiteTable): string[] =>
   getPrimaryKeyPropNamesFromConfig(table, getTableConfig);
 
 /**
- * `update<Table>Many` — batch update with a per-entry `set` and `where`.
- *
- * The entries run as one UPDATE statement each, in input order, inside a single
- * transaction (a savepoint when the request context already carries one), so a failing
- * entry rolls the whole batch back and a row matched by several entries sees them applied
- * in order. The result lists each entry's updated rows in entry order, with `null`
- * standing in for an entry whose `where` matched no rows, so the common one-row-per-entry
- * case stays aligned with the input.
+ * SQLite's batch runner. A synchronous driver (better-sqlite3) commits the moment its
+ * transaction callback returns, so that callback must not be async — an awaited statement
+ * would run after the COMMIT. The driver kind is probed from the first statement's result
+ * rather than declared, so the same resolver serves both driver families.
  */
-const generateUpdateMany = (
-  db: BaseSQLiteDatabase<any, any, any, any>,
-  tableName: string,
-  table: SQLiteTable,
-  tables: Record<string, Table>,
-  relationMap: Record<string, Record<string, TableNamedRelations>>,
-  updateManyInput: GraphQLInputObjectType,
-  fieldName: string,
-  typeName: string,
-  typeNameMapper?: TypeNameMapper,
-  filterCtx?: RelationFilterBase,
-  txCtx?: MutationTxCtx,
-  nested?: NestedWriteRuntime,
-  limits?: LimitPolicyFor,
-  policies?: ResolverPolicies,
-): CreatedResolver => {
-  const queryArgs = {
-    updates: {
-      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(updateManyInput))),
-    },
-  } as const satisfies GraphQLFieldConfigArgumentMap;
-
-  // Derived once at build time — PK prop names don't change per request.
-  const pkNames = sqlitePrimaryKeyPropNames(table);
-
-  const hooks = policies?.onWrite?.(tableName, 'updateMany');
-
-  return {
-    name: fieldName,
-    resolver: async (
-      _source,
-      args: { updates: { where?: Filters<Table>; set: Record<string, any> }[] },
-      context,
-      info,
-    ) => {
-      try {
-        return await runMutation(
-          db,
-          context,
-          info,
-          txCtx,
-          async (executor) => {
-            const { updates } = args;
-            if (!updates.length) {
-              throw new GraphQLError('No updates were provided!');
-            }
-            await runWriteHook(hooks, 'before', {
-              table: tableName,
-              operation: 'updateMany',
-              single: false,
-              args,
-              context,
-              info,
-              tx: executor,
-            });
-            const scope = policies?.scope?.(context);
-            const contextColumns = policies?.contextValues?.(tableName);
-
-            const parsedInfo = parseResolveInfo(info, {
-              deep: true,
-            }) as ResolveTree;
-
-            const { columns, hasRelations, withParams } = prepareMutationRelationColumns({
-              relationMap,
-              tables,
-              tableName,
-              typeName,
-              typeNameMapper,
-              table,
-              pkNames,
-              parsedInfo,
-              limits,
-              scope,
-              defaultOrderBy: policies?.defaultOrderBy,
-            });
-
-            // Remap and validate every entry before the transaction opens, so a malformed
-            // entry rejects the request instead of rolling back mid-batch.
-            const entries = updates.map(({ where, set }) => {
-              const split = nested?.enabled(tableName) ? nested.split(tableName, set) : undefined;
-              const ops = split && nested!.hasOps(split.ops) ? split.ops : undefined;
-              const input = stripContextValues(
-                remapUpdateInput(split ? split.columns : set, table, tableName),
-                contextColumns,
-              );
-              // An entry that only writes through a relation still has work to do.
-              if (!Object.keys(input).length && !ops) {
-                throw new GraphQLError('Unable to update with no values specified!');
-              }
-              return {
-                set: input,
-                ops,
-                filters: withScope(
-                  scope,
-                  tableName,
-                  table,
-                  where ? extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName)) : undefined,
-                ),
-              };
-            });
-
-            const anyNested = entries.some((entry) => entry.ops);
-            const returning = anyNested
-              ? nested!.withJoinColumns(
-                  tableName,
-                  mergedOps(entries.map((entry) => ({ ops: entry.ops ?? {} }))),
-                  { ...columns },
-                  table,
-                )
-              : columns;
-
-            const runEntry = (tx: any, entry: (typeof entries)[number]) => {
-              let query = tx.update(table).set(entry.set);
-              if (entry.filters) {
-                query = query.where(entry.filters);
-              }
-              // `.all()` instead of awaiting the thenable: a sync driver (better-sqlite3)
-              // executes it immediately, which is the only way the statement still runs
-              // inside the synchronous native transaction below.
-              return query.returning(returning).all();
-            };
-
-            // Nested writes need statements interleaved with awaited reads, which only an async
-            // driver can do inside a transaction — `features.nestedWrites` rejects a sync driver
-            // at build time, so this branch is always on one.
-            const runNestedEntry = async (tx: any, entry: (typeof entries)[number]) => {
-              const values = entry.ops
-                ? { ...entry.set, ...(await nested!.applyParentSide(tx, tableName, entry.ops, context)) }
-                : entry.set;
-
-              // Same as the single update: an entry with no column values reads the rows its
-              // `where` matched so the nested operations have something to attach to.
-              const writes = Object.keys(values).length > 0;
-              let query = writes ? tx.update(table).set(values) : tx.select(returning).from(table);
-              if (entry.filters) {
-                query = query.where(entry.filters);
-              }
-              const rows = (await (writes ? query.returning(returning) : query)) as Record<string, any>[];
-
-              if (entry.ops) {
-                await nested!.applyChildSide(tx, tableName, entry.ops, rows, context);
-              }
-              return rows;
-            };
-
-            // On a caller-supplied transaction — or the shared multi-mutation transaction
-            // opened by `runMutation` — this opens a savepoint, so the batch stays atomic
-            // without breaking the outer transaction. A sync driver's transaction callback
-            // must not be async — it would commit before any awaited statement ran — so the
-            // driver kind is probed from the first statement's result instead.
-            const perEntry: Record<string, any>[][] = await executor.transaction((tx: any) => {
-              if (anyNested) {
-                return (async () => {
-                  const results: Record<string, any>[][] = [];
-                  for (const entry of entries) {
-                    results.push(await runNestedEntry(tx, entry));
-                  }
-                  return results;
-                })();
-              }
-
-              const first = runEntry(tx, entries[0]!);
-              if (typeof (first as any)?.then === 'function') {
-                // Async driver: await sequentially so the entries apply in input order.
-                return (async () => {
-                  const results: Record<string, any>[][] = [await first];
-                  for (let i = 1; i < entries.length; i++) {
-                    results.push(await runEntry(tx, entries[i]!));
-                  }
-                  return results;
-                })();
-              }
-              const results: Record<string, any>[][] = [first];
-              for (let i = 1; i < entries.length; i++) {
-                results.push(runEntry(tx, entries[i]!));
-              }
-              return results;
-            });
-
-            const flatRows = perEntry.flat();
-            await runWriteHook(hooks, 'after', {
-              table: tableName,
-              operation: 'updateMany',
-              single: false,
-              args,
-              rows: flatRows,
-              context,
-              info,
-              tx: executor,
-            });
-
-            const enriched = hasRelations
-              ? await eagerLoadMutationRelations(executor, tableName, flatRows, pkNames, withParams)
-              : flatRows;
-
-            // Rebuild the per-entry slots: a no-match entry contributes `null`, a multi-match
-            // entry contributes each of its rows.
-            const output: (Record<string, any> | null)[] = [];
-            let offset = 0;
-            for (const rows of perEntry) {
-              if (!rows.length) {
-                output.push(null);
-                continue;
-              }
-              for (let i = 0; i < rows.length; i++) {
-                output.push(remapToGraphQLSingleOutput(enriched[offset + i], tableName, table, relationMap));
-              }
-              offset += rows.length;
-            }
-            return output;
-          },
-          !!hooks,
-        );
-      } catch (e) {
-        throw toGraphQLError(e);
-      }
-    },
-    args: queryArgs,
+const runSqliteUpdateManyBatch: UpdateManyBatchRunner = ({
+  executor,
+  entries,
+  table,
+  returning,
+  anyNested,
+  nested,
+  tableName,
+  context,
+}) => {
+  const runEntry = (tx: any, entry: UpdateManyEntry) => {
+    let query = tx.update(table).set(entry.set);
+    if (entry.filters) {
+      query = query.where(entry.filters);
+    }
+    // `.all()` instead of awaiting the thenable: a sync driver executes it immediately,
+    // which is the only way the statement still runs inside the native transaction below.
+    return query.returning(returning).all();
   };
+
+  // Nested writes need statements interleaved with awaited reads, which only an async driver
+  // can do inside a transaction — `features.nestedWrites` rejects a sync driver at build
+  // time, so this path is always on one.
+  const runNestedEntry = async (tx: any, entry: UpdateManyEntry) => {
+    const values = entry.ops
+      ? { ...entry.set, ...(await nested!.applyParentSide(tx, tableName, entry.ops, context)) }
+      : entry.set;
+
+    // Same as the single update: an entry with no column values reads the rows its `where`
+    // matched so the nested operations have something to attach to.
+    const writes = Object.keys(values).length > 0;
+    let query = writes ? tx.update(table).set(values) : tx.select(returning).from(table);
+    if (entry.filters) {
+      query = query.where(entry.filters);
+    }
+    const rows = (await (writes ? query.returning(returning) : query)) as Record<string, any>[];
+
+    if (entry.ops) {
+      await nested!.applyChildSide(tx, tableName, entry.ops, rows, context);
+    }
+    return rows;
+  };
+
+  // On a caller-supplied transaction — or the shared multi-mutation transaction opened by
+  // `runMutation` — this opens a savepoint, so the batch stays atomic without breaking the
+  // outer transaction.
+  return executor.transaction((tx: any) => {
+    if (anyNested) {
+      return (async () => {
+        const results: Record<string, any>[][] = [];
+        for (const entry of entries) {
+          results.push(await runNestedEntry(tx, entry));
+        }
+        return results;
+      })();
+    }
+
+    const first = runEntry(tx, entries[0]!);
+    if (typeof (first as any)?.then === 'function') {
+      // Async driver: await sequentially so the entries apply in input order.
+      return (async () => {
+        const results: Record<string, any>[][] = [await first];
+        for (let i = 1; i < entries.length; i++) {
+          results.push(await runEntry(tx, entries[i]!));
+        }
+        return results;
+      })();
+    }
+    const results: Record<string, any>[][] = [first];
+    for (let i = 1; i < entries.length; i++) {
+      results.push(runEntry(tx, entries[i]!));
+    }
+    return results;
+  });
 };
+
+const generateUpdateMany = createUpdateManyGenerator(sqlitePrimaryKeyPropNames, runSqliteUpdateManyBatch);
 
 const sqliteSchemaData = createSchemaDataGenerator({
   tableClass: SQLiteTable,

--- a/src/util/builders/update-many.ts
+++ b/src/util/builders/update-many.ts
@@ -1,0 +1,287 @@
+// =============================================================================
+// The dialect-independent half of `update<Table>Many`.
+//
+// PostgreSQL and SQLite build this resolver identically right up to the point
+// where the entries actually execute — argument parsing, the per-entry remap
+// and validation, the nested-write split, the write hooks, relation
+// enrichment and the per-entry output slots are all the same. The two dialects
+// differ only in HOW the batch runs inside its transaction, which is what
+// {@link UpdateManyBatchRunner} abstracts.
+// =============================================================================
+
+import type { Table } from 'drizzle-orm';
+import type { GraphQLFieldConfigArgumentMap, GraphQLInputObjectType } from 'graphql';
+import { GraphQLError, GraphQLList, GraphQLNonNull } from 'graphql';
+import type { ResolveTree } from 'graphql-parse-resolve-info';
+import { parseResolveInfo } from 'graphql-parse-resolve-info';
+import {
+  eagerLoadMutationRelations,
+  extractFilters,
+  type LimitPolicyFor,
+  type MutationTxCtx,
+  prepareMutationRelationColumns,
+  type RelationFilterBase,
+  type ResolverPolicies,
+  relationFilterCtx,
+  runMutation,
+  runWriteHook,
+  stripContextValues,
+  type TypeNameMapper,
+  toGraphQLError,
+  withScope,
+} from '../builders/common.ts';
+import { remapToGraphQLSingleOutput } from '../data-mappers/index.ts';
+import { remapUpdateInput } from './field-updates.ts';
+import { mergedOps, type NestedWriteRuntime } from './nested-writes.ts';
+import type { UpdateManyGenerator } from './schema-data.ts';
+import type { CreatedResolver, Filters, TableNamedRelations } from './types.ts';
+
+/** One entry of the `updates` argument, already remapped and validated. */
+export type UpdateManyEntry = {
+  /** Column values to write, context-supplied columns stripped. */
+  set: Record<string, any>;
+  /** Nested-write operations, or `undefined` when the entry writes columns only. */
+  ops: Record<string, any> | undefined;
+  /** The entry's `where`, already combined with the row scope. */
+  filters: any;
+};
+
+/** Everything a batch runner needs; assembled by the shared resolver before the batch opens. */
+export type UpdateManyBatchCtx = {
+  /** The executor the mutation runs on — `db`, a caller's transaction, or the shared one. */
+  executor: any;
+  entries: UpdateManyEntry[];
+  table: any;
+  /** The columns each statement returns, join columns included when nested writes are on. */
+  returning: Record<string, any>;
+  /** True when at least one entry carries nested-write operations. */
+  anyNested: boolean;
+  nested: NestedWriteRuntime | undefined;
+  tableName: string;
+  context: any;
+};
+
+/** Runs the entries and returns each one's rows, in entry order. */
+export type UpdateManyBatchRunner = (ctx: UpdateManyBatchCtx) => Promise<Record<string, any>[][]>;
+
+/**
+ * The batch runner for a dialect whose driver is always asynchronous: one UPDATE per entry,
+ * awaited in input order, inside a single transaction. On a caller-supplied transaction — or
+ * the shared multi-mutation transaction opened by `runMutation` — this opens a savepoint, so
+ * the batch stays atomic without breaking the outer transaction.
+ */
+export const runUpdateManyBatch: UpdateManyBatchRunner = ({
+  executor,
+  entries,
+  table,
+  returning,
+  nested,
+  tableName,
+  context,
+}) =>
+  executor.transaction(async (tx: any) => {
+    const results: Record<string, any>[][] = [];
+    for (const entry of entries) {
+      const values = entry.ops
+        ? { ...entry.set, ...(await nested!.applyParentSide(tx, tableName, entry.ops, context)) }
+        : entry.set;
+
+      // Same as the single update: an entry with no column values reads the rows its
+      // `where` matched so the nested operations have something to attach to.
+      const writes = Object.keys(values).length > 0;
+      let query = writes ? tx.update(table).set(values) : tx.select(returning).from(table);
+      if (entry.filters) {
+        query = query.where(entry.filters) as any;
+      }
+      const rows = (await (writes ? (query.returning(returning) as any) : query)) as Record<string, any>[];
+
+      if (entry.ops) {
+        await nested!.applyChildSide(tx, tableName, entry.ops, rows, context);
+      }
+      results.push(rows);
+    }
+    return results;
+  });
+
+/**
+ * Builds a dialect's `update<Table>Many` generator.
+ *
+ * `update<Table>Many` is a batch update with a per-entry `set` and `where`. The entries run
+ * as one UPDATE statement each, in input order, inside a single transaction (a savepoint when
+ * the request context already carries one), so a failing entry rolls the whole batch back and
+ * a row matched by several entries sees them applied in order. The result lists each entry's
+ * updated rows in entry order, with `null` standing in for an entry whose `where` matched no
+ * rows, so the common one-row-per-entry case stays aligned with the input.
+ *
+ * @param primaryKeyPropNames the dialect's composite-aware primary-key lookup
+ * @param runBatch how the entries execute; defaults to {@link runUpdateManyBatch}
+ */
+export const createUpdateManyGenerator = (
+  primaryKeyPropNames: (table: any) => string[],
+  runBatch: UpdateManyBatchRunner = runUpdateManyBatch,
+): UpdateManyGenerator => {
+  return (
+    db: any,
+    tableName: string,
+    table: any,
+    tables: Record<string, Table>,
+    relationMap: Record<string, Record<string, TableNamedRelations>>,
+    updateManyInput: GraphQLInputObjectType,
+    fieldName: string,
+    typeName: string,
+    typeNameMapper?: TypeNameMapper,
+    filterCtx?: RelationFilterBase,
+    txCtx?: MutationTxCtx,
+    nested?: NestedWriteRuntime,
+    limits?: LimitPolicyFor,
+    policies?: ResolverPolicies,
+  ): CreatedResolver => {
+    const queryArgs = {
+      updates: {
+        type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(updateManyInput))),
+      },
+    } as const satisfies GraphQLFieldConfigArgumentMap;
+
+    // Derived once at build time — PK prop names don't change per request.
+    const pkNames = primaryKeyPropNames(table);
+    const hooks = policies?.onWrite?.(tableName, 'updateMany');
+
+    return {
+      name: fieldName,
+      resolver: async (
+        _source,
+        args: { updates: { where?: Filters<Table>; set: Record<string, any> }[] },
+        context,
+        info,
+      ) => {
+        try {
+          return await runMutation(
+            db,
+            context,
+            info,
+            txCtx,
+            async (executor) => {
+              const { updates } = args;
+              if (!updates.length) {
+                throw new GraphQLError('No updates were provided!');
+              }
+              await runWriteHook(hooks, 'before', {
+                table: tableName,
+                operation: 'updateMany',
+                single: false,
+                args,
+                context,
+                info,
+                tx: executor,
+              });
+              const scope = policies?.scope?.(context);
+              const contextColumns = policies?.contextValues?.(tableName);
+
+              const parsedInfo = parseResolveInfo(info, {
+                deep: true,
+              }) as ResolveTree;
+
+              const { columns, hasRelations, withParams } = prepareMutationRelationColumns({
+                relationMap,
+                tables,
+                tableName,
+                typeName,
+                typeNameMapper,
+                table,
+                pkNames,
+                parsedInfo,
+                limits,
+                scope,
+                defaultOrderBy: policies?.defaultOrderBy,
+              });
+
+              // Remap and validate every entry before the transaction opens, so a malformed
+              // entry rejects the request instead of rolling back mid-batch.
+              const entries: UpdateManyEntry[] = updates.map(({ where, set }) => {
+                const split = nested?.enabled(tableName) ? nested.split(tableName, set) : undefined;
+                const ops = split && nested!.hasOps(split.ops) ? split.ops : undefined;
+                const input = stripContextValues(
+                  remapUpdateInput(split ? split.columns : set, table, tableName),
+                  contextColumns,
+                );
+                // An entry that only writes through a relation still has work to do.
+                if (!Object.keys(input).length && !ops) {
+                  throw new GraphQLError('Unable to update with no values specified!');
+                }
+                return {
+                  set: input,
+                  ops,
+                  filters: withScope(
+                    scope,
+                    tableName,
+                    table,
+                    where
+                      ? extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName))
+                      : undefined,
+                  ),
+                };
+              });
+
+              const anyNested = entries.some((entry) => entry.ops);
+              const returning = anyNested
+                ? nested!.withJoinColumns(
+                    tableName,
+                    mergedOps(entries.map((entry) => ({ ops: entry.ops ?? {} }))),
+                    { ...columns },
+                    table,
+                  )
+                : columns;
+
+              const perEntry = await runBatch({
+                executor,
+                entries,
+                table,
+                returning,
+                anyNested,
+                nested,
+                tableName,
+                context,
+              });
+
+              const flatRows = perEntry.flat();
+              await runWriteHook(hooks, 'after', {
+                table: tableName,
+                operation: 'updateMany',
+                single: false,
+                args,
+                rows: flatRows,
+                context,
+                info,
+                tx: executor,
+              });
+
+              const enriched = hasRelations
+                ? await eagerLoadMutationRelations(executor, tableName, flatRows, pkNames, withParams)
+                : flatRows;
+
+              // Rebuild the per-entry slots: a no-match entry contributes `null`, a multi-match
+              // entry contributes each of its rows.
+              const output: (Record<string, any> | null)[] = [];
+              let offset = 0;
+              for (const rows of perEntry) {
+                if (!rows.length) {
+                  output.push(null);
+                  continue;
+                }
+                for (let i = 0; i < rows.length; i++) {
+                  output.push(remapToGraphQLSingleOutput(enriched[offset + i], tableName, table, relationMap));
+                }
+                offset += rows.length;
+              }
+              return output;
+            },
+            !!hooks,
+          );
+        } catch (e) {
+          throw toGraphQLError(e);
+        }
+      },
+      args: queryArgs,
+    };
+  };
+};


### PR DESCRIPTION
Stacked on #99 → #98 → #94. Review the top commit only.

## What

`update<Table>Many` was duplicated between the pg and sqlite builders — 179 and 220 lines. Diffing them shows they are identical from the argument map through the per-entry remap and validation, the nested-write split, the write hooks, relation enrichment and the per-entry `null`-slot rebuild. Roughly 150 lines of that.

They differ in exactly one place: how the batch executes inside its transaction.

## How

`src/util/builders/update-many.ts` holds the shared resolver. `createUpdateManyGenerator(primaryKeyPropNames, runBatch?)` builds a dialect's generator; the one difference is the `UpdateManyBatchRunner` hook, handed everything it needs (`executor`, `entries`, `table`, `returning`, `anyNested`, `nested`, `tableName`, `context`) and returning each entry's rows in entry order.

- **`runUpdateManyBatch`** — the default, and exactly what pg had: one UPDATE per entry, awaited in input order, inside a single `executor.transaction` (a savepoint when the request already carries one).
- **`runSqliteUpdateManyBatch`** — stays in `sqlite.ts`. A synchronous driver (better-sqlite3) commits the moment its transaction callback returns, so sqlite cannot hand it an async callback: it probes the driver kind from the first statement's result and runs the entries synchronously via `.all()` when there is nothing to await. That is a real driver constraint, not drift, so it stays dialect-local.

pg's generator is now a single line. sqlite keeps its runner and nothing else.

## Numbers

- `src/util/builders/pg.ts`: 552 → 350 lines
- `src/util/builders/sqlite.ts`: 454 → 289 lines
- `src/util/builders/update-many.ts`: +287 lines
- net **−80**, with ~150 lines of duplicated logic collapsed to one copy

## Verification

- `npm run typecheck` — both projects clean
- `npx biome check` — clean
- `npx vitest run tests/pglite tests/sqlite*.test.ts` — 70 files, **1044 passed**
- `npx vitest run tests/pg.test.ts tests/mysql.test.ts tests/pg-custom.test.ts tests/mysql-custom.test.ts` — 4 files, **180 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)