### PR TITLE
fix: name the real cause when a schema table is missing from the relations config

### DIFF
--- a/src/util/builders/errors.ts
+++ b/src/util/builders/errors.ts
@@ -1,0 +1,15 @@
+/**
+ * A table the drizzle instance has no relational query builder for.
+ *
+ * `db.query` is keyed by the *relations* config, while SQLite and MySQL take the schema
+ * separately — so a table passed as `schema` but left out of `buildRelations`/`defineRelations`
+ * is generated for, then has nothing to read through. (A table with no relations of its own is
+ * fine; it only has to appear in the relations config.) PostgreSQL cannot reach this: its
+ * schema is derived from the relations config, so the two can never disagree.
+ *
+ * The old message blamed a missing `schema`, which is the one thing the caller did do.
+ */
+export const missingQueryBuilderError = (tableName: string): Error =>
+  new Error(
+    `Drizzle-GraphQL Error: Table '${tableName}' was passed to the drizzle constructor's schema but is missing from its relations config, so drizzle-orm exposes no query builder for it. Include it in the relations you pass to buildRelations/defineRelations, or drop it from the generated schema with config.exclude.tables.`,
+  );

--- a/src/util/builders/mysql.ts
+++ b/src/util/builders/mysql.ts
@@ -76,6 +76,7 @@ import {
   generateGroupByType,
   generateHavingInput,
 } from './aggregates.ts';
+import { missingQueryBuilderError } from './errors.ts';
 import { remapUpdateInput } from './field-updates.ts';
 import type {
   CreatedResolver,
@@ -105,9 +106,7 @@ const generateSelectArray = (
     | RelationalQueryBuilder<any, any, any>
     | undefined;
   if (!queryBase) {
-    throw new Error(
-      `Drizzle-GraphQL Error: Table ${tableName} not found in drizzle instance. Did you forget to pass schema to drizzle constructor?`,
-    );
+    throw missingQueryBuilderError(tableName);
   }
 
   const table = tables[tableName]!;
@@ -178,9 +177,7 @@ const generateSelectSingle = (
     | RelationalQueryBuilder<any, any, any>
     | undefined;
   if (!queryBase) {
-    throw new Error(
-      `Drizzle-GraphQL Error: Table ${tableName} not found in drizzle instance. Did you forget to pass schema to drizzle constructor?`,
-    );
+    throw missingQueryBuilderError(tableName);
   }
 
   const queryArgs = selectSingleArgs(orderArgs, filterArgs, policies?.softDelete, tableName);

--- a/src/util/builders/sqlite.ts
+++ b/src/util/builders/sqlite.ts
@@ -22,6 +22,7 @@ import {
   toGraphQLError,
   withDefaultOrderBy,
 } from '../builders/common.ts';
+import { missingQueryBuilderError } from './errors.ts';
 import { createSchemaDataGenerator } from './schema-data.ts';
 import type { CreatedResolver, SchemaGeneratorOptions, TableNamedRelations, TableSelectArgs } from './types.ts';
 import { createUpdateManyGenerator, type UpdateManyBatchRunner, type UpdateManyEntry } from './update-many.ts';
@@ -45,9 +46,7 @@ const generateSelectArray = (
     | RelationalQueryBuilder<any, any, any>
     | undefined;
   if (!queryBase) {
-    throw new Error(
-      `Drizzle-GraphQL Error: Table ${tableName} not found in drizzle instance. Did you forget to pass schema to drizzle constructor?`,
-    );
+    throw missingQueryBuilderError(tableName);
   }
 
   const table = tables[tableName]!;
@@ -118,9 +117,7 @@ const generateSelectSingle = (
     | RelationalQueryBuilder<any, any, any>
     | undefined;
   if (!queryBase) {
-    throw new Error(
-      `Drizzle-GraphQL Error: Table ${tableName} not found in drizzle instance. Did you forget to pass schema to drizzle constructor?`,
-    );
+    throw missingQueryBuilderError(tableName);
   }
 
   const queryArgs = selectSingleArgs(orderArgs, filterArgs, policies?.softDelete, tableName);

--- a/tests/sqlite-missing-relations.test.ts
+++ b/tests/sqlite-missing-relations.test.ts
@@ -1,0 +1,44 @@
+import { createClient } from '@libsql/client';
+import { buildRelations } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/libsql';
+import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { describe, expect, it } from 'vitest';
+import { buildSchema } from '@/index';
+
+// `db.query` is keyed by the relations config, while SQLite and MySQL take the schema
+// separately — so these two can disagree. A table in one but not the other used to fail with
+// "Did you forget to pass schema to drizzle constructor?", which is the one thing the caller
+// did do.
+
+const Users = sqliteTable('users', {
+  id: integer('id').primaryKey(),
+  name: text('name').notNull(),
+});
+
+const Loner = sqliteTable('loner', {
+  id: integer('id').primaryKey(),
+  note: text('note'),
+});
+
+const dbWith = (relationTables: Record<string, any>) =>
+  drizzle({
+    client: createClient({ url: ':memory:' }),
+    schema: { Users, Loner },
+    relations: buildRelations(relationTables, () => ({})),
+  } as any);
+
+describe('a schema table missing from the relations config', () => {
+  it('names the real cause', () => {
+    expect(() => buildSchema(dbWith({ Users }) as any)).toThrow(
+      /Table 'Loner' was passed to the drizzle constructor's schema but is missing from its relations config/,
+    );
+  });
+
+  it('builds once the table is in the relations config, even with no relations of its own', () => {
+    expect(() => buildSchema(dbWith({ Users, Loner }) as any)).not.toThrow();
+  });
+
+  it('builds when the table is excluded instead', () => {
+    expect(() => buildSchema(dbWith({ Users }) as any, { exclude: { tables: ['Loner'] } })).not.toThrow();
+  });
+});


### PR DESCRIPTION
Stacked on #102 → #101 → #99 → #98 → #94. Review the top commit only.

## The bug

`db.query` is keyed by the **relations** config. SQLite and MySQL take the schema *separately*, as `schema:` on the drizzle constructor. So the two can disagree — and when they do, `buildSchema` generates fields for a table it then has no query builder to read through, and fails with:

```
Drizzle-GraphQL Error: Table Loner not found in drizzle instance.
Did you forget to pass schema to drizzle constructor?
```

which blames the one thing the caller did do. Reproduced directly:

```ts
drizzle({
  client,
  schema: { Users, Loner },                       // Loner is here
  relations: buildRelations({ Users }, () => ({})), // but not here
});
// db.query keys:    [ 'Users' ]
// fullSchema keys:  [ 'Users', 'Loner' ]
```

**This is not about a table having no relations of its own.** That has always worked — `db.query` contains an entry for every table in the relations config whether or not it declares any relations, and there is now a test asserting it. The bug is only about a table missing from the relations config entirely.

## The fix

The message names the actual cause and both ways out: add the table to the relations you pass to `buildRelations`/`defineRelations`, or drop it from the generated schema with `config.exclude.tables`. It lives in `src/util/builders/errors.ts` so the two sqlite and two mysql call sites can't drift.

## On PostgreSQL

PG cannot reach this path at all. drizzle-orm v1 rc.2 removed `fullSchema` from `PgAsyncDatabase`, so `buildSchema` derives the PG schema *from* the relations config — the two can never disagree, and `db.query[tableName]` is always defined.

A side effect worth knowing about: that also makes pg's ~140-line plain-select fallback for tables without query-builder support unreachable under drizzle-orm v1. It's dead weight now, but removing it is a separate call from fixing an error message, so this PR leaves it alone. Happy to follow up if you want it gone.

## Tests

`tests/sqlite-missing-relations.test.ts` — three cases:

1. the message names the real cause
2. a table **with no relations of its own** builds fine once it's in the relations config
3. `config.exclude.tables` is a working escape hatch

## Verification

- `npm run typecheck` — both projects clean
- `npx biome check` — clean
- `npx vitest run tests/pglite tests/sqlite*.test.ts` — 71 files, **1047 passed** (+3 new)
- `npx vitest run tests/pg.test.ts tests/mysql.test.ts tests/pg-custom.test.ts tests/mysql-custom.test.ts` — 4 files, **180 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)