### PR TITLE
refactor(builders): put MySQL on the shared build path

### DIFF
--- a/src/util/builders/build-context.ts
+++ b/src/util/builders/build-context.ts
@@ -1,0 +1,533 @@
+// =============================================================================
+// The part of a schema build that has nothing to do with the dialect.
+//
+// Every builder starts the same way: find the tables, resolve the feature flags,
+// flatten the relation graph, register the per-build scalar/enum/exclusion state,
+// assemble the filter context and the type cache, and generate each table's types.
+// Every builder ends the same way too, and the read half in between — the two
+// select fields, the aggregate field and the group-by field — is identical down to
+// the argument lists.
+//
+// This module holds all three stretches once. What a dialect still owns is its
+// mutation half: PostgreSQL and SQLite return the rows they wrote, MySQL cannot,
+// so its mutation fields, return types and resolvers differ throughout.
+//
+// Keeping this shared is not just deduplication. A feature added to the prelude
+// used to reach two of the three dialects — `uniqueKeyFilters` (#90) shipped as a
+// flag MySQL accepted and never acted on, because MySQL carried its own copy.
+// =============================================================================
+
+import { is, One, type Table } from 'drizzle-orm';
+import type { GraphQLFieldConfig, GraphQLInputObjectType, GraphQLObjectType } from 'graphql';
+import { GraphQLList, GraphQLNonNull } from 'graphql';
+import {
+  aggregateFieldComplexity,
+  attachTargetPrimaryKeys,
+  bindPolicies,
+  buildNamedRelations,
+  buildUniqueKeyMap,
+  createMutationTxCtx,
+  createRelationResolverFactory,
+  extractRelationJoinColumns,
+  generateTableTypes,
+  getUniqueColumnSets,
+  type LimitPolicyFor,
+  listFieldComplexity,
+  type MutationTxCtx,
+  type NullOrdering,
+  pruneNonEagerRelations,
+  type RelationAggregateFactory,
+  type RelationFilterBase,
+  type RelationResolverFactory,
+  type ResolverFieldNames,
+  type ResolverPolicies,
+  registerColumnExclusions,
+  type TablesRelationalConfig,
+  type TypeCacheCtx,
+  type TypeNameMapper,
+  type UniqueKeyMap,
+  visibleColumns,
+} from '../builders/common.ts';
+import type { TableFieldExtensionFactory } from '../extensions.ts';
+import { resolveTableFeatures } from '../features.ts';
+import { registerEnumConfig, registerScalarOverrides } from '../type-converter/index.ts';
+import {
+  createRelationAggregateFactory,
+  generateAggregate,
+  generateAggregateTypes,
+  generateGroupBy,
+  generateGroupByEnum,
+  generateGroupByType,
+  generateHavingInput,
+} from './aggregates.ts';
+import {
+  buildNestedWritePlans,
+  createNestedWriteRuntime,
+  createNestedWriteTypes,
+  type NestedWriteRuntime,
+  type NestedWriteTypes,
+} from './nested-writes.ts';
+import { createSelectGenerators } from './select.ts';
+import type { GeneratedTableTypes, SchemaGeneratorOptions, TableFeatures, TableNamedRelations } from './types.ts';
+
+/** What {@link createSchemaBuilder} cannot work out for itself. */
+export type SchemaBuildAdapter<WithReturning extends boolean = boolean> = {
+  /** The dialect's table class, used with `is()` to pick tables out of the schema module. */
+  tableClass: any;
+  /**
+   * The dialect's `getTableConfig`. The three dialects expose the same
+   * `{ primaryKeys, uniqueConstraints, indexes }` shape from different modules.
+   */
+  getTableConfig: (table: any) => any;
+  /** Primary-key property names, composite-aware — built on the dialect's `getTableConfig`. */
+  primaryKeyPropNames: (table: any) => string[];
+  /** How the dialect's `ORDER BY` sorts NULLs, which relation pagination has to match. */
+  nullOrdering: NullOrdering;
+  /**
+   * Whether a write can return the rows it wrote. `false` on MySQL, which has no `RETURNING`
+   * clause — its table types carry no `${Table}Item` outputs because no mutation returns one.
+   */
+  returnsRows: WithReturning;
+  /**
+   * Dialect-specific validation of the database handle against the requested options, run
+   * once the tables are known but before anything is generated. SQLite uses it to reject
+   * features a synchronous driver cannot support; MySQL to reject nested writes.
+   */
+  preflight?: (db: any, options: SchemaGeneratorOptions) => void;
+};
+
+/**
+ * Everything a build accumulates before its root fields exist, handed to the dialect so it
+ * can generate its mutation half against the same tables, caches and policies the shared
+ * half used.
+ */
+export type SchemaBuildContext<WithReturning extends boolean = boolean> = {
+  db: any;
+  /** The schema module as given, including whatever is not a table. */
+  schema: Record<string, unknown>;
+  options: SchemaGeneratorOptions;
+  /** The tables this build covers — excluded ones already dropped. */
+  tables: Record<string, Table>;
+  tableEntries: [string, Table][];
+  /** This table's feature flags, with any per-table predicate already run. */
+  featureOf: (tableName: string) => TableFeatures;
+  /** Whether any table in the build wants a feature — i.e. whether to build shared machinery. */
+  anyTable: (feature: keyof TableFeatures) => boolean;
+  /** The full relation graph, used by type generation. */
+  namedRelations: Record<string, Record<string, TableNamedRelations>>;
+  /** The relations to eager-load via `with:`, used by the resolvers. */
+  eagerRelations: Record<string, Record<string, TableNamedRelations>>;
+  filterCtx: RelationFilterBase;
+  /** The build's policies as configured, before binding. */
+  tablePolicies: SchemaGeneratorOptions['policies'];
+  policies: ResolverPolicies | undefined;
+  softDeleteOf: NonNullable<SchemaGeneratorOptions['policies']>['softDelete'];
+  resolverFactory: RelationResolverFactory;
+  cacheCtx: TypeCacheCtx;
+  nestedRuntime: NestedWriteRuntime | undefined;
+  nestedTypes: NestedWriteTypes | undefined;
+  /** Undefined unless `transactions: 'auto'`; its field-name set is filled by `finalizeBuild`. */
+  mutationTxCtx: MutationTxCtx | undefined;
+  gqlSchemaTypes: Record<string, GeneratedTableTypes<WithReturning>>;
+  // A plain map rather than graphql's `ThunkObjMap`, which is a union with a thunk and so
+  // cannot be indexed through a property. Still assignable wherever a thunk map is wanted.
+  queries: Record<string, GraphQLFieldConfig<any, any>>;
+  mutations: Record<string, GraphQLFieldConfig<any, any>>;
+  inputs: Record<string, GraphQLInputObjectType>;
+  outputs: Record<string, GraphQLObjectType>;
+  limits: LimitPolicyFor | undefined;
+  typeNameMapper: TypeNameMapper | undefined;
+};
+
+/**
+ * Binds a dialect and returns the shared halves of its build.
+ *
+ * Called once per dialect module at import time, so the select generators — which close over
+ * the dialect's primary-key lookup and NULL ordering — are built once rather than per
+ * `buildSchema`.
+ */
+export const createSchemaBuilder = <WithReturning extends boolean>(adapter: SchemaBuildAdapter<WithReturning>) => {
+  const primaryKeyPropNames = adapter.primaryKeyPropNames;
+  const uniqueColumnSets = (table: Table): string[][] => getUniqueColumnSets(table, adapter.getTableConfig);
+  const { generateSelectArray, generateSelectSingle } = createSelectGenerators(
+    primaryKeyPropNames,
+    adapter.nullOrdering,
+  );
+
+  /** Everything up to and including each table's generated types. */
+  const prepareBuild = (
+    db: any,
+    schema: Record<string, unknown>,
+    relations: TablesRelationalConfig,
+    options: SchemaGeneratorOptions,
+  ): SchemaBuildContext<WithReturning> => {
+    const { relationsDepthLimit, prefixes, typeNameMapper, shouldEagerLoad, features, complexity, limits } = options;
+    const schemaEntries = Object.entries(schema);
+    // Excluded tables are dropped here, before anything reads `tableEntries` — which also makes
+    // `buildNamedRelations` skip every relation pointing at one, since it resolves targets
+    // through this list.
+    const excludedTables = new Set(options.exclude?.tables ?? []);
+    const tableEntries = schemaEntries.filter(
+      ([key, value]) => is(value, adapter.tableClass) && !excludedTables.has(key),
+    ) as [string, Table][];
+    const tables = Object.fromEntries(tableEntries) as Record<string, Table>;
+
+    // A feature flag may be a per-table predicate, so every flag is resolved against the table
+    // it applies to. `anyTable` answers the build-wide question — whether machinery shared
+    // across tables is worth constructing at all.
+    const featureOf = resolveTableFeatures(features);
+    const anyTable = (feature: keyof TableFeatures) => tableEntries.some(([name]) => featureOf(name)[feature]);
+
+    if (!tableEntries.length) {
+      throw new Error(
+        "Drizzle-GraphQL Error: No tables detected in Drizzle-ORM's database instance. Did you forget to pass schema to drizzle constructor?",
+      );
+    }
+
+    // Resolve scalar overrides into the type-converter's registry before any type generation —
+    // every subsequent column→GraphQL type decision and runtime value remap consults it.
+    registerScalarOverrides(tables, options);
+    // Same lifecycle: the enum registry is per-build, so a second build never reuses the first
+    // build's enum types (and with them its naming decisions).
+    registerEnumConfig(options);
+    // And the same for column exclusions: a per-build registry read by every site that decides
+    // what the schema contains, reset here so a rebuild never inherits the previous build's.
+    registerColumnExclusions(tables, options.exclude);
+
+    // Flatten drizzle-orm v1 TablesRelationalConfig into the canonical shape
+    // used throughout common.ts: Record<tableName, Record<relName, TableNamedRelations>>
+    const namedRelations = buildNamedRelations(relations ?? {}, tableEntries);
+    // Relations *into* an excluded table are already gone (their target no longer resolves);
+    // relations *out of* one have no type left to hang a field on.
+    for (const excluded of excludedTables) {
+      delete namedRelations[excluded];
+    }
+    // Record each relation target's primary key (composite-aware) so paginated relations
+    // default to a deterministic PK order. Must run before pruning / type generation, which
+    // share these entry objects.
+    attachTargetPrimaryKeys(namedRelations, tables, (table) => primaryKeyPropNames(table));
+    // Relations to eager-load via `with:`. Query/mutation resolvers use this pruned map so
+    // opted-out relations never overfetch; type generation keeps the full map so their
+    // fields still exist and resolve lazily.
+    const eagerRelations = pruneNonEagerRelations(namedRelations, shouldEagerLoad);
+
+    // A `where` field per compound unique constraint, for the tables that asked for one. Built
+    // once and shared by the input types and the resolvers: the fields a request may spell and
+    // the fields a resolver understands are the same map, so neither can drift from the other.
+    const uniqueKeys: Record<string, UniqueKeyMap> = {};
+    for (const [tableName, table] of tableEntries) {
+      if (!featureOf(tableName).uniqueKeyFilters) {
+        continue;
+      }
+      // Whatever the filter input already offers under a name keeps it — columns are added
+      // first, then relations, and a key field last.
+      const taken = new Set([...Object.keys(visibleColumns(table)), ...Object.keys(namedRelations[tableName] ?? {})]);
+      const map = buildUniqueKeyMap(uniqueColumnSets(table), taken);
+      if (Object.keys(map).length) {
+        uniqueKeys[tableName] = map;
+      }
+    }
+
+    const filterCtx: RelationFilterBase = { tables, relationMap: namedRelations, uniqueKeys };
+
+    // The row scope compiled against this build's relation graph, plus the columns whose value
+    // the server supplies. Both stay undefined unless configured.
+    const tablePolicies = options.policies;
+    const contextValuesOf = tablePolicies?.contextValues;
+    const softDeleteOf = tablePolicies?.softDelete;
+    const policies = bindPolicies(tablePolicies, filterCtx);
+
+    const resolverFactory: RelationResolverFactory = createRelationResolverFactory(
+      db,
+      tables,
+      adapter.nullOrdering,
+      filterCtx,
+      limits,
+      tablePolicies,
+    );
+
+    // Fresh cache per build — prevents type name collisions when buildSchema() is called
+    // multiple times.
+    const cacheCtx: TypeCacheCtx = {
+      typeName: options.typeName ?? ((info) => info.defaultName),
+      genericFilterCache: new Map(),
+      objectTypeCache: new Map(),
+      relationFieldContainers: new Map(),
+      fullyBuiltTables: new Set(),
+      relationTypeCache: new Map(),
+      selectFieldCache: new WeakMap(),
+      filterFieldCache: new WeakMap(),
+      orderTypeCache: new WeakMap(),
+      filterTypeCache: new WeakMap(),
+      listRelationFilterCache: new Map(),
+      aggregateTypeCache: new Map(),
+      complexity,
+      limits,
+      docs: options.docs ?? {},
+      primaryKeyOf: (name) => (tables[name] ? primaryKeyPropNames(tables[name] as Table) : []),
+      contextValuesOf,
+      softDeleteOf,
+      featureOf,
+      uniqueKeysOf: (tableName) => uniqueKeys[tableName],
+    };
+
+    adapter.preflight?.(db, options);
+
+    // Nested writes: the plans decide which relations are writable at all, the types add their
+    // fields to the create/update inputs, and the runtime executes them. All three are left
+    // undefined when the feature is off, so the inputs and the resolvers stay as they were.
+    const nestedPlans = features.nestedWrites
+      ? buildNestedWritePlans(
+          tables,
+          namedRelations,
+          (target) => uniqueColumnSets(target as Table),
+          (target) => primaryKeyPropNames(target as Table),
+          extractRelationJoinColumns,
+        )
+      : undefined;
+    const nestedTypes = nestedPlans
+      ? createNestedWriteTypes({ plans: nestedPlans, cacheCtx, typeNameMapper })
+      : undefined;
+    const nestedRuntime = nestedPlans
+      ? createNestedWriteRuntime({
+          plans: nestedPlans,
+          filterCtx,
+          policies: tablePolicies,
+          contextValues: contextValuesOf,
+        })
+      : undefined;
+
+    // Built when at least one table wants relation aggregates; a table that has them off is
+    // handed `undefined` below, so `generateTableTypes` emits no `${relation}Aggregate` fields
+    // on its object type.
+    const relationAggregateFactory: RelationAggregateFactory | undefined = anyTable('relationAggregates')
+      ? createRelationAggregateFactory(db, tables, cacheCtx, typeNameMapper, filterCtx, tablePolicies)
+      : undefined;
+
+    const gqlSchemaTypes = Object.fromEntries(
+      Object.entries(tables).map(([tableName, _table]) => [
+        tableName,
+        generateTableTypes(
+          tableName,
+          tables,
+          namedRelations,
+          adapter.returnsRows,
+          relationsDepthLimit,
+          cacheCtx,
+          typeNameMapper,
+          prefixes.insert,
+          prefixes.update,
+          resolverFactory,
+          featureOf(tableName).relationAggregates ? relationAggregateFactory : undefined,
+          nestedTypes,
+        ),
+      ]),
+    ) as Record<string, GeneratedTableTypes<WithReturning>>;
+
+    return {
+      db,
+      schema,
+      options,
+      tables,
+      tableEntries,
+      featureOf,
+      anyTable,
+      namedRelations,
+      eagerRelations,
+      filterCtx,
+      tablePolicies,
+      policies,
+      softDeleteOf,
+      resolverFactory,
+      cacheCtx,
+      nestedRuntime,
+      nestedTypes,
+      // Shared per-request transaction machinery for multi-mutation documents; undefined
+      // unless `transactions: 'auto'`. Its field-name set is filled once all mutations exist.
+      mutationTxCtx: createMutationTxCtx(options.transactions),
+      gqlSchemaTypes,
+      queries: {},
+      mutations: {},
+      inputs: {},
+      outputs: {},
+      limits,
+      typeNameMapper,
+    };
+  };
+
+  /**
+   * The table's read fields — both selects, the aggregate and the group-by — generated and
+   * hung off the query root. Identical for every dialect: a read returns rows everywhere.
+   *
+   * The types it built are returned rather than registered, because where they land in the
+   * schema's type map is the caller's business — MySQL has no `${Table}Item` output to
+   * interleave them with, and the printed order of the two schemas should not drift.
+   */
+  const addReadFields = (
+    ctx: SchemaBuildContext<WithReturning>,
+    tableName: string,
+    names: ResolverFieldNames,
+    tableTypes: GeneratedTableTypes<WithReturning>,
+    drizzleMeta: TableFieldExtensionFactory,
+  ) => {
+    const { db, tables, cacheCtx, filterCtx, eagerRelations, policies, tablePolicies, limits, typeNameMapper } = ctx;
+    const { complexity } = ctx.options;
+    const table = tables[tableName] as Table;
+    const tableFeatures = ctx.featureOf(tableName);
+    const { tableFilters, tableOrder } = tableTypes.inputs;
+    const { selectSingleOutput, selectArrOutput } = tableTypes.outputs;
+    const { typeName, listFieldName, singleFieldName, aggregateFieldName, groupByFieldName } = names;
+
+    const selectArrGenerated = generateSelectArray(
+      db,
+      tableName,
+      tables,
+      eagerRelations,
+      tableOrder,
+      tableFilters,
+      listFieldName,
+      typeName,
+      typeNameMapper,
+      filterCtx,
+      tableFeatures.distinct,
+      limits,
+      policies,
+      cacheCtx.typeName,
+    );
+    const selectSingleGenerated = generateSelectSingle(
+      db,
+      tableName,
+      tables,
+      eagerRelations,
+      tableOrder,
+      tableFilters,
+      singleFieldName,
+      typeName,
+      typeNameMapper,
+      filterCtx,
+      limits,
+      policies,
+      cacheCtx.typeName,
+    );
+
+    const aggregateType = tableFeatures.aggregates
+      ? generateAggregateTypes(table, tableName, typeName, cacheCtx)
+      : undefined;
+    const aggregateGenerated = tableFeatures.aggregates
+      ? generateAggregate(
+          db,
+          tableName,
+          table,
+          typeName,
+          aggregateFieldName,
+          tableFilters,
+          filterCtx,
+          tablePolicies,
+          cacheCtx.typeName,
+        )
+      : undefined;
+
+    // The grouped result reuses the aggregate output types, so it only exists alongside them.
+    const groupByType =
+      tableFeatures.aggregates && tableFeatures.groupBy
+        ? generateGroupByType(table, tableName, typeName, cacheCtx)
+        : undefined;
+    const groupByEnum = groupByType ? generateGroupByEnum(table, tableName, typeName, cacheCtx) : undefined;
+    const havingInput = groupByEnum ? generateHavingInput(table, tableName, typeName, cacheCtx) : undefined;
+    const groupByGenerated =
+      groupByType && groupByEnum && havingInput
+        ? generateGroupBy(
+            db,
+            tableName,
+            table,
+            typeName,
+            groupByFieldName,
+            tableFilters,
+            groupByEnum,
+            havingInput,
+            filterCtx,
+            tablePolicies,
+            cacheCtx.typeName,
+          )
+        : undefined;
+
+    ctx.queries[selectArrGenerated.name] = {
+      type: selectArrOutput,
+      args: selectArrGenerated.args,
+      resolve: selectArrGenerated.resolver,
+      extensions: {
+        drizzle: drizzleMeta({ kind: 'query', operation: 'select', single: false, targetArg: 'where' }),
+        ...(complexity ? { complexity: listFieldComplexity(complexity, limits?.(tableName)) } : {}),
+      },
+    };
+    ctx.queries[selectSingleGenerated.name] = {
+      type: selectSingleOutput,
+      args: selectSingleGenerated.args,
+      resolve: selectSingleGenerated.resolver,
+      extensions: {
+        drizzle: drizzleMeta({ kind: 'query', operation: 'select', single: true, targetArg: 'where' }),
+      },
+    };
+    if (aggregateGenerated && aggregateType) {
+      ctx.queries[aggregateGenerated.name] = {
+        type: new GraphQLNonNull(aggregateType),
+        args: aggregateGenerated.args,
+        resolve: aggregateGenerated.resolver,
+        extensions: {
+          drizzle: drizzleMeta({ kind: 'aggregate', operation: 'aggregate', single: true, targetArg: 'where' }),
+          ...(complexity ? { complexity: aggregateFieldComplexity(complexity) } : {}),
+        },
+      };
+    }
+    if (groupByGenerated && groupByType) {
+      ctx.queries[groupByGenerated.name] = {
+        type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(groupByType))),
+        args: groupByGenerated.args,
+        resolve: groupByGenerated.resolver,
+        extensions: {
+          drizzle: drizzleMeta({ kind: 'aggregate', operation: 'groupBy', single: false, targetArg: 'where' }),
+          ...(complexity ? { complexity: aggregateFieldComplexity(complexity) } : {}),
+        },
+      };
+    }
+
+    return { aggregateType, groupByType, havingInput };
+  };
+
+  /** The relation field resolvers and the transaction roster, once every root field exists. */
+  const finalizeBuild = (ctx: SchemaBuildContext<WithReturning>): any => {
+    // Every generated mutation name is now known — the first mutation resolver of a request
+    // uses this set to count the document's root mutation fields (and to leave documents
+    // containing consumer-added mutations alone).
+    if (ctx.mutationTxCtx) {
+      for (const name of Object.keys(ctx.mutations)) {
+        ctx.mutationTxCtx.fieldNames.add(name);
+      }
+    }
+
+    const fieldResolvers: Record<string, Record<string, any>> = {};
+    for (const [tableName, tableRelations] of Object.entries(ctx.namedRelations)) {
+      const relResolvers: Record<string, any> = {};
+      for (const [relName, relEntry] of Object.entries(tableRelations)) {
+        const isOne = is((relEntry as any).relation ?? relEntry, One);
+        const resolver = ctx.resolverFactory({ tableName, relationName: relName, relEntry, isOne });
+        if (resolver) {
+          relResolvers[relName] = resolver;
+        }
+      }
+      if (Object.keys(relResolvers).length > 0) {
+        fieldResolvers[tableName] = relResolvers;
+      }
+    }
+
+    return {
+      queries: ctx.queries,
+      mutations: ctx.mutations,
+      inputs: ctx.inputs,
+      types: ctx.outputs,
+      fieldResolvers,
+    };
+  };
+
+  return { primaryKeyPropNames, uniqueColumnSets, prepareBuild, addReadFields, finalizeBuild };
+};

--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -126,7 +126,7 @@ export { extractRelationsParams, pruneNonEagerRelations } from './common/relatio
 export { createRelationResolverFactory } from './common/relation-resolvers.ts';
 export type { RelationAggregateFactory, RelationResolverFactory, TablesRelationalConfig } from './common/relations.ts';
 export { attachTargetPrimaryKeys, buildNamedRelations, extractRelationJoinColumns } from './common/relations.ts';
-export { computeResolverFieldNames } from './common/resolver-names.ts';
+export { computeResolverFieldNames, type ResolverFieldNames } from './common/resolver-names.ts';
 export { eagerLoadMutationRelations, runRelationalSelect } from './common/select-runtime.ts';
 export type { SelectionCtx } from './common/selected-columns.ts';
 export { extractSelectedColumnsFromTree, extractSelectedColumnsFromTreeSQLFormat } from './common/selected-columns.ts';

--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -153,3 +153,5 @@ export type {
   WriteOperation,
 } from './common/write-hooks.ts';
 export { normalizeWriteHooks, runWriteHook } from './common/write-hooks.ts';
+export type { WriteBody, WriteHookEmitter, WriteResolverSpec } from './common/write-scaffold.ts';
+export { writeResolver } from './common/write-scaffold.ts';

--- a/src/util/builders/common/resolver-names.ts
+++ b/src/util/builders/common/resolver-names.ts
@@ -4,16 +4,8 @@
 import { capitalize, uncapitalize } from '../../case-ops/index.ts';
 import type { TypeNameMapper } from './naming.ts';
 
-/**
- * Derives the generated query/mutation field names for a table from the naming config
- * (typeNameMapper + prefixes/suffixes). Shared by all three dialect builders.
- */
-export const computeResolverFieldNames = (
-  tableName: string,
-  typeNameMapper: TypeNameMapper | undefined,
-  prefixes: { insert: string; update: string; delete: string; upsert?: string; restore?: string },
-  suffixes: { list: string; single: string },
-): {
+/** The query and mutation field names one table generates. */
+export type ResolverFieldNames = {
   typeName: string;
   listFieldName: string;
   singleFieldName: string;
@@ -32,7 +24,18 @@ export const computeResolverFieldNames = (
   restoreFieldName: string;
   restoreSingleFieldName: string;
   deleteCountFieldName: string;
-} => {
+};
+
+/**
+ * Derives the generated query/mutation field names for a table from the naming config
+ * (typeNameMapper + prefixes/suffixes). Shared by all three dialect builders.
+ */
+export const computeResolverFieldNames = (
+  tableName: string,
+  typeNameMapper: TypeNameMapper | undefined,
+  prefixes: { insert: string; update: string; delete: string; upsert?: string; restore?: string },
+  suffixes: { list: string; single: string },
+): ResolverFieldNames => {
   const mapped = typeNameMapper?.(tableName);
   const typeName = mapped ? capitalize(mapped.singular) : capitalize(tableName);
   const listFieldName = (mapped?.plural ?? uncapitalize(tableName)) + suffixes.list;

--- a/src/util/builders/common/write-scaffold.ts
+++ b/src/util/builders/common/write-scaffold.ts
@@ -1,0 +1,106 @@
+// The scaffolding every generated mutation resolver shares, whatever the dialect or the
+// operation: look up the table's write hooks, run the statement inside the request's
+// transaction, emit the hooks around it, and tag anything that escapes with the field it
+// came from.
+//
+// This was written out by hand at twelve call sites — six in the MySQL builder, five in the
+// shared pg/SQLite write resolvers, one in the shared `updateMany` — and every one of them
+// spelled the same hook payload, the same `runMutation` wrapper and the same catch clause.
+// What actually differs between a MySQL insert and a PostgreSQL one is the statement in the
+// middle: MySQL has no RETURNING clause, so it writes and reports `{ isSuccess }`, while the
+// others select their rows back on the way out. That difference lives in the body below,
+// which is exactly the shape a caller passes in.
+
+import type { GraphQLFieldConfigArgumentMap } from 'graphql';
+import type { CreatedResolver } from '../types.ts';
+import { type DrizzleErrorContext, toGraphQLError, withErrorContext } from './errors.ts';
+import type { ResolverPolicies } from './policies.ts';
+import { type MutationTxCtx, runMutation } from './transactions.ts';
+import { runWriteHook, type WriteOperation } from './write-hooks.ts';
+
+/**
+ * The table's `onWrite` hooks, bound to this field and this request. A body calls `before()`
+ * ahead of its statement and `after(rows)` once the statement has returned; both are no-ops
+ * when the table registered no hook.
+ */
+export type WriteHookEmitter = {
+  before: () => Promise<void> | undefined;
+  /** @param rows the rows the write produced, or `[]` where the dialect returns none. */
+  after: (rows?: any[]) => Promise<void> | undefined;
+};
+
+/** The statement a mutation field runs, and whatever it resolves to. */
+export type WriteBody<TArgs> = (
+  params: {
+    /** The transaction (or bare `db`) the write must run on. */
+    executor: any;
+    args: TArgs;
+    context: any;
+    info: any;
+  } & WriteHookEmitter,
+) => Promise<any>;
+
+export type WriteResolverSpec<TArgs> = {
+  db: any;
+  tableName: string;
+  operation: WriteOperation;
+  /** Whether the field writes one row or a list — reported to the hooks, nothing else. */
+  single: boolean;
+  fieldName: string;
+  /** The field's GraphQL arguments, passed through untouched. */
+  args: GraphQLFieldConfigArgumentMap;
+  txCtx?: MutationTxCtx;
+  policies?: ResolverPolicies;
+  run: WriteBody<TArgs>;
+};
+
+/**
+ * Wraps one mutation body in the scaffolding above and returns the field it becomes.
+ *
+ * A field carrying a hook is forced into a transaction even when it would have run straight
+ * on `db`: a hook exists to write atomically with the mutation, and one that ran outside the
+ * transaction could not roll anything back.
+ */
+export const writeResolver = <TArgs = any>({
+  db,
+  tableName,
+  operation,
+  single,
+  fieldName,
+  args: queryArgs,
+  txCtx,
+  policies,
+  run,
+}: WriteResolverSpec<TArgs>): CreatedResolver => {
+  const hooks = policies?.onWrite?.(tableName, operation);
+  const errorCtx: DrizzleErrorContext = { table: tableName, operation, field: fieldName };
+
+  return {
+    name: fieldName,
+    resolver: async (_source, args: TArgs, context, info) => {
+      try {
+        return await runMutation(
+          db,
+          context,
+          info,
+          txCtx,
+          (executor) => {
+            const payload = { table: tableName, operation, single, args, context, info, tx: executor };
+            return run({
+              executor,
+              args,
+              context,
+              info,
+              before: () => runWriteHook(hooks, 'before', payload),
+              after: (rows) => runWriteHook(hooks, 'after', { ...payload, rows: rows ?? [] }),
+            });
+          },
+          !!hooks,
+        );
+      } catch (e) {
+        throw withErrorContext(toGraphQLError(e), errorCtx);
+      }
+    },
+    args: queryArgs,
+  };
+};

--- a/src/util/builders/mysql.ts
+++ b/src/util/builders/mysql.ts
@@ -1,6 +1,6 @@
-import { is, One, type Table } from 'drizzle-orm';
+import type { Table } from 'drizzle-orm';
 import { getTableConfig, type MySqlDatabase, MySqlTable } from 'drizzle-orm/mysql-core';
-import type { GraphQLFieldConfig, GraphQLFieldConfigArgumentMap, ThunkObjMap } from 'graphql';
+import type { GraphQLFieldConfigArgumentMap } from 'graphql';
 import {
   GraphQLBoolean,
   type GraphQLInputObjectType,
@@ -9,71 +9,42 @@ import {
   GraphQLNonNull,
   GraphQLObjectType,
 } from 'graphql';
-
 import type { GeneratedEntities } from '../../types.ts';
 import {
-  aggregateFieldComplexity,
   applyContextValues,
   applyContextValuesAll,
   assertSingleMatch,
-  attachTargetPrimaryKeys,
-  bindPolicies,
-  buildNamedRelations,
-  buildUniqueKeyMap,
   computeResolverFieldNames,
-  createMutationTxCtx,
-  createRelationResolverFactory,
   type DrizzleErrorContext,
   drizzleError,
   extractFilters,
   extractRequiredFilters,
   generateOnConflictInput,
-  generateTableTypes,
   generateUpdateManyInput,
   generateWriteCount,
   getPrimaryKeyPropNamesFromConfig,
-  getUniqueColumnSets,
   hardDeleteArg,
-  listFieldComplexity,
   type MutationTxCtx,
   mysqlValuesColumnRef,
   type OnConflictArg,
-  pruneNonEagerRelations,
-  type RelationAggregateFactory,
   type RelationFilterBase,
-  type RelationResolverFactory,
   type ResolverPolicies,
-  registerColumnExclusions,
   relationFilterCtx,
   resolveConflictPlan,
   runMutation,
   runWriteHook,
   stripContextValues,
   type TablesRelationalConfig,
-  type TypeCacheCtx,
   toGraphQLError,
-  type UniqueKeyMap,
-  visibleColumns,
   type WriteOperation,
   withErrorContext,
   withScope,
 } from '../builders/common.ts';
 import { remapFromGraphQLArrayInput, remapFromGraphQLSingleInput } from '../data-mappers/index.ts';
 import { type DrizzleMutationMeta, tableFieldExtensions } from '../extensions.ts';
-import { resolveTableFeatures } from '../features.ts';
-import { registerEnumConfig, registerScalarOverrides } from '../type-converter/index.ts';
-import {
-  createRelationAggregateFactory,
-  generateAggregate,
-  generateAggregateTypes,
-  generateGroupBy,
-  generateGroupByEnum,
-  generateGroupByType,
-  generateHavingInput,
-} from './aggregates.ts';
+import { createSchemaBuilder } from './build-context.ts';
 import { remapUpdateInput } from './field-updates.ts';
-import { createSelectGenerators } from './select.ts';
-import type { CreatedResolver, Filters, SchemaGeneratorOptions, TableFeatures } from './types.ts';
+import type { CreatedResolver, Filters, SchemaGeneratorOptions } from './types.ts';
 
 const generateInsertArray = (
   db: MySqlDatabase<any, any, any, any>,
@@ -657,11 +628,23 @@ const generateDelete = (
 const mysqlPrimaryKeyPropNames = (table: MySqlTable): string[] =>
   getPrimaryKeyPropNamesFromConfig(table, getTableConfig);
 
-// MySQL sorts NULLs as the smallest values (first in ASC).
-const { generateSelectArray, generateSelectSingle } = createSelectGenerators(
-  mysqlPrimaryKeyPropNames,
-  'nulls-smallest',
-);
+// MySQL sorts NULLs as the smallest values (first in ASC), and its writes return no rows.
+const { prepareBuild, addReadFields, finalizeBuild } = createSchemaBuilder({
+  tableClass: MySqlTable,
+  getTableConfig,
+  primaryKeyPropNames: mysqlPrimaryKeyPropNames,
+  nullOrdering: 'nulls-smallest',
+  returnsRows: false,
+  // A nested write reads the key of the row it just wrote back out of the statement that
+  // wrote it, which MySQL has no RETURNING clause for.
+  preflight: (_db, options) => {
+    if (options.features.nestedWrites) {
+      throw new Error(
+        'Drizzle-GraphQL Error: features.nestedWrites is not supported on MySQL — a nested write needs the parent row it just inserted returned to it, and MySQL has no RETURNING clause.',
+      );
+    }
+  },
+});
 
 export const generateSchemaData = <
   TDrizzleInstance extends MySqlDatabase<any, any, any, any>,
@@ -672,155 +655,28 @@ export const generateSchemaData = <
   relations: TablesRelationalConfig,
   options: SchemaGeneratorOptions,
 ): GeneratedEntities<TDrizzleInstance, TSchema> => {
-  const { relationsDepthLimit, prefixes, suffixes, typeNameMapper, shouldEagerLoad, features, complexity, limits } =
-    options;
-  const rawSchema = schema;
-  const schemaEntries = Object.entries(rawSchema);
+  const { prefixes, suffixes, typeNameMapper } = options;
 
-  // Excluded tables are dropped here, before anything reads `tableEntries` — which also makes
-  // `buildNamedRelations` skip every relation pointing at one, since it resolves targets
-  // through this list.
-  const excludedTables = new Set(options.exclude?.tables ?? []);
-  const tableEntries = schemaEntries.filter(([key, value]) => is(value, MySqlTable) && !excludedTables.has(key)) as [
-    string,
-    MySqlTable,
-  ][];
-  const tables = Object.fromEntries(tableEntries);
-
-  // A feature flag may be a per-table predicate, so every flag is resolved against the table
-  // it applies to. `anyTable` answers the build-wide question — whether machinery shared
-  // across tables is worth constructing at all.
-  const featureOf = resolveTableFeatures(features);
-  const anyTable = (feature: keyof TableFeatures) => tableEntries.some(([name]) => featureOf(name)[feature]);
-
-  if (!tableEntries.length) {
-    throw new Error(
-      "Drizzle-GraphQL Error: No tables detected in Drizzle-ORM's database instance. Did you forget to pass schema to drizzle constructor?",
-    );
-  }
-
-  // A nested write reads the key of the row it just wrote back out of the statement that
-  // wrote it, which MySQL has no RETURNING clause for.
-  if (features.nestedWrites) {
-    throw new Error(
-      'Drizzle-GraphQL Error: features.nestedWrites is not supported on MySQL — a nested write needs the parent row it just inserted returned to it, and MySQL has no RETURNING clause.',
-    );
-  }
-
-  // Resolve scalar overrides into the type-converter's registry before any type generation —
-  // every subsequent column→GraphQL type decision and runtime value remap consults it.
-  registerScalarOverrides(tables, options);
-  // Same lifecycle: the enum registry is per-build, so a second build never reuses the first
-  // build's enum types (and with them its naming decisions).
-  registerEnumConfig(options);
-  // And the same for column exclusions: a per-build registry read by every site that decides
-  // what the schema contains, reset here so a rebuild never inherits the previous build's.
-  registerColumnExclusions(tables, options.exclude);
-
-  // Build namedRelations from the drizzle-orm v1 relations config.
-  const namedRelations = buildNamedRelations(relations ?? {}, tableEntries);
-  // Relations *into* an excluded table are already gone (their target no longer resolves);
-  // relations *out of* one have no type left to hang a field on.
-  for (const excluded of excludedTables) {
-    delete namedRelations[excluded];
-  }
-  // Record each relation target's (composite-aware) primary key for deterministic
-  // paginated ordering. Must run before pruning / type generation (shared entry objects).
-  attachTargetPrimaryKeys(namedRelations, tables, mysqlPrimaryKeyPropNames);
-  // Pruned map for query resolvers' `with:`; type generation keeps the full map.
-  const eagerRelations = pruneNonEagerRelations(namedRelations, shouldEagerLoad);
-
-  // A `where` field per compound unique constraint, for the tables that asked for one. Built
-  // once and shared by the input types and the resolvers: the fields a request may spell and
-  // the fields a resolver understands are the same map, so neither can drift from the other.
-  const uniqueKeys: Record<string, UniqueKeyMap> = {};
-  for (const [tableName, table] of tableEntries) {
-    if (!featureOf(tableName).uniqueKeyFilters) {
-      continue;
-    }
-    // Whatever the filter input already offers under a name keeps it — columns are added
-    // first, then relations, and a key field last.
-    const taken = new Set([...Object.keys(visibleColumns(table)), ...Object.keys(namedRelations[tableName] ?? {})]);
-    const map = buildUniqueKeyMap(getUniqueColumnSets(table, getTableConfig), taken);
-    if (Object.keys(map).length) {
-      uniqueKeys[tableName] = map;
-    }
-  }
-
-  const filterCtx: RelationFilterBase = { tables, relationMap: namedRelations, uniqueKeys };
-
-  // The row scope compiled against this build's relation graph, plus the columns whose value
-  // the server supplies. Both stay undefined unless configured.
-  const tablePolicies = options.policies;
-  const contextValuesOf = tablePolicies?.contextValues;
-  const softDeleteOf = tablePolicies?.softDelete;
-  const policies = bindPolicies(tablePolicies, filterCtx);
-
-  const resolverFactory: RelationResolverFactory = createRelationResolverFactory(
-    db,
-    tables,
-    'nulls-smallest',
-    filterCtx,
-    limits,
-    tablePolicies,
-  );
-
-  // Fresh cache per generateSchemaData call — prevents type name collisions
-  // when buildSchema() is called multiple times.
-  const cacheCtx: TypeCacheCtx = {
-    typeName: options.typeName ?? ((info) => info.defaultName),
-    genericFilterCache: new Map(),
-    objectTypeCache: new Map(),
-    relationFieldContainers: new Map(),
-    fullyBuiltTables: new Set(),
-    relationTypeCache: new Map(),
-    selectFieldCache: new WeakMap(),
-    filterFieldCache: new WeakMap(),
-    orderTypeCache: new WeakMap(),
-    filterTypeCache: new WeakMap(),
-    listRelationFilterCache: new Map(),
-    aggregateTypeCache: new Map(),
-    complexity,
-    limits,
-    docs: options.docs ?? {},
-    primaryKeyOf: (name) => (tables[name] ? mysqlPrimaryKeyPropNames(tables[name] as MySqlTable) : []),
-    contextValuesOf,
-    softDeleteOf,
+  // Table discovery, the relation graph, the per-build registries, the filter context, the
+  // type cache and every table's types — all of it dialect-independent, so all of it lives
+  // in `build-context.ts` and is shared with the PostgreSQL/SQLite builder.
+  const ctx = prepareBuild(db, schema as Record<string, unknown>, relations, options);
+  const {
     featureOf,
-    uniqueKeysOf: (tableName) => uniqueKeys[tableName],
-  };
+    anyTable,
+    filterCtx,
+    policies,
+    softDeleteOf,
+    cacheCtx,
+    mutationTxCtx,
+    gqlSchemaTypes,
+    mutations,
+    inputs,
+    outputs,
+  } = ctx;
 
-  // Built when at least one table wants relation aggregates; a table that has them off is
-  // handed `undefined` below, so `generateTableTypes` emits no `${relation}Aggregate` fields
-  // on its object type.
-  const relationAggregateFactory: RelationAggregateFactory | undefined = anyTable('relationAggregates')
-    ? createRelationAggregateFactory(db, tables, cacheCtx, typeNameMapper, filterCtx, tablePolicies)
-    : undefined;
-
-  const queries: ThunkObjMap<GraphQLFieldConfig<any, any>> = {};
-  const mutations: ThunkObjMap<GraphQLFieldConfig<any, any>> = {};
-  // One per schema build: every mutation resolver shares it so a multi-mutation request can
-  // ride a single transaction. Undefined unless transactions were requested.
-  const mutationTxCtx = createMutationTxCtx(options.transactions);
-  const gqlSchemaTypes = Object.fromEntries(
-    Object.entries(tables).map(([tableName, _table]) => [
-      tableName,
-      generateTableTypes(
-        tableName,
-        tables,
-        namedRelations,
-        false,
-        relationsDepthLimit,
-        cacheCtx,
-        typeNameMapper,
-        prefixes.insert,
-        prefixes.update,
-        resolverFactory,
-        featureOf(tableName).relationAggregates ? relationAggregateFactory : undefined,
-      ),
-    ]),
-  );
-
+  // MySQL cannot return the rows a write touched, so every mutation reports only whether it
+  // succeeded — one shared type for the whole build.
   const mutationReturnType = new GraphQLObjectType({
     name: cacheCtx.typeName({ kind: 'shared', defaultName: 'MutationReturn' }),
     fields: {
@@ -829,9 +685,6 @@ export const generateSchemaData = <
       },
     },
   });
-
-  const inputs: Record<string, GraphQLInputObjectType> = {};
-  const outputs: Record<string, GraphQLObjectType> = {};
   // Every MySQL mutation returns it, so it only belongs in the type map when at least one
   // mutation is generated.
   if ((['insert', 'upsert', 'update', 'delete'] as const).some((feature) => anyTable(feature))) {
@@ -845,15 +698,12 @@ export const generateSchemaData = <
     // so a wrapper can read a field's identity instead of parsing its configurable name.
     const drizzleMeta = tableFieldExtensions(tableName, mysqlPrimaryKeyPropNames(schema[tableName] as MySqlTable));
     const { insertInput, updateInput, tableFilters, tableOrder } = tableTypes.inputs;
-    const { selectSingleOutput, selectArrOutput } = tableTypes.outputs;
+    const { selectSingleOutput } = tableTypes.outputs;
 
     // Compute field names using the mapper logic
+    const names = computeResolverFieldNames(tableName, typeNameMapper, prefixes, suffixes);
     const {
       typeName,
-      listFieldName,
-      singleFieldName,
-      aggregateFieldName,
-      groupByFieldName,
       createArrayFieldName,
       createSingleFieldName,
       upsertArrayFieldName,
@@ -867,43 +717,16 @@ export const generateSchemaData = <
       restoreFieldName,
       restoreSingleFieldName,
       deleteCountFieldName,
-    } = computeResolverFieldNames(tableName, typeNameMapper, prefixes, suffixes);
+    } = names;
     // A table that marks rows deleted instead of removing them also gets the mutation that
     // reverses it — clearing the column through an ordinary update is not possible, since the
     // column is not in the update input and a marked row is invisible to a `where` anyway.
     const softDeleteInfo = softDeleteOf?.(tableName);
 
-    const selectArrGenerated = generateSelectArray(
-      db,
-      tableName,
-      tables,
-      eagerRelations,
-      tableOrder,
-      tableFilters,
-      listFieldName,
-      typeName,
-      typeNameMapper,
-      filterCtx,
-      tableFeatures.distinct,
-      limits,
-      policies,
-      cacheCtx.typeName,
-    );
-    const selectSingleGenerated = generateSelectSingle(
-      db,
-      tableName,
-      tables,
-      eagerRelations,
-      tableOrder,
-      tableFilters,
-      singleFieldName,
-      typeName,
-      typeNameMapper,
-      filterCtx,
-      limits,
-      policies,
-      cacheCtx.typeName,
-    );
+    // Both selects, the aggregate and the group-by: generated and hung off the query root
+    // by the shared builder, since a read is a read on every dialect.
+    const { aggregateType, groupByType, havingInput } = addReadFields(ctx, tableName, names, tableTypes, drizzleMeta);
+
     const insertArrGenerated = tableFeatures.insert
       ? generateInsertArray(
           db,
@@ -1108,90 +931,6 @@ export const generateSchemaData = <
             txCtx: mutationTxCtx,
           })
         : undefined;
-    const aggregateType = tableFeatures.aggregates
-      ? generateAggregateTypes(schema[tableName] as MySqlTable, tableName, typeName, cacheCtx)
-      : undefined;
-    const aggregateGenerated = tableFeatures.aggregates
-      ? generateAggregate(
-          db,
-          tableName,
-          schema[tableName] as MySqlTable,
-          typeName,
-          aggregateFieldName,
-          tableFilters,
-          filterCtx,
-          tablePolicies,
-          cacheCtx.typeName,
-        )
-      : undefined;
-
-    // The grouped result reuses the aggregate output types, so it only exists alongside them.
-    const groupByType =
-      tableFeatures.aggregates && tableFeatures.groupBy
-        ? generateGroupByType(schema[tableName] as MySqlTable, tableName, typeName, cacheCtx)
-        : undefined;
-    const groupByEnum = groupByType
-      ? generateGroupByEnum(schema[tableName] as MySqlTable, tableName, typeName, cacheCtx)
-      : undefined;
-    const havingInput = groupByEnum
-      ? generateHavingInput(schema[tableName] as MySqlTable, tableName, typeName, cacheCtx)
-      : undefined;
-    const groupByGenerated =
-      groupByType && groupByEnum && havingInput
-        ? generateGroupBy(
-            db,
-            tableName,
-            schema[tableName] as MySqlTable,
-            typeName,
-            groupByFieldName,
-            tableFilters,
-            groupByEnum,
-            havingInput,
-            filterCtx,
-            tablePolicies,
-            cacheCtx.typeName,
-          )
-        : undefined;
-
-    queries[selectArrGenerated.name] = {
-      type: selectArrOutput,
-      args: selectArrGenerated.args,
-      resolve: selectArrGenerated.resolver,
-      extensions: {
-        drizzle: drizzleMeta({ kind: 'query', operation: 'select', single: false, targetArg: 'where' }),
-        ...(complexity ? { complexity: listFieldComplexity(complexity, limits?.(tableName)) } : {}),
-      },
-    };
-    queries[selectSingleGenerated.name] = {
-      type: selectSingleOutput,
-      args: selectSingleGenerated.args,
-      resolve: selectSingleGenerated.resolver,
-      extensions: {
-        drizzle: drizzleMeta({ kind: 'query', operation: 'select', single: true, targetArg: 'where' }),
-      },
-    };
-    if (aggregateGenerated && aggregateType) {
-      queries[aggregateGenerated.name] = {
-        type: new GraphQLNonNull(aggregateType),
-        args: aggregateGenerated.args,
-        resolve: aggregateGenerated.resolver,
-        extensions: {
-          drizzle: drizzleMeta({ kind: 'aggregate', operation: 'aggregate', single: true, targetArg: 'where' }),
-          ...(complexity ? { complexity: aggregateFieldComplexity(complexity) } : {}),
-        },
-      };
-    }
-    if (groupByGenerated && groupByType) {
-      queries[groupByGenerated.name] = {
-        type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(groupByType))),
-        args: groupByGenerated.args,
-        resolve: groupByGenerated.resolver,
-        extensions: {
-          drizzle: drizzleMeta({ kind: 'aggregate', operation: 'groupBy', single: false, targetArg: 'where' }),
-          ...(complexity ? { complexity: aggregateFieldComplexity(complexity) } : {}),
-        },
-      };
-    }
     // Each mutation is paired with the identity it publishes on `extensions.drizzle`, so a
     // consumer can tell an insert from an upsert without unpicking the configured prefixes —
     // and, for a delete, whether the field can purge rather than mark.
@@ -1263,29 +1002,5 @@ export const generateSchemaData = <
     }
   }
 
-  // The first mutation resolver of a request counts the operation's root mutation fields to
-  // know how many completions to wait for — but only fields this library generated can report
-  // completion, so the shared-transaction path needs the full roster of generated names.
-  if (mutationTxCtx) {
-    for (const name of Object.keys(mutations)) {
-      mutationTxCtx.fieldNames.add(name);
-    }
-  }
-
-  const fieldResolvers: Record<string, Record<string, any>> = {};
-  for (const [tableName, tableRelations] of Object.entries(namedRelations)) {
-    const relResolvers: Record<string, any> = {};
-    for (const [relName, relEntry] of Object.entries(tableRelations)) {
-      const isOne = is((relEntry as any).relation ?? relEntry, One);
-      const resolver = resolverFactory({ tableName, relationName: relName, relEntry, isOne });
-      if (resolver) {
-        relResolvers[relName] = resolver;
-      }
-    }
-    if (Object.keys(relResolvers).length > 0) {
-      fieldResolvers[tableName] = relResolvers;
-    }
-  }
-
-  return { queries, mutations, inputs, types: outputs, fieldResolvers } as any;
+  return finalizeBuild(ctx);
 };

--- a/src/util/builders/mysql.ts
+++ b/src/util/builders/mysql.ts
@@ -1,6 +1,5 @@
 import type { Table } from 'drizzle-orm';
 import { getTableConfig, type MySqlDatabase, MySqlTable } from 'drizzle-orm/mysql-core';
-import type { GraphQLFieldConfigArgumentMap } from 'graphql';
 import {
   GraphQLBoolean,
   type GraphQLInputObjectType,
@@ -15,7 +14,6 @@ import {
   applyContextValuesAll,
   assertSingleMatch,
   computeResolverFieldNames,
-  type DrizzleErrorContext,
   drizzleError,
   extractFilters,
   extractRequiredFilters,
@@ -31,20 +29,21 @@ import {
   type ResolverPolicies,
   relationFilterCtx,
   resolveConflictPlan,
-  runMutation,
-  runWriteHook,
   stripContextValues,
   type TablesRelationalConfig,
-  toGraphQLError,
   type WriteOperation,
-  withErrorContext,
   withScope,
+  writeResolver,
 } from '../builders/common.ts';
 import { remapFromGraphQLArrayInput, remapFromGraphQLSingleInput } from '../data-mappers/index.ts';
 import { type DrizzleMutationMeta, tableFieldExtensions } from '../extensions.ts';
 import { createSchemaBuilder } from './build-context.ts';
 import { remapUpdateInput } from './field-updates.ts';
 import type { CreatedResolver, Filters, SchemaGeneratorOptions } from './types.ts';
+
+// Every MySQL mutation answers `{ isSuccess: true }`: with no RETURNING clause there is
+// nothing else the statement can report.
+const isSuccess = { isSuccess: true };
 
 const generateInsertArray = (
   db: MySqlDatabase<any, any, any, any>,
@@ -54,68 +53,37 @@ const generateInsertArray = (
   fieldName: string,
   txCtx?: MutationTxCtx,
   policies?: ResolverPolicies,
-): CreatedResolver => {
-  const queryArgs: GraphQLFieldConfigArgumentMap = {
-    values: {
-      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(baseType))),
+): CreatedResolver =>
+  writeResolver<{ values: Record<string, any>[] }>({
+    db,
+    tableName,
+    operation: 'insert',
+    single: false,
+    fieldName,
+    txCtx,
+    policies,
+    args: {
+      values: {
+        type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(baseType))),
+      },
     },
-  };
-
-  const hooks = policies?.onWrite?.(tableName, 'insert');
-  const errorCtx: DrizzleErrorContext = { table: tableName, operation: 'insert', field: fieldName };
-
-  return {
-    name: fieldName,
-    resolver: async (_source, args: { values: Record<string, any>[] }, context, info) => {
-      try {
-        return await runMutation(
-          db,
-          context,
-          info,
-          txCtx,
-          async (executor) => {
-            const input = applyContextValuesAll(
-              remapFromGraphQLArrayInput(args.values, table),
-              policies?.contextValues?.(tableName),
-              context,
-            );
-            if (!input.length) {
-              throw drizzleError('No values were provided!', { code: 'DRIZZLE_NO_VALUES' });
-            }
-            await runWriteHook(hooks, 'before', {
-              table: tableName,
-              operation: 'insert',
-              single: false,
-              args,
-              context,
-              info,
-              tx: executor,
-            });
-
-            await executor.insert(table).values(input);
-
-            await runWriteHook(hooks, 'after', {
-              table: tableName,
-              operation: 'insert',
-              single: false,
-              args,
-              rows: [],
-              context,
-              info,
-              tx: executor,
-            });
-
-            return { isSuccess: true };
-          },
-          !!hooks,
-        );
-      } catch (e) {
-        throw withErrorContext(toGraphQLError(e), errorCtx);
+    run: async ({ executor, args, context, before, after }) => {
+      const input = applyContextValuesAll(
+        remapFromGraphQLArrayInput(args.values, table),
+        policies?.contextValues?.(tableName),
+        context,
+      );
+      if (!input.length) {
+        throw drizzleError('No values were provided!', { code: 'DRIZZLE_NO_VALUES' });
       }
+      await before();
+
+      await executor.insert(table).values(input);
+
+      await after();
+      return isSuccess;
     },
-    args: queryArgs,
-  };
-};
+  });
 
 const generateInsertSingle = (
   db: MySqlDatabase<any, any, any, any>,
@@ -125,65 +93,34 @@ const generateInsertSingle = (
   fieldName: string,
   txCtx?: MutationTxCtx,
   policies?: ResolverPolicies,
-): CreatedResolver => {
-  const queryArgs: GraphQLFieldConfigArgumentMap = {
-    values: {
-      type: new GraphQLNonNull(baseType),
+): CreatedResolver =>
+  writeResolver<{ values: Record<string, any> }>({
+    db,
+    tableName,
+    operation: 'insert',
+    single: true,
+    fieldName,
+    txCtx,
+    policies,
+    args: {
+      values: {
+        type: new GraphQLNonNull(baseType),
+      },
     },
-  };
+    run: async ({ executor, args, context, before, after }) => {
+      await before();
+      const input = applyContextValues(
+        remapFromGraphQLSingleInput(args.values, table),
+        policies?.contextValues?.(tableName),
+        context,
+      );
 
-  const hooks = policies?.onWrite?.(tableName, 'insert');
-  const errorCtx: DrizzleErrorContext = { table: tableName, operation: 'insert', field: fieldName };
+      await executor.insert(table).values(input);
 
-  return {
-    name: fieldName,
-    resolver: async (_source, args: { values: Record<string, any> }, context, info) => {
-      try {
-        return await runMutation(
-          db,
-          context,
-          info,
-          txCtx,
-          async (executor) => {
-            await runWriteHook(hooks, 'before', {
-              table: tableName,
-              operation: 'insert',
-              single: true,
-              args,
-              context,
-              info,
-              tx: executor,
-            });
-            const input = applyContextValues(
-              remapFromGraphQLSingleInput(args.values, table),
-              policies?.contextValues?.(tableName),
-              context,
-            );
-
-            await executor.insert(table).values(input);
-
-            await runWriteHook(hooks, 'after', {
-              table: tableName,
-              operation: 'insert',
-              single: true,
-              args,
-              rows: [],
-              context,
-              info,
-              tx: executor,
-            });
-
-            return { isSuccess: true };
-          },
-          !!hooks,
-        );
-      } catch (e) {
-        throw withErrorContext(toGraphQLError(e), errorCtx);
-      }
+      await after();
+      return isSuccess;
     },
-    args: queryArgs,
-  };
-};
+  });
 
 const generateUpsert = (
   db: MySqlDatabase<any, any, any, any>,
@@ -196,96 +133,61 @@ const generateUpsert = (
   txCtx?: MutationTxCtx,
   policies?: ResolverPolicies,
 ): CreatedResolver => {
-  const queryArgs: GraphQLFieldConfigArgumentMap = {
-    values: {
-      type: single ? new GraphQLNonNull(baseType) : new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(baseType))),
-    },
-    onConflict: {
-      type: onConflictType,
-      description: 'How a conflicting row is resolved. Defaults to overwriting it.',
-    },
-  };
-
   const pkNames = mysqlPrimaryKeyPropNames(table);
 
-  const hooks = policies?.onWrite?.(tableName, 'upsert');
-  const errorCtx: DrizzleErrorContext = { table: tableName, operation: 'upsert', field: fieldName };
-
-  return {
-    name: fieldName,
-    resolver: async (
-      _source,
-      args: { values: Record<string, any> | Record<string, any>[]; onConflict?: OnConflictArg },
-      context,
-      info,
-    ) => {
-      try {
-        return await runMutation(
-          db,
-          context,
-          info,
-          txCtx,
-          async (executor) => {
-            const input = applyContextValuesAll(
-              single
-                ? [remapFromGraphQLSingleInput(args.values as Record<string, any>, table)]
-                : remapFromGraphQLArrayInput(args.values as Record<string, any>[], table),
-              policies?.contextValues?.(tableName),
-              context,
-            );
-            if (!input.length) {
-              throw drizzleError('No values were provided!', { code: 'DRIZZLE_NO_VALUES' });
-            }
-            await runWriteHook(hooks, 'before', {
-              table: tableName,
-              operation: 'upsert',
-              single,
-              args,
-              context,
-              info,
-              tx: executor,
-            });
-
-            // MySQL's ON DUPLICATE KEY UPDATE fires on whichever unique key was violated, so
-            // there is no target to resolve and no predicate to attach.
-            const plan = resolveConflictPlan({
-              table,
-              values: input,
-              onConflict: args.onConflict,
-              pkNames,
-              uniqueSets: [],
-              excludedRef: mysqlValuesColumnRef,
-              withTarget: false,
-            });
-
-            if (plan.action === 'NOTHING') {
-              // INSERT IGNORE is the closest MySQL gets to DO NOTHING.
-              await executor.insert(table).ignore().values(input);
-            } else {
-              await executor.insert(table).values(input).onDuplicateKeyUpdate({ set: plan.set });
-            }
-
-            await runWriteHook(hooks, 'after', {
-              table: tableName,
-              operation: 'upsert',
-              single,
-              args,
-              rows: [],
-              context,
-              info,
-              tx: executor,
-            });
-
-            return { isSuccess: true };
-          },
-          !!hooks,
-        );
-      } catch (e) {
-        throw withErrorContext(toGraphQLError(e), errorCtx);
-      }
+  return writeResolver<{ values: Record<string, any> | Record<string, any>[]; onConflict?: OnConflictArg }>({
+    db,
+    tableName,
+    operation: 'upsert',
+    single,
+    fieldName,
+    txCtx,
+    policies,
+    args: {
+      values: {
+        type: single ? new GraphQLNonNull(baseType) : new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(baseType))),
+      },
+      onConflict: {
+        type: onConflictType,
+        description: 'How a conflicting row is resolved. Defaults to overwriting it.',
+      },
     },
-    args: queryArgs,
-  };
+    run: async ({ executor, args, context, before, after }) => {
+      const input = applyContextValuesAll(
+        single
+          ? [remapFromGraphQLSingleInput(args.values as Record<string, any>, table)]
+          : remapFromGraphQLArrayInput(args.values as Record<string, any>[], table),
+        policies?.contextValues?.(tableName),
+        context,
+      );
+      if (!input.length) {
+        throw drizzleError('No values were provided!', { code: 'DRIZZLE_NO_VALUES' });
+      }
+      await before();
+
+      // MySQL's ON DUPLICATE KEY UPDATE fires on whichever unique key was violated, so
+      // there is no target to resolve and no predicate to attach.
+      const plan = resolveConflictPlan({
+        table,
+        values: input,
+        onConflict: args.onConflict,
+        pkNames,
+        uniqueSets: [],
+        excludedRef: mysqlValuesColumnRef,
+        withTarget: false,
+      });
+
+      if (plan.action === 'NOTHING') {
+        // INSERT IGNORE is the closest MySQL gets to DO NOTHING.
+        await executor.insert(table).ignore().values(input);
+      } else {
+        await executor.insert(table).values(input).onDuplicateKeyUpdate({ set: plan.set });
+      }
+
+      await after();
+      return isSuccess;
+    },
+  });
 };
 
 const generateUpdate = (
@@ -300,97 +202,63 @@ const generateUpdate = (
   filterCtx?: RelationFilterBase,
   txCtx?: MutationTxCtx,
   policies?: ResolverPolicies,
-): CreatedResolver => {
-  const queryArgs = {
-    set: {
-      type: new GraphQLNonNull(setArgs),
+): CreatedResolver =>
+  writeResolver<{ where?: Filters<Table>; set: Record<string, any> }>({
+    db,
+    tableName,
+    operation: 'update',
+    single,
+    fieldName,
+    txCtx,
+    policies,
+    args: {
+      set: {
+        type: new GraphQLNonNull(setArgs),
+      },
+      where: {
+        type: single || requireWhere ? new GraphQLNonNull(filterArgs) : filterArgs,
+      },
     },
-    where: {
-      type: single || requireWhere ? new GraphQLNonNull(filterArgs) : filterArgs,
-    },
-  } as const satisfies GraphQLFieldConfigArgumentMap;
+    run: async ({ executor, args, context, before, after }) => {
+      const { where, set } = args;
+      const scope = policies?.scope?.(context);
 
-  const hooks = policies?.onWrite?.(tableName, 'update');
-  const errorCtx: DrizzleErrorContext = { table: tableName, operation: 'update', field: fieldName };
-
-  return {
-    name: fieldName,
-    resolver: async (_source, args: { where?: Filters<Table>; set: Record<string, any> }, context, info) => {
-      try {
-        return await runMutation(
-          db,
-          context,
-          info,
-          txCtx,
-          async (executor) => {
-            const { where, set } = args;
-            const scope = policies?.scope?.(context);
-
-            // A context-derived column is the server's to set, so an update never reassigns
-            // one — that is what stops a row being handed to another owner.
-            const input = stripContextValues(
-              remapUpdateInput(set, table, tableName),
-              policies?.contextValues?.(tableName),
-            );
-            if (!Object.keys(input).length) {
-              throw drizzleError('Unable to update with no values specified!', { code: 'DRIZZLE_NO_VALUES' });
-            }
-            await runWriteHook(hooks, 'before', {
-              table: tableName,
-              operation: 'update',
-              single,
-              args,
-              context,
-              info,
-              tx: executor,
-            });
-
-            const relationCtx = relationFilterCtx(filterCtx, tableName);
-            // The scope is ANDed on last, so a caller-supplied `where` can only narrow it.
-            const filters = withScope(
-              scope,
-              tableName,
-              table,
-              single || requireWhere
-                ? extractRequiredFilters(table, tableName, where, relationCtx)
-                : where
-                  ? extractFilters(table, tableName, where, relationCtx)
-                  : undefined,
-            );
-
-            if (single) {
-              await assertSingleMatch(executor, table, filters!);
-            }
-
-            let query = executor.update(table).set(input);
-            if (filters) {
-              query = query.where(filters) as any;
-            }
-
-            await query;
-
-            await runWriteHook(hooks, 'after', {
-              table: tableName,
-              operation: 'update',
-              single,
-              args,
-              rows: [],
-              context,
-              info,
-              tx: executor,
-            });
-
-            return { isSuccess: true };
-          },
-          !!hooks,
-        );
-      } catch (e) {
-        throw withErrorContext(toGraphQLError(e), errorCtx);
+      // A context-derived column is the server's to set, so an update never reassigns
+      // one — that is what stops a row being handed to another owner.
+      const input = stripContextValues(remapUpdateInput(set, table, tableName), policies?.contextValues?.(tableName));
+      if (!Object.keys(input).length) {
+        throw drizzleError('Unable to update with no values specified!', { code: 'DRIZZLE_NO_VALUES' });
       }
+      await before();
+
+      const relationCtx = relationFilterCtx(filterCtx, tableName);
+      // The scope is ANDed on last, so a caller-supplied `where` can only narrow it.
+      const filters = withScope(
+        scope,
+        tableName,
+        table,
+        single || requireWhere
+          ? extractRequiredFilters(table, tableName, where, relationCtx)
+          : where
+            ? extractFilters(table, tableName, where, relationCtx)
+            : undefined,
+      );
+
+      if (single) {
+        await assertSingleMatch(executor, table, filters!);
+      }
+
+      let query = executor.update(table).set(input);
+      if (filters) {
+        query = query.where(filters) as any;
+      }
+
+      await query;
+
+      await after();
+      return isSuccess;
     },
-    args: queryArgs,
-  };
-};
+  });
 
 /**
  * `update<Table>Many` — batch update with a per-entry `set` and `where`.
@@ -410,100 +278,64 @@ const generateUpdateMany = (
   filterCtx?: RelationFilterBase,
   txCtx?: MutationTxCtx,
   policies?: ResolverPolicies,
-): CreatedResolver => {
-  const queryArgs = {
-    updates: {
-      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(updateManyInput))),
+): CreatedResolver =>
+  writeResolver<{ updates: { where?: Filters<Table>; set: Record<string, any> }[] }>({
+    db,
+    tableName,
+    operation: 'updateMany',
+    single: false,
+    fieldName,
+    txCtx,
+    policies,
+    args: {
+      updates: {
+        type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(updateManyInput))),
+      },
     },
-  } as const satisfies GraphQLFieldConfigArgumentMap;
-
-  const hooks = policies?.onWrite?.(tableName, 'updateMany');
-  const errorCtx: DrizzleErrorContext = { table: tableName, operation: 'updateMany', field: fieldName };
-
-  return {
-    name: fieldName,
-    resolver: async (
-      _source,
-      args: { updates: { where?: Filters<Table>; set: Record<string, any> }[] },
-      context,
-      info,
-    ) => {
-      try {
-        return await runMutation(
-          db,
-          context,
-          info,
-          txCtx,
-          async (executor) => {
-            const { updates } = args;
-            if (!updates.length) {
-              throw drizzleError('No updates were provided!', { code: 'DRIZZLE_NO_VALUES' });
-            }
-            await runWriteHook(hooks, 'before', {
-              table: tableName,
-              operation: 'updateMany',
-              single: false,
-              args,
-              context,
-              info,
-              tx: executor,
-            });
-            const scope = policies?.scope?.(context);
-            const contextColumns = policies?.contextValues?.(tableName);
-
-            // Remap and validate every entry before the transaction opens, so a malformed
-            // entry rejects the request instead of rolling back mid-batch.
-            const entries = updates.map(({ where, set }) => {
-              const input = stripContextValues(remapUpdateInput(set, table, tableName), contextColumns);
-              if (!Object.keys(input).length) {
-                throw drizzleError('Unable to update with no values specified!', { code: 'DRIZZLE_NO_VALUES' });
-              }
-              return {
-                set: input,
-                filters: withScope(
-                  scope,
-                  tableName,
-                  table,
-                  where ? extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName)) : undefined,
-                ),
-              };
-            });
-
-            // On a caller-supplied transaction — or the shared multi-mutation transaction
-            // opened by `runMutation` — this opens a savepoint, so the batch stays atomic
-            // without breaking the outer transaction.
-            await executor.transaction(async (tx: any) => {
-              for (const entry of entries) {
-                let query = tx.update(table).set(entry.set);
-                if (entry.filters) {
-                  query = query.where(entry.filters) as any;
-                }
-                await query;
-              }
-            });
-
-            await runWriteHook(hooks, 'after', {
-              table: tableName,
-              operation: 'updateMany',
-              single: false,
-              args,
-              rows: [],
-              context,
-              info,
-              tx: executor,
-            });
-
-            return { isSuccess: true };
-          },
-          !!hooks,
-        );
-      } catch (e) {
-        throw withErrorContext(toGraphQLError(e), errorCtx);
+    run: async ({ executor, args, context, before, after }) => {
+      const { updates } = args;
+      if (!updates.length) {
+        throw drizzleError('No updates were provided!', { code: 'DRIZZLE_NO_VALUES' });
       }
+      await before();
+      const scope = policies?.scope?.(context);
+      const contextColumns = policies?.contextValues?.(tableName);
+
+      // Remap and validate every entry before the transaction opens, so a malformed
+      // entry rejects the request instead of rolling back mid-batch.
+      const entries = updates.map(({ where, set }) => {
+        const input = stripContextValues(remapUpdateInput(set, table, tableName), contextColumns);
+        if (!Object.keys(input).length) {
+          throw drizzleError('Unable to update with no values specified!', { code: 'DRIZZLE_NO_VALUES' });
+        }
+        return {
+          set: input,
+          filters: withScope(
+            scope,
+            tableName,
+            table,
+            where ? extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName)) : undefined,
+          ),
+        };
+      });
+
+      // On a caller-supplied transaction — or the shared multi-mutation transaction
+      // opened by `runMutation` — this opens a savepoint, so the batch stays atomic
+      // without breaking the outer transaction.
+      await executor.transaction(async (tx: any) => {
+        for (const entry of entries) {
+          let query = tx.update(table).set(entry.set);
+          if (entry.filters) {
+            query = query.where(entry.filters) as any;
+          }
+          await query;
+        }
+      });
+
+      await after();
+      return isSuccess;
     },
-    args: queryArgs,
-  };
-};
+  });
 
 /**
  * `delete<Table>` and, for a table that declares a soft-delete column, `restore<Table>`.
@@ -531,97 +363,68 @@ const generateDelete = (
   // Only a soft-deleting table that opted in gets the argument, so the schema itself says
   // which tables can be purged — and `restore` never takes one, having nothing to remove.
   const canHardDelete = !restore && softDelete?.hardDelete === true;
-  const queryArgs = {
-    where: {
-      type: single || requireWhere ? new GraphQLNonNull(filterArgs) : filterArgs,
+
+  return writeResolver<{ where?: Filters<Table>; hard?: boolean }>({
+    db,
+    tableName,
+    operation,
+    single,
+    fieldName,
+    txCtx,
+    policies,
+    args: {
+      where: {
+        type: single || requireWhere ? new GraphQLNonNull(filterArgs) : filterArgs,
+      },
+      ...(canHardDelete ? { hard: hardDeleteArg } : {}),
     },
-    ...(canHardDelete ? { hard: hardDeleteArg } : {}),
-  } as GraphQLFieldConfigArgumentMap;
+    run: async ({ executor, args, context, before, after }) => {
+      await before();
+      const { where } = args;
+      // `canHardDelete` decides whether the argument exists; this decides what it does,
+      // so a stitched-in `hard: true` on a table that never opted in stays a soft delete.
+      const hard = canHardDelete && args.hard === true;
+      const scope = policies?.scope?.(context);
 
-  const hooks = policies?.onWrite?.(tableName, operation);
-  const errorCtx: DrizzleErrorContext = { table: tableName, operation, field: fieldName };
+      const relationCtx = relationFilterCtx(filterCtx, tableName);
+      // Same rule as update: the scope is ANDed on last, so a delete can only ever reach
+      // rows inside it — an out-of-scope row is not matched rather than being refused.
+      // A soft-deleting table adds the marker predicate the same way: `delete` only sees
+      // rows that are not already marked, `restore` only sees the ones that are.
+      const filters = withScope(
+        scope,
+        tableName,
+        table,
+        single || requireWhere
+          ? extractRequiredFilters(table, tableName, where, relationCtx)
+          : where
+            ? extractFilters(table, tableName, where, relationCtx)
+            : undefined,
+        // A hard delete reads at INCLUDE: the rows it mostly exists to remove are the
+        // ones already marked, which the default EXCLUDE could not reach at all.
+        restore ? 'ONLY' : hard ? 'INCLUDE' : undefined,
+      );
 
-  return {
-    name: fieldName,
-    resolver: async (_source, args: { where?: Filters<Table>; hard?: boolean }, context, info) => {
-      try {
-        return await runMutation(
-          db,
-          context,
-          info,
-          txCtx,
-          async (executor) => {
-            await runWriteHook(hooks, 'before', {
-              table: tableName,
-              operation,
-              single,
-              args,
-              context,
-              info,
-              tx: executor,
-            });
-            const { where } = args;
-            // `canHardDelete` decides whether the argument exists; this decides what it does,
-            // so a stitched-in `hard: true` on a table that never opted in stays a soft delete.
-            const hard = canHardDelete && args.hard === true;
-            const scope = policies?.scope?.(context);
-
-            const relationCtx = relationFilterCtx(filterCtx, tableName);
-            // Same rule as update: the scope is ANDed on last, so a delete can only ever reach
-            // rows inside it — an out-of-scope row is not matched rather than being refused.
-            // A soft-deleting table adds the marker predicate the same way: `delete` only sees
-            // rows that are not already marked, `restore` only sees the ones that are.
-            const filters = withScope(
-              scope,
-              tableName,
-              table,
-              single || requireWhere
-                ? extractRequiredFilters(table, tableName, where, relationCtx)
-                : where
-                  ? extractFilters(table, tableName, where, relationCtx)
-                  : undefined,
-              // A hard delete reads at INCLUDE: the rows it mostly exists to remove are the
-              // ones already marked, which the default EXCLUDE could not reach at all.
-              restore ? 'ONLY' : hard ? 'INCLUDE' : undefined,
-            );
-
-            if (single) {
-              await assertSingleMatch(executor, table, filters!);
-            }
-
-            let query =
-              softDelete && !hard
-                ? executor
-                    .update(table)
-                    .set({ [softDelete.columnName]: restore ? softDelete.writeRestored : softDelete.writeDeleted() })
-                : executor.delete(table);
-            if (filters) {
-              query = query.where(filters) as any;
-            }
-
-            await query;
-
-            await runWriteHook(hooks, 'after', {
-              table: tableName,
-              operation,
-              single,
-              args,
-              rows: [],
-              context,
-              info,
-              tx: executor,
-            });
-
-            return { isSuccess: true };
-          },
-          !!hooks,
-        );
-      } catch (e) {
-        throw withErrorContext(toGraphQLError(e), errorCtx);
+      if (single) {
+        await assertSingleMatch(executor, table, filters!);
       }
+
+      let query =
+        softDelete && !hard
+          ? executor
+              .update(table)
+              .set({ [softDelete.columnName]: restore ? softDelete.writeRestored : softDelete.writeDeleted() })
+          : executor.delete(table);
+      if (filters) {
+        query = query.where(filters) as any;
+      }
+
+      await query;
+
+      await after();
+      return isSuccess;
     },
-    args: queryArgs,
-  };
+  });
 };
 
 /** Primary-key property names for a MySQL table, including table-level composite keys. */

--- a/src/util/builders/pg.ts
+++ b/src/util/builders/pg.ts
@@ -17,6 +17,8 @@ const pgSchemaData = createSchemaDataGenerator({
   primaryKeyPropNames: pgPrimaryKeyPropNames,
   // PostgreSQL sorts NULLs as the largest values (last in ASC).
   nullOrdering: 'nulls-largest',
+  // Writes come back with their rows, so the table types carry the `${Table}Item` outputs.
+  returnsRows: true,
   generateUpdateMany,
 });
 

--- a/src/util/builders/schema-data.ts
+++ b/src/util/builders/schema-data.ts
@@ -1,72 +1,37 @@
 // =============================================================================
-// The dialect-independent half of `generateSchemaData`.
+// `generateSchemaData` for the two dialects whose writes return the rows they
+// wrote — PostgreSQL and SQLite. They build a schema identically, so this module
+// holds it once and a dialect supplies only what it genuinely owns, through
+// {@link DialectSchemaAdapter}.
 //
-// PostgreSQL and SQLite build a schema the same way: the same tables are found,
-// the same relation graph is flattened, the same per-table types and resolvers
-// are generated, and the same fields are hung off the query and mutation roots.
-// The two builders used to carry ~750 lines of that logic each, drifting
-// independently. This module holds it once; a dialect supplies only the handful
-// of things it genuinely owns, through {@link DialectSchemaAdapter}.
-//
-// MySQL is deliberately not on this path: its writes return no rows, so its
-// mutation fields, their return types and their resolvers differ throughout.
+// The parts that are not even dialect-specific — everything up to each table's
+// types, the read fields, and the relation resolvers at the end — live in
+// `build-context.ts`, which MySQL shares. What remains here is the mutation half:
+// MySQL has no RETURNING clause, so its mutation fields, return types and
+// resolvers differ throughout.
 // =============================================================================
 
-import { is, One, type Table } from 'drizzle-orm';
-import type { GraphQLFieldConfig, GraphQLInputObjectType, GraphQLObjectType, ThunkObjMap } from 'graphql';
+import type { Table } from 'drizzle-orm';
+import type { GraphQLInputObjectType } from 'graphql';
 import { GraphQLInt, GraphQLList, GraphQLNonNull } from 'graphql';
 import {
-  aggregateFieldComplexity,
-  attachTargetPrimaryKeys,
-  bindPolicies,
-  buildNamedRelations,
-  buildUniqueKeyMap,
   computeResolverFieldNames,
-  createMutationTxCtx,
-  createRelationResolverFactory,
-  extractRelationJoinColumns,
   generateOnConflictInput,
-  generateTableTypes,
   generateUpdateManyInput,
   generateWriteCount,
   getUniqueColumnSets,
   type LimitPolicyFor,
-  listFieldComplexity,
   type MutationTxCtx,
-  type NullOrdering,
-  pruneNonEagerRelations,
-  type RelationAggregateFactory,
   type RelationFilterBase,
-  type RelationResolverFactory,
   type ResolverPolicies,
-  registerColumnExclusions,
   type TablesRelationalConfig,
-  type TypeCacheCtx,
   type TypeNameMapper,
   type TypeNameResolver,
-  type UniqueKeyMap,
-  visibleColumns,
 } from '../builders/common.ts';
 import { tableFieldExtensions } from '../extensions.ts';
-import { resolveTableFeatures } from '../features.ts';
-import { registerEnumConfig, registerScalarOverrides } from '../type-converter/index.ts';
-import {
-  createRelationAggregateFactory,
-  generateAggregate,
-  generateAggregateTypes,
-  generateGroupBy,
-  generateGroupByEnum,
-  generateGroupByType,
-  generateHavingInput,
-} from './aggregates.ts';
-import {
-  buildNestedWritePlans,
-  createNestedWriteRuntime,
-  createNestedWriteTypes,
-  type NestedWriteRuntime,
-} from './nested-writes.ts';
-import { createSelectGenerators } from './select.ts';
-import type { CreatedResolver, SchemaGeneratorOptions, TableFeatures, TableNamedRelations } from './types.ts';
+import { createSchemaBuilder, type SchemaBuildAdapter } from './build-context.ts';
+import type { NestedWriteRuntime } from './nested-writes.ts';
+import type { CreatedResolver, SchemaGeneratorOptions, TableNamedRelations } from './types.ts';
 import { buildWriteResolvers } from './write-resolvers.ts';
 
 /** `update<Table>Many` — batch update, whose statement loop is dialect-specific. */
@@ -89,25 +54,12 @@ export type UpdateManyGenerator = (
   resolveName?: TypeNameResolver,
 ) => CreatedResolver;
 
-/** Everything {@link createSchemaDataGenerator} cannot decide for itself. */
-export type DialectSchemaAdapter = {
-  /** The dialect's table class, used with `is()` to pick tables out of the schema module. */
-  tableClass: any;
-  /**
-   * The dialect's `getTableConfig`. The three dialects expose the same
-   * `{ primaryKeys, uniqueConstraints, indexes }` shape from different modules.
-   */
-  getTableConfig: (table: any) => any;
-  /** Primary-key property names, composite-aware — built on the dialect's `getTableConfig`. */
-  primaryKeyPropNames: (table: any) => string[];
-  /** How the dialect's `ORDER BY` sorts NULLs, which relation pagination has to match. */
-  nullOrdering: NullOrdering;
-  /**
-   * Dialect-specific validation of the database handle against the requested options,
-   * run once the tables are known but before anything is generated. SQLite uses it to
-   * reject features a synchronous driver cannot support.
-   */
-  preflight?: (db: any, options: SchemaGeneratorOptions) => void;
+/**
+ * Everything {@link createSchemaDataGenerator} cannot decide for itself: the shared build's
+ * adapter, plus the one generator whose statement loop is dialect-specific. Both dialects on
+ * this path return the rows they write, so it is fixed to `true`.
+ */
+export type DialectSchemaAdapter = SchemaBuildAdapter<true> & {
   generateUpdateMany: UpdateManyGenerator;
 };
 
@@ -122,12 +74,9 @@ export const createSchemaDataGenerator = (adapter: DialectSchemaAdapter) => {
   const uniqueColumnSets = (table: Table): string[][] => getUniqueColumnSets(table, adapter.getTableConfig);
   const { generateInsertArray, generateInsertSingle, generateUpsert, generateUpdate, generateDelete } =
     buildWriteResolvers(primaryKeyPropNames);
-  // Derived rather than supplied: the two values a select generator needs are already on the
-  // adapter, and all three dialects read the same way.
-  const { generateSelectArray, generateSelectSingle } = createSelectGenerators(
-    primaryKeyPropNames,
-    adapter.nullOrdering,
-  );
+  // The three stretches of a build that have nothing to do with the dialect: everything up to
+  // each table's types, the read fields in the middle, and the relation resolvers at the end.
+  const { prepareBuild, addReadFields, finalizeBuild } = createSchemaBuilder(adapter);
 
   return (
     db: any,
@@ -135,188 +84,28 @@ export const createSchemaDataGenerator = (adapter: DialectSchemaAdapter) => {
     relations: TablesRelationalConfig,
     options: SchemaGeneratorOptions,
   ): any => {
+    const { prefixes, suffixes, conflictDoNothing, typeNameMapper, limits } = options;
+
+    // Table discovery, the relation graph, the per-build registries, the filter context, the
+    // type cache and every table's types — all of it dialect-independent, so all of it lives
+    // in `build-context.ts` and is shared with the MySQL builder.
+    const ctx = prepareBuild(db, schema, relations, options);
     const {
-      relationsDepthLimit,
-      prefixes,
-      suffixes,
-      conflictDoNothing,
-      typeNameMapper,
-      shouldEagerLoad,
-      features,
-      complexity,
-      limits,
-    } = options;
-    const schemaEntries = Object.entries(schema);
-    // Excluded tables are dropped here, before anything reads `tableEntries` — which also makes
-    // `buildNamedRelations` skip every relation pointing at one, since it resolves targets
-    // through this list.
-    const excludedTables = new Set(options.exclude?.tables ?? []);
-    const tableEntries = schemaEntries.filter(
-      ([key, value]) => is(value, adapter.tableClass) && !excludedTables.has(key),
-    ) as [string, Table][];
-    const tables = Object.fromEntries(tableEntries) as Record<string, Table>;
-
-    // A feature flag may be a per-table predicate, so every flag is resolved against the table
-    // it applies to. `anyTable` answers the build-wide question — whether machinery shared
-    // across tables is worth constructing at all.
-    const featureOf = resolveTableFeatures(features);
-    const anyTable = (feature: keyof TableFeatures) => tableEntries.some(([name]) => featureOf(name)[feature]);
-
-    if (!tableEntries.length) {
-      throw new Error(
-        "Drizzle-GraphQL Error: No tables detected in Drizzle-ORM's database instance. Did you forget to pass schema to drizzle constructor?",
-      );
-    }
-
-    // Resolve scalar overrides into the type-converter's registry before any type generation —
-    // every subsequent column→GraphQL type decision and runtime value remap consults it.
-    registerScalarOverrides(tables, options);
-    // Same lifecycle: the enum registry is per-build, so a second build never reuses the first
-    // build's enum types (and with them its naming decisions).
-    registerEnumConfig(options);
-    // And the same for column exclusions: a per-build registry read by every site that decides
-    // what the schema contains, reset here so a rebuild never inherits the previous build's.
-    registerColumnExclusions(tables, options.exclude);
-
-    // Flatten drizzle-orm v1 TablesRelationalConfig into the canonical shape
-    // used throughout common.ts: Record<tableName, Record<relName, TableNamedRelations>>
-    const namedRelations = buildNamedRelations(relations ?? {}, tableEntries);
-    // Relations *into* an excluded table are already gone (their target no longer resolves);
-    // relations *out of* one have no type left to hang a field on.
-    for (const excluded of excludedTables) {
-      delete namedRelations[excluded];
-    }
-    // Record each relation target's primary key (composite-aware) so paginated relations
-    // default to a deterministic PK order. Must run before pruning / type generation, which
-    // share these entry objects.
-    attachTargetPrimaryKeys(namedRelations, tables, (table) => primaryKeyPropNames(table));
-    // Relations to eager-load via `with:`. Query/mutation resolvers use this pruned map so
-    // opted-out relations never overfetch; type generation keeps the full map so their
-    // fields still exist and resolve lazily.
-    const eagerRelations = pruneNonEagerRelations(namedRelations, shouldEagerLoad);
-
-    // A `where` field per compound unique constraint, for the tables that asked for one. Built
-    // once and shared by the input types and the resolvers: the fields a request may spell and
-    // the fields a resolver understands are the same map, so neither can drift from the other.
-    const uniqueKeys: Record<string, UniqueKeyMap> = {};
-    for (const [tableName, table] of tableEntries) {
-      if (!featureOf(tableName).uniqueKeyFilters) {
-        continue;
-      }
-      // Whatever the filter input already offers under a name keeps it — columns are added
-      // first, then relations, and a key field last.
-      const taken = new Set([...Object.keys(visibleColumns(table)), ...Object.keys(namedRelations[tableName] ?? {})]);
-      const map = buildUniqueKeyMap(uniqueColumnSets(table), taken);
-      if (Object.keys(map).length) {
-        uniqueKeys[tableName] = map;
-      }
-    }
-
-    const filterCtx: RelationFilterBase = { tables, relationMap: namedRelations, uniqueKeys };
-
-    // The row scope compiled against this build's relation graph, plus the columns whose value
-    // the server supplies. Both stay undefined unless configured.
-    const tablePolicies = options.policies;
-    const contextValuesOf = tablePolicies?.contextValues;
-    const softDeleteOf = tablePolicies?.softDelete;
-    const policies = bindPolicies(tablePolicies, filterCtx);
-
-    const resolverFactory: RelationResolverFactory = createRelationResolverFactory(
-      db,
       tables,
-      adapter.nullOrdering,
-      filterCtx,
-      limits,
-      tablePolicies,
-    );
-
-    // Fresh cache per generateSchemaData call — prevents type name collisions
-    // when buildSchema() is called multiple times.
-    const cacheCtx: TypeCacheCtx = {
-      typeName: options.typeName ?? ((info) => info.defaultName),
-      genericFilterCache: new Map(),
-      objectTypeCache: new Map(),
-      relationFieldContainers: new Map(),
-      fullyBuiltTables: new Set(),
-      relationTypeCache: new Map(),
-      selectFieldCache: new WeakMap(),
-      filterFieldCache: new WeakMap(),
-      orderTypeCache: new WeakMap(),
-      filterTypeCache: new WeakMap(),
-      listRelationFilterCache: new Map(),
-      aggregateTypeCache: new Map(),
-      complexity,
-      limits,
-      docs: options.docs ?? {},
-      primaryKeyOf: (name) => (tables[name] ? primaryKeyPropNames(tables[name] as Table) : []),
-      contextValuesOf,
-      softDeleteOf,
       featureOf,
-      uniqueKeysOf: (tableName) => uniqueKeys[tableName],
-    };
-
-    adapter.preflight?.(db, options);
-
-    // Nested writes: the plans decide which relations are writable at all, the types add their
-    // fields to the create/update inputs, and the runtime executes them. All three are left
-    // undefined when the feature is off, so the inputs and the resolvers stay as they were.
-    const nestedPlans = features.nestedWrites
-      ? buildNestedWritePlans(
-          tables,
-          namedRelations,
-          (target) => uniqueColumnSets(target as Table),
-          (target) => primaryKeyPropNames(target as Table),
-          extractRelationJoinColumns,
-        )
-      : undefined;
-    const nestedTypes = nestedPlans
-      ? createNestedWriteTypes({ plans: nestedPlans, cacheCtx, typeNameMapper })
-      : undefined;
-    const nestedRuntime = nestedPlans
-      ? createNestedWriteRuntime({
-          plans: nestedPlans,
-          filterCtx,
-          policies: tablePolicies,
-          contextValues: contextValuesOf,
-        })
-      : undefined;
-
-    // Built when at least one table wants relation aggregates; a table that has them off is
-    // handed `undefined` below, so `generateTableTypes` emits no `${relation}Aggregate` fields
-    // on its object type.
-    const relationAggregateFactory: RelationAggregateFactory | undefined = anyTable('relationAggregates')
-      ? createRelationAggregateFactory(db, tables, cacheCtx, typeNameMapper, filterCtx, tablePolicies)
-      : undefined;
-
-    const queries: ThunkObjMap<GraphQLFieldConfig<any, any>> = {};
-    const mutations: ThunkObjMap<GraphQLFieldConfig<any, any>> = {};
-
-    // Shared per-request transaction machinery for multi-mutation documents; undefined
-    // unless `transactions: 'auto'`. Its field-name set is filled once all mutations exist.
-    const mutationTxCtx = createMutationTxCtx(options.transactions);
-
-    const gqlSchemaTypes = Object.fromEntries(
-      Object.entries(tables).map(([tableName, _table]) => [
-        tableName,
-        generateTableTypes(
-          tableName,
-          tables,
-          namedRelations,
-          true,
-          relationsDepthLimit,
-          cacheCtx,
-          typeNameMapper,
-          prefixes.insert,
-          prefixes.update,
-          resolverFactory,
-          featureOf(tableName).relationAggregates ? relationAggregateFactory : undefined,
-          nestedTypes,
-        ),
-      ]),
-    );
-
-    const inputs: Record<string, GraphQLInputObjectType> = {};
-    const outputs: Record<string, GraphQLObjectType> = {};
+      eagerRelations,
+      filterCtx,
+      policies,
+      softDeleteOf,
+      namedRelations,
+      cacheCtx,
+      nestedRuntime,
+      mutationTxCtx,
+      gqlSchemaTypes,
+      mutations,
+      inputs,
+      outputs,
+    } = ctx;
 
     for (const [tableName, tableTypes] of Object.entries(gqlSchemaTypes)) {
       // Everything this table generates, with any per-table predicate already run.
@@ -325,15 +114,12 @@ export const createSchemaDataGenerator = (adapter: DialectSchemaAdapter) => {
       // so a wrapper can read a field's identity instead of parsing its configurable name.
       const drizzleMeta = tableFieldExtensions(tableName, primaryKeyPropNames(schema[tableName] as Table));
       const { insertInput, updateInput, tableFilters, tableOrder } = tableTypes.inputs;
-      const { selectSingleOutput, selectArrOutput, singleTableItemOutput, arrTableItemOutput } = tableTypes.outputs;
+      const { selectSingleOutput, singleTableItemOutput, arrTableItemOutput } = tableTypes.outputs;
 
       // Compute field names using the mapper logic
+      const names = computeResolverFieldNames(tableName, typeNameMapper, prefixes, suffixes);
       const {
         typeName,
-        listFieldName,
-        singleFieldName,
-        aggregateFieldName,
-        groupByFieldName,
         createArrayFieldName,
         createSingleFieldName,
         upsertArrayFieldName,
@@ -347,43 +133,16 @@ export const createSchemaDataGenerator = (adapter: DialectSchemaAdapter) => {
         restoreFieldName,
         restoreSingleFieldName,
         deleteCountFieldName,
-      } = computeResolverFieldNames(tableName, typeNameMapper, prefixes, suffixes);
+      } = names;
       // A table that marks rows deleted instead of removing them also gets the mutation that
       // reverses it — clearing the column through an ordinary update is not possible, since the
       // column is not in the update input and a marked row is invisible to a `where` anyway.
       const softDeleteInfo = softDeleteOf?.(tableName);
 
-      const selectArrGenerated = generateSelectArray(
-        db,
-        tableName,
-        tables,
-        eagerRelations,
-        tableOrder,
-        tableFilters,
-        listFieldName,
-        typeName,
-        typeNameMapper,
-        filterCtx,
-        tableFeatures.distinct,
-        limits,
-        policies,
-        cacheCtx.typeName,
-      );
-      const selectSingleGenerated = generateSelectSingle(
-        db,
-        tableName,
-        tables,
-        eagerRelations,
-        tableOrder,
-        tableFilters,
-        singleFieldName,
-        typeName,
-        typeNameMapper,
-        filterCtx,
-        limits,
-        policies,
-        cacheCtx.typeName,
-      );
+      // Both selects, the aggregate and the group-by: generated and hung off the query root
+      // by the shared builder, since a read is a read on every dialect.
+      const { aggregateType, groupByType, havingInput } = addReadFields(ctx, tableName, names, tableTypes, drizzleMeta);
+
       const insertArrGenerated = tableFeatures.insert
         ? generateInsertArray(
             db,
@@ -659,90 +418,6 @@ export const createSchemaDataGenerator = (adapter: DialectSchemaAdapter) => {
               txCtx: mutationTxCtx,
             })
           : undefined;
-      const aggregateType = tableFeatures.aggregates
-        ? generateAggregateTypes(schema[tableName] as Table, tableName, typeName, cacheCtx)
-        : undefined;
-      const aggregateGenerated = tableFeatures.aggregates
-        ? generateAggregate(
-            db,
-            tableName,
-            schema[tableName] as Table,
-            typeName,
-            aggregateFieldName,
-            tableFilters,
-            filterCtx,
-            tablePolicies,
-            cacheCtx.typeName,
-          )
-        : undefined;
-
-      // The grouped result reuses the aggregate output types, so it only exists alongside them.
-      const groupByType =
-        tableFeatures.aggregates && tableFeatures.groupBy
-          ? generateGroupByType(schema[tableName] as Table, tableName, typeName, cacheCtx)
-          : undefined;
-      const groupByEnum = groupByType
-        ? generateGroupByEnum(schema[tableName] as Table, tableName, typeName, cacheCtx)
-        : undefined;
-      const havingInput = groupByEnum
-        ? generateHavingInput(schema[tableName] as Table, tableName, typeName, cacheCtx)
-        : undefined;
-      const groupByGenerated =
-        groupByType && groupByEnum && havingInput
-          ? generateGroupBy(
-              db,
-              tableName,
-              schema[tableName] as Table,
-              typeName,
-              groupByFieldName,
-              tableFilters,
-              groupByEnum,
-              havingInput,
-              filterCtx,
-              tablePolicies,
-              cacheCtx.typeName,
-            )
-          : undefined;
-
-      queries[selectArrGenerated.name] = {
-        type: selectArrOutput,
-        args: selectArrGenerated.args,
-        resolve: selectArrGenerated.resolver,
-        extensions: {
-          drizzle: drizzleMeta({ kind: 'query', operation: 'select', single: false, targetArg: 'where' }),
-          ...(complexity ? { complexity: listFieldComplexity(complexity, limits?.(tableName)) } : {}),
-        },
-      };
-      queries[selectSingleGenerated.name] = {
-        type: selectSingleOutput,
-        args: selectSingleGenerated.args,
-        resolve: selectSingleGenerated.resolver,
-        extensions: {
-          drizzle: drizzleMeta({ kind: 'query', operation: 'select', single: true, targetArg: 'where' }),
-        },
-      };
-      if (aggregateGenerated && aggregateType) {
-        queries[aggregateGenerated.name] = {
-          type: new GraphQLNonNull(aggregateType),
-          args: aggregateGenerated.args,
-          resolve: aggregateGenerated.resolver,
-          extensions: {
-            drizzle: drizzleMeta({ kind: 'aggregate', operation: 'aggregate', single: true, targetArg: 'where' }),
-            ...(complexity ? { complexity: aggregateFieldComplexity(complexity) } : {}),
-          },
-        };
-      }
-      if (groupByGenerated && groupByType) {
-        queries[groupByGenerated.name] = {
-          type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(groupByType))),
-          args: groupByGenerated.args,
-          resolve: groupByGenerated.resolver,
-          extensions: {
-            drizzle: drizzleMeta({ kind: 'aggregate', operation: 'groupBy', single: false, targetArg: 'where' }),
-            ...(complexity ? { complexity: aggregateFieldComplexity(complexity) } : {}),
-          },
-        };
-      }
       if (insertArrGenerated) {
         mutations[insertArrGenerated.name] = {
           type: arrTableItemOutput,
@@ -915,30 +590,6 @@ export const createSchemaDataGenerator = (adapter: DialectSchemaAdapter) => {
       }
     }
 
-    // Every generated mutation name is now known — the first mutation resolver of a request
-    // uses this set to count the document's root mutation fields (and to leave documents
-    // containing consumer-added mutations alone).
-    if (mutationTxCtx) {
-      for (const name of Object.keys(mutations)) {
-        mutationTxCtx.fieldNames.add(name);
-      }
-    }
-
-    const fieldResolvers: Record<string, Record<string, any>> = {};
-    for (const [tableName, tableRelations] of Object.entries(namedRelations)) {
-      const relResolvers: Record<string, any> = {};
-      for (const [relName, relEntry] of Object.entries(tableRelations)) {
-        const isOne = is((relEntry as any).relation ?? relEntry, One);
-        const resolver = resolverFactory({ tableName, relationName: relName, relEntry, isOne });
-        if (resolver) {
-          relResolvers[relName] = resolver;
-        }
-      }
-      if (Object.keys(relResolvers).length > 0) {
-        fieldResolvers[tableName] = relResolvers;
-      }
-    }
-
-    return { queries, mutations, inputs, types: outputs, fieldResolvers } as any;
+    return finalizeBuild(ctx);
   };
 };

--- a/src/util/builders/sqlite.ts
+++ b/src/util/builders/sqlite.ts
@@ -101,6 +101,8 @@ const sqliteSchemaData = createSchemaDataGenerator({
   primaryKeyPropNames: sqlitePrimaryKeyPropNames,
   // SQLite sorts NULLs as the smallest values (first in ASC).
   nullOrdering: 'nulls-smallest',
+  // Writes come back with their rows, so the table types carry the `${Table}Item` outputs.
+  returnsRows: true,
   // A synchronous driver (e.g. better-sqlite3) commits the moment its transaction callback
   // returns, so it can neither interleave awaited statements inside one transaction nor hold
   // one open across resolver calls — which is what both of these features require.

--- a/src/util/builders/update-many.ts
+++ b/src/util/builders/update-many.ts
@@ -15,7 +15,6 @@ import { GraphQLList, GraphQLNonNull } from 'graphql';
 import type { ResolveTree } from 'graphql-parse-resolve-info';
 import { parseResolveInfo } from 'graphql-parse-resolve-info';
 import {
-  type DrizzleErrorContext,
   drizzleError,
   eagerLoadMutationRelations,
   extractFilters,
@@ -25,14 +24,11 @@ import {
   type RelationFilterBase,
   type ResolverPolicies,
   relationFilterCtx,
-  runMutation,
-  runWriteHook,
   stripContextValues,
   type TypeNameMapper,
   type TypeNameResolver,
-  toGraphQLError,
-  withErrorContext,
   withScope,
+  writeResolver,
 } from '../builders/common.ts';
 import { remapToGraphQLSingleOutput } from '../data-mappers/index.ts';
 import { remapUpdateInput } from './field-updates.ts';
@@ -150,146 +146,113 @@ export const createUpdateManyGenerator = (
 
     // Derived once at build time — PK prop names don't change per request.
     const pkNames = primaryKeyPropNames(table);
-    const hooks = policies?.onWrite?.(tableName, 'updateMany');
-    const errorCtx: DrizzleErrorContext = { table: tableName, operation: 'updateMany', field: fieldName };
 
-    return {
-      name: fieldName,
-      resolver: async (
-        _source,
-        args: { updates: { where?: Filters<Table>; set: Record<string, any> }[] },
-        context,
-        info,
-      ) => {
-        try {
-          return await runMutation(
-            db,
-            context,
-            info,
-            txCtx,
-            async (executor) => {
-              const { updates } = args;
-              if (!updates.length) {
-                throw drizzleError('No updates were provided!', { code: 'DRIZZLE_NO_VALUES' });
-              }
-              await runWriteHook(hooks, 'before', {
-                table: tableName,
-                operation: 'updateMany',
-                single: false,
-                args,
-                context,
-                info,
-                tx: executor,
-              });
-              const scope = policies?.scope?.(context);
-              const contextColumns = policies?.contextValues?.(tableName);
-
-              const parsedInfo = parseResolveInfo(info, {
-                deep: true,
-              }) as ResolveTree;
-
-              const { columns, hasRelations, withParams } = prepareMutationRelationColumns({
-                relationMap,
-                tables,
-                tableName,
-                typeName,
-                typeNameMapper,
-                resolveName,
-                table,
-                pkNames,
-                parsedInfo,
-                limits,
-                scope,
-                defaultOrderBy: policies?.defaultOrderBy,
-              });
-
-              // Remap and validate every entry before the transaction opens, so a malformed
-              // entry rejects the request instead of rolling back mid-batch.
-              const entries: UpdateManyEntry[] = updates.map(({ where, set }) => {
-                const split = nested?.enabled(tableName) ? nested.split(tableName, set) : undefined;
-                const ops = split && nested!.hasOps(split.ops) ? split.ops : undefined;
-                const input = stripContextValues(
-                  remapUpdateInput(split ? split.columns : set, table, tableName),
-                  contextColumns,
-                );
-                // An entry that only writes through a relation still has work to do.
-                if (!Object.keys(input).length && !ops) {
-                  throw drizzleError('Unable to update with no values specified!', { code: 'DRIZZLE_NO_VALUES' });
-                }
-                return {
-                  set: input,
-                  ops,
-                  filters: withScope(
-                    scope,
-                    tableName,
-                    table,
-                    where
-                      ? extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName))
-                      : undefined,
-                  ),
-                };
-              });
-
-              const anyNested = entries.some((entry) => entry.ops);
-              const returning = anyNested
-                ? nested!.withJoinColumns(
-                    tableName,
-                    mergedOps(entries.map((entry) => ({ ops: entry.ops ?? {} }))),
-                    { ...columns },
-                    table,
-                  )
-                : columns;
-
-              const perEntry = await runBatch({
-                executor,
-                entries,
-                table,
-                returning,
-                anyNested,
-                nested,
-                tableName,
-                context,
-              });
-
-              const flatRows = perEntry.flat();
-              await runWriteHook(hooks, 'after', {
-                table: tableName,
-                operation: 'updateMany',
-                single: false,
-                args,
-                rows: flatRows,
-                context,
-                info,
-                tx: executor,
-              });
-
-              const enriched = hasRelations
-                ? await eagerLoadMutationRelations(executor, tableName, flatRows, pkNames, withParams)
-                : flatRows;
-
-              // Rebuild the per-entry slots: a no-match entry contributes `null`, a multi-match
-              // entry contributes each of its rows.
-              const output: (Record<string, any> | null)[] = [];
-              let offset = 0;
-              for (const rows of perEntry) {
-                if (!rows.length) {
-                  output.push(null);
-                  continue;
-                }
-                for (let i = 0; i < rows.length; i++) {
-                  output.push(remapToGraphQLSingleOutput(enriched[offset + i], tableName, table, relationMap));
-                }
-                offset += rows.length;
-              }
-              return output;
-            },
-            !!hooks,
-          );
-        } catch (e) {
-          throw withErrorContext(toGraphQLError(e), errorCtx);
-        }
-      },
+    return writeResolver<{ updates: { where?: Filters<Table>; set: Record<string, any> }[] }>({
+      db,
+      tableName,
+      operation: 'updateMany',
+      single: false,
+      fieldName,
+      txCtx,
+      policies,
       args: queryArgs,
-    };
+      run: async ({ executor, args, context, info, before, after }) => {
+        const { updates } = args;
+        if (!updates.length) {
+          throw drizzleError('No updates were provided!', { code: 'DRIZZLE_NO_VALUES' });
+        }
+        await before();
+        const scope = policies?.scope?.(context);
+        const contextColumns = policies?.contextValues?.(tableName);
+
+        const parsedInfo = parseResolveInfo(info, {
+          deep: true,
+        }) as ResolveTree;
+
+        const { columns, hasRelations, withParams } = prepareMutationRelationColumns({
+          relationMap,
+          tables,
+          tableName,
+          typeName,
+          typeNameMapper,
+          resolveName,
+          table,
+          pkNames,
+          parsedInfo,
+          limits,
+          scope,
+          defaultOrderBy: policies?.defaultOrderBy,
+        });
+
+        // Remap and validate every entry before the transaction opens, so a malformed
+        // entry rejects the request instead of rolling back mid-batch.
+        const entries: UpdateManyEntry[] = updates.map(({ where, set }) => {
+          const split = nested?.enabled(tableName) ? nested.split(tableName, set) : undefined;
+          const ops = split && nested!.hasOps(split.ops) ? split.ops : undefined;
+          const input = stripContextValues(
+            remapUpdateInput(split ? split.columns : set, table, tableName),
+            contextColumns,
+          );
+          // An entry that only writes through a relation still has work to do.
+          if (!Object.keys(input).length && !ops) {
+            throw drizzleError('Unable to update with no values specified!', { code: 'DRIZZLE_NO_VALUES' });
+          }
+          return {
+            set: input,
+            ops,
+            filters: withScope(
+              scope,
+              tableName,
+              table,
+              where ? extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName)) : undefined,
+            ),
+          };
+        });
+
+        const anyNested = entries.some((entry) => entry.ops);
+        const returning = anyNested
+          ? nested!.withJoinColumns(
+              tableName,
+              mergedOps(entries.map((entry) => ({ ops: entry.ops ?? {} }))),
+              { ...columns },
+              table,
+            )
+          : columns;
+
+        const perEntry = await runBatch({
+          executor,
+          entries,
+          table,
+          returning,
+          anyNested,
+          nested,
+          tableName,
+          context,
+        });
+
+        const flatRows = perEntry.flat();
+        await after(flatRows);
+
+        const enriched = hasRelations
+          ? await eagerLoadMutationRelations(executor, tableName, flatRows, pkNames, withParams)
+          : flatRows;
+
+        // Rebuild the per-entry slots: a no-match entry contributes `null`, a multi-match
+        // entry contributes each of its rows.
+        const output: (Record<string, any> | null)[] = [];
+        let offset = 0;
+        for (const rows of perEntry) {
+          if (!rows.length) {
+            output.push(null);
+            continue;
+          }
+          for (let i = 0; i < rows.length; i++) {
+            output.push(remapToGraphQLSingleOutput(enriched[offset + i], tableName, table, relationMap));
+          }
+          offset += rows.length;
+        }
+        return output;
+      },
+    });
   };
 };

--- a/src/util/builders/write-resolvers.ts
+++ b/src/util/builders/write-resolvers.ts
@@ -4,8 +4,11 @@
 // bodies were duplicated verbatim between pg.ts and sqlite.ts. The only differences were the
 // dialect spellings of `db` and `table` and how primary-key prop names are derived — the
 // first two collapse into the union/base types below, the third is the factory's parameter.
-// MySQL is NOT built from here: its mutations return no rows, so it re-selects after every
-// write and its resolvers have a genuinely different shape.
+// MySQL is NOT built from here: it has no RETURNING clause, so where these bodies read their
+// rows back out of the statement, MySQL's report `{ isSuccess }` — a genuinely different
+// shape, not a spelling difference. What all three dialects do share is the scaffolding
+// around the statement (hooks, transaction, error context), which lives in
+// `common/write-scaffold.ts` and wraps every body below.
 
 import type { Table } from 'drizzle-orm';
 import type { PgAsyncDatabase } from 'drizzle-orm/pg-core';
@@ -24,7 +27,6 @@ import {
   applyContextValuesAll,
   applyObjectTypeName,
   assertSingleMatch,
-  type DrizzleErrorContext,
   drizzleError,
   eagerLoadMutationRelations,
   excludedColumnRef,
@@ -40,16 +42,13 @@ import {
   type ResolverPolicies,
   relationFilterCtx,
   resolveConflictPlan,
-  runMutation,
-  runWriteHook,
   type SelectionCtx,
   stripContextValues,
   type TypeNameMapper,
   type TypeNameResolver,
-  toGraphQLError,
   type WriteOperation,
-  withErrorContext,
   withScope,
+  writeResolver,
 } from './common.ts';
 import { remapUpdateInput } from './field-updates.ts';
 import { mergedOps, type NestedWriteRuntime, updateWithNestedOps, writeWithNestedOps } from './nested-writes.ts';
@@ -97,117 +96,91 @@ export const buildWriteResolvers = (primaryKeyPropNames: PrimaryKeyPropNames) =>
     // Primary-key prop names are constant per table — derive them once at build time
     // rather than re-running getTableConfig on every mutation request.
     const pkNames = primaryKeyPropNames(table);
-    const hooks = policies?.onWrite?.(tableName, 'insert');
-    const errorCtx: DrizzleErrorContext = { table: tableName, operation: 'insert', field: fieldName };
 
-    return {
-      name: fieldName,
-      resolver: async (_source, args: { values: Record<string, any>[] }, context, info) => {
-        try {
-          return await runMutation(
-            db,
-            context,
-            info,
-            txCtx,
-            async (executor) => {
-              if (!args.values.length) {
-                throw drizzleError('No values were provided!', { code: 'DRIZZLE_NO_VALUES' });
-              }
-              await runWriteHook(hooks, 'before', {
-                table: tableName,
-                operation: 'insert',
-                single: false,
-                args,
-                context,
-                info,
-                tx: executor,
-              });
-
-              // Split each row's relation fields off its columns. Only when something is actually
-              // nested does the write leave the single multi-row statement below.
-              const entries = nested?.enabled(tableName)
-                ? args.values.map((values) => nested.split(tableName, values))
-                : undefined;
-              const nestedEntries = entries?.some((entry) => nested!.hasOps(entry.ops)) ? entries : undefined;
-              const contextColumns = policies?.contextValues?.(tableName);
-              const scope = policies?.scope?.(context);
-              const input = nestedEntries
-                ? []
-                : applyContextValuesAll(
-                    remapFromGraphQLArrayInput(entries ? entries.map((entry) => entry.columns) : args.values, table),
-                    contextColumns,
-                    context,
-                  );
-
-              const parsedInfo = parseResolveInfo(info, {
-                deep: true,
-              }) as ResolveTree;
-
-              const { columns, hasRelations, withParams } = prepareMutationRelationColumns({
-                relationMap,
-                tables,
-                tableName,
-                typeName,
-                typeNameMapper,
-                resolveName,
-                table,
-                pkNames,
-                parsedInfo,
-                limits,
-                scope,
-                defaultOrderBy: policies?.defaultOrderBy,
-              });
-
-              const returning = nestedEntries
-                ? nested!.withJoinColumns(tableName, mergedOps(nestedEntries), { ...columns }, table)
-                : columns;
-
-              const runInsert = async (target: any, values: Record<string, any>[]) => {
-                let query = target.insert(table).values(values).returning(returning);
-                if (conflictDoNothing) {
-                  query = query.onConflictDoNothing() as any;
-                }
-                return (await query) as Record<string, any>[];
-              };
-
-              const result = nestedEntries
-                ? await writeWithNestedOps({
-                    executor,
-                    runtime: nested!,
-                    tableName,
-                    entries: nestedEntries,
-                    remapValues: (values) =>
-                      applyContextValues(remapFromGraphQLSingleInput(values, table), contextColumns, context),
-                    write: (tx, values) => runInsert(tx, [values]),
-                    context,
-                  })
-                : await runInsert(executor, input);
-
-              await runWriteHook(hooks, 'after', {
-                table: tableName,
-                operation: 'insert',
-                single: false,
-                args,
-                rows: result,
-                context,
-                info,
-                tx: executor,
-              });
-
-              const enriched = hasRelations
-                ? await eagerLoadMutationRelations(executor, tableName, result, pkNames, withParams)
-                : result;
-
-              return remapToGraphQLArrayOutput(enriched, tableName, table, relationMap);
-            },
-            !!hooks,
-          );
-        } catch (e) {
-          throw withErrorContext(toGraphQLError(e), errorCtx);
-        }
-      },
+    return writeResolver<{ values: Record<string, any>[] }>({
+      db,
+      tableName,
+      operation: 'insert',
+      single: false,
+      fieldName,
+      txCtx,
+      policies,
       args: queryArgs,
-    };
+      run: async ({ executor, args, context, info, before, after }) => {
+        if (!args.values.length) {
+          throw drizzleError('No values were provided!', { code: 'DRIZZLE_NO_VALUES' });
+        }
+        await before();
+
+        // Split each row's relation fields off its columns. Only when something is actually
+        // nested does the write leave the single multi-row statement below.
+        const entries = nested?.enabled(tableName)
+          ? args.values.map((values) => nested.split(tableName, values))
+          : undefined;
+        const nestedEntries = entries?.some((entry) => nested!.hasOps(entry.ops)) ? entries : undefined;
+        const contextColumns = policies?.contextValues?.(tableName);
+        const scope = policies?.scope?.(context);
+        const input = nestedEntries
+          ? []
+          : applyContextValuesAll(
+              remapFromGraphQLArrayInput(entries ? entries.map((entry) => entry.columns) : args.values, table),
+              contextColumns,
+              context,
+            );
+
+        const parsedInfo = parseResolveInfo(info, {
+          deep: true,
+        }) as ResolveTree;
+
+        const { columns, hasRelations, withParams } = prepareMutationRelationColumns({
+          relationMap,
+          tables,
+          tableName,
+          typeName,
+          typeNameMapper,
+          resolveName,
+          table,
+          pkNames,
+          parsedInfo,
+          limits,
+          scope,
+          defaultOrderBy: policies?.defaultOrderBy,
+        });
+
+        const returning = nestedEntries
+          ? nested!.withJoinColumns(tableName, mergedOps(nestedEntries), { ...columns }, table)
+          : columns;
+
+        const runInsert = async (target: any, values: Record<string, any>[]) => {
+          let query = target.insert(table).values(values).returning(returning);
+          if (conflictDoNothing) {
+            query = query.onConflictDoNothing() as any;
+          }
+          return (await query) as Record<string, any>[];
+        };
+
+        const result = nestedEntries
+          ? await writeWithNestedOps({
+              executor,
+              runtime: nested!,
+              tableName,
+              entries: nestedEntries,
+              remapValues: (values) =>
+                applyContextValues(remapFromGraphQLSingleInput(values, table), contextColumns, context),
+              write: (tx, values) => runInsert(tx, [values]),
+              context,
+            })
+          : await runInsert(executor, input);
+
+        await after(result);
+
+        const enriched = hasRelations
+          ? await eagerLoadMutationRelations(executor, tableName, result, pkNames, withParams)
+          : result;
+
+        return remapToGraphQLArrayOutput(enriched, tableName, table, relationMap);
+      },
+    });
   };
 
   const generateInsertSingle = (
@@ -236,118 +209,92 @@ export const buildWriteResolvers = (primaryKeyPropNames: PrimaryKeyPropNames) =>
 
     // Derived once at build time — PK prop names don't change per request.
     const pkNames = primaryKeyPropNames(table);
-    const hooks = policies?.onWrite?.(tableName, 'insert');
-    const errorCtx: DrizzleErrorContext = { table: tableName, operation: 'insert', field: fieldName };
 
-    return {
-      name: fieldName,
-      resolver: async (_source, args: { values: Record<string, any> }, context, info) => {
-        try {
-          return await runMutation(
-            db,
-            context,
-            info,
-            txCtx,
-            async (executor) => {
-              await runWriteHook(hooks, 'before', {
-                table: tableName,
-                operation: 'insert',
-                single: true,
-                args,
-                context,
-                info,
-                tx: executor,
-              });
-              const entry = nested?.enabled(tableName) ? nested.split(tableName, args.values) : undefined;
-              const nestedEntry = entry && nested!.hasOps(entry.ops) ? entry : undefined;
-              const contextColumns = policies?.contextValues?.(tableName);
-              const scope = policies?.scope?.(context);
-              const input = nestedEntry
-                ? {}
-                : applyContextValues(
-                    remapFromGraphQLSingleInput(entry ? entry.columns : args.values, table),
-                    contextColumns,
-                    context,
-                  );
-
-              const parsedInfo = parseResolveInfo(info, {
-                deep: true,
-              }) as ResolveTree;
-
-              const { columns, hasRelations, withParams } = prepareMutationRelationColumns({
-                relationMap,
-                tables,
-                tableName,
-                typeName,
-                typeNameMapper,
-                resolveName,
-                table,
-                pkNames,
-                parsedInfo,
-                limits,
-                scope,
-                defaultOrderBy: policies?.defaultOrderBy,
-              });
-
-              const returning = nestedEntry
-                ? nested!.withJoinColumns(tableName, nestedEntry.ops, { ...columns }, table)
-                : columns;
-
-              const runInsert = async (target: any, values: Record<string, any>) => {
-                let query = target.insert(table).values(values).returning(returning);
-                if (conflictDoNothing) {
-                  query = query.onConflictDoNothing() as any;
-                }
-                return (await query) as Record<string, any>[];
-              };
-
-              const result = nestedEntry
-                ? await writeWithNestedOps({
-                    executor,
-                    runtime: nested!,
-                    tableName,
-                    entries: [nestedEntry],
-                    remapValues: (values) =>
-                      applyContextValues(remapFromGraphQLSingleInput(values, table), contextColumns, context),
-                    write: runInsert,
-                    context,
-                  })
-                : await runInsert(executor, input);
-
-              await runWriteHook(hooks, 'after', {
-                table: tableName,
-                operation: 'insert',
-                single: true,
-                args,
-                rows: result,
-                context,
-                info,
-                tx: executor,
-              });
-
-              if (!result[0]) {
-                // Only reachable under `conflictDoNothing`, which is why the field is nullable
-                // there and non-null everywhere else.
-                if (!conflictDoNothing) {
-                  throw drizzleError('The insert returned no row.', { code: 'DRIZZLE_NO_ROW_RETURNED' });
-                }
-                return undefined;
-              }
-
-              const enriched = hasRelations
-                ? await eagerLoadMutationRelations(executor, tableName, result, pkNames, withParams)
-                : result;
-
-              return remapToGraphQLSingleOutput(enriched[0], tableName, table, relationMap);
-            },
-            !!hooks,
-          );
-        } catch (e) {
-          throw withErrorContext(toGraphQLError(e), errorCtx);
-        }
-      },
+    return writeResolver<{ values: Record<string, any> }>({
+      db,
+      tableName,
+      operation: 'insert',
+      single: true,
+      fieldName,
+      txCtx,
+      policies,
       args: queryArgs,
-    };
+      run: async ({ executor, args, context, info, before, after }) => {
+        await before();
+        const entry = nested?.enabled(tableName) ? nested.split(tableName, args.values) : undefined;
+        const nestedEntry = entry && nested!.hasOps(entry.ops) ? entry : undefined;
+        const contextColumns = policies?.contextValues?.(tableName);
+        const scope = policies?.scope?.(context);
+        const input = nestedEntry
+          ? {}
+          : applyContextValues(
+              remapFromGraphQLSingleInput(entry ? entry.columns : args.values, table),
+              contextColumns,
+              context,
+            );
+
+        const parsedInfo = parseResolveInfo(info, {
+          deep: true,
+        }) as ResolveTree;
+
+        const { columns, hasRelations, withParams } = prepareMutationRelationColumns({
+          relationMap,
+          tables,
+          tableName,
+          typeName,
+          typeNameMapper,
+          resolveName,
+          table,
+          pkNames,
+          parsedInfo,
+          limits,
+          scope,
+          defaultOrderBy: policies?.defaultOrderBy,
+        });
+
+        const returning = nestedEntry
+          ? nested!.withJoinColumns(tableName, nestedEntry.ops, { ...columns }, table)
+          : columns;
+
+        const runInsert = async (target: any, values: Record<string, any>) => {
+          let query = target.insert(table).values(values).returning(returning);
+          if (conflictDoNothing) {
+            query = query.onConflictDoNothing() as any;
+          }
+          return (await query) as Record<string, any>[];
+        };
+
+        const result = nestedEntry
+          ? await writeWithNestedOps({
+              executor,
+              runtime: nested!,
+              tableName,
+              entries: [nestedEntry],
+              remapValues: (values) =>
+                applyContextValues(remapFromGraphQLSingleInput(values, table), contextColumns, context),
+              write: runInsert,
+              context,
+            })
+          : await runInsert(executor, input);
+
+        await after(result);
+
+        if (!result[0]) {
+          // Only reachable under `conflictDoNothing`, which is why the field is nullable
+          // there and non-null everywhere else.
+          if (!conflictDoNothing) {
+            throw drizzleError('The insert returned no row.', { code: 'DRIZZLE_NO_ROW_RETURNED' });
+          }
+          return undefined;
+        }
+
+        const enriched = hasRelations
+          ? await eagerLoadMutationRelations(executor, tableName, result, pkNames, withParams)
+          : result;
+
+        return remapToGraphQLSingleOutput(enriched[0], tableName, table, relationMap);
+      },
+    });
   };
 
   /**
@@ -388,146 +335,114 @@ export const buildWriteResolvers = (primaryKeyPropNames: PrimaryKeyPropNames) =>
     };
 
     const pkNames = primaryKeyPropNames(table);
-    const hooks = policies?.onWrite?.(tableName, 'upsert');
-    const errorCtx: DrizzleErrorContext = { table: tableName, operation: 'upsert', field: fieldName };
 
-    return {
-      name: fieldName,
-      resolver: async (
-        _source,
-        args: { values: Record<string, any> | Record<string, any>[]; onConflict?: OnConflictArg },
-        context,
-        info,
-      ) => {
-        try {
-          return await runMutation(
-            db,
-            context,
-            info,
-            txCtx,
-            async (executor) => {
-              const supplied = single ? [args.values as Record<string, any>] : (args.values as Record<string, any>[]);
-              if (!supplied.length) {
-                throw drizzleError('No values were provided!', { code: 'DRIZZLE_NO_VALUES' });
-              }
-              await runWriteHook(hooks, 'before', {
-                table: tableName,
-                operation: 'upsert',
-                single,
-                args,
-                context,
-                info,
-                tx: executor,
-              });
-
-              const entries = nested?.enabled(tableName)
-                ? supplied.map((values) => nested.split(tableName, values))
-                : undefined;
-              const nestedEntries = entries?.some((entry) => nested!.hasOps(entry.ops)) ? entries : undefined;
-              const contextColumns = policies?.contextValues?.(tableName);
-              const scope = policies?.scope?.(context);
-              const input = nestedEntries
-                ? []
-                : applyContextValuesAll(
-                    remapFromGraphQLArrayInput(entries ? entries.map((entry) => entry.columns) : supplied, table),
-                    contextColumns,
-                    context,
-                  );
-
-              const parsedInfo = parseResolveInfo(info, { deep: true }) as ResolveTree;
-
-              const { columns, hasRelations, withParams } = prepareMutationRelationColumns({
-                relationMap,
-                tables,
-                tableName,
-                typeName,
-                typeNameMapper,
-                resolveName,
-                table,
-                pkNames,
-                parsedInfo,
-                limits,
-                scope,
-                defaultOrderBy: policies?.defaultOrderBy,
-              });
-
-              const returning = nestedEntries
-                ? nested!.withJoinColumns(tableName, mergedOps(nestedEntries), { ...columns }, table)
-                : columns;
-
-              // The conflict plan reads the columns the write actually supplies, so a nested write
-              // — whose rows go in one at a time, each already carrying whatever its parent-side
-              // operations produced — resolves its plan per row rather than once for the batch.
-              const runUpsert = async (target: any, values: Record<string, any>[]) => {
-                const plan = resolveConflictPlan({
-                  table,
-                  values,
-                  onConflict: args.onConflict,
-                  pkNames,
-                  uniqueSets,
-                  excludedRef: excludedColumnRef,
-                  withTarget: true,
-                  buildWhere: (where) =>
-                    extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName)),
-                });
-
-                let query = target.insert(table).values(values).returning(returning);
-                // On conflict the statement updates a row that already exists, so the scope applies
-                // to it exactly as it would to `update<Table>`: a conflicting row the caller cannot
-                // see is left alone rather than taken over.
-                const setWhere = withScope(scope, tableName, table, plan.setWhere);
-                query =
-                  plan.action === 'NOTHING'
-                    ? (query.onConflictDoNothing(plan.target ? { target: plan.target } : undefined) as any)
-                    : (query.onConflictDoUpdate({ target: plan.target!, set: plan.set, setWhere }) as any);
-
-                return (await query) as Record<string, any>[];
-              };
-
-              const result = nestedEntries
-                ? await writeWithNestedOps({
-                    executor,
-                    runtime: nested!,
-                    tableName,
-                    entries: nestedEntries,
-                    remapValues: (values) =>
-                      applyContextValues(remapFromGraphQLSingleInput(values, table), contextColumns, context),
-                    write: (tx, values) => runUpsert(tx, [values]),
-                    context,
-                  })
-                : await runUpsert(executor, input);
-
-              await runWriteHook(hooks, 'after', {
-                table: tableName,
-                operation: 'upsert',
-                single,
-                args,
-                rows: result,
-                context,
-                info,
-                tx: executor,
-              });
-
-              if (single && !result[0]) {
-                return undefined;
-              }
-
-              const enriched = hasRelations
-                ? await eagerLoadMutationRelations(executor, tableName, result, pkNames, withParams)
-                : result;
-
-              return single
-                ? remapToGraphQLSingleOutput(enriched[0], tableName, table, relationMap)
-                : remapToGraphQLArrayOutput(enriched, tableName, table, relationMap);
-            },
-            !!hooks,
-          );
-        } catch (e) {
-          throw withErrorContext(toGraphQLError(e), errorCtx);
-        }
-      },
+    return writeResolver<{ values: Record<string, any> | Record<string, any>[]; onConflict?: OnConflictArg }>({
+      db,
+      tableName,
+      operation: 'upsert',
+      single,
+      fieldName,
+      txCtx,
+      policies,
       args: queryArgs,
-    };
+      run: async ({ executor, args, context, info, before, after }) => {
+        const supplied = single ? [args.values as Record<string, any>] : (args.values as Record<string, any>[]);
+        if (!supplied.length) {
+          throw drizzleError('No values were provided!', { code: 'DRIZZLE_NO_VALUES' });
+        }
+        await before();
+
+        const entries = nested?.enabled(tableName)
+          ? supplied.map((values) => nested.split(tableName, values))
+          : undefined;
+        const nestedEntries = entries?.some((entry) => nested!.hasOps(entry.ops)) ? entries : undefined;
+        const contextColumns = policies?.contextValues?.(tableName);
+        const scope = policies?.scope?.(context);
+        const input = nestedEntries
+          ? []
+          : applyContextValuesAll(
+              remapFromGraphQLArrayInput(entries ? entries.map((entry) => entry.columns) : supplied, table),
+              contextColumns,
+              context,
+            );
+
+        const parsedInfo = parseResolveInfo(info, { deep: true }) as ResolveTree;
+
+        const { columns, hasRelations, withParams } = prepareMutationRelationColumns({
+          relationMap,
+          tables,
+          tableName,
+          typeName,
+          typeNameMapper,
+          resolveName,
+          table,
+          pkNames,
+          parsedInfo,
+          limits,
+          scope,
+          defaultOrderBy: policies?.defaultOrderBy,
+        });
+
+        const returning = nestedEntries
+          ? nested!.withJoinColumns(tableName, mergedOps(nestedEntries), { ...columns }, table)
+          : columns;
+
+        // The conflict plan reads the columns the write actually supplies, so a nested write
+        // — whose rows go in one at a time, each already carrying whatever its parent-side
+        // operations produced — resolves its plan per row rather than once for the batch.
+        const runUpsert = async (target: any, values: Record<string, any>[]) => {
+          const plan = resolveConflictPlan({
+            table,
+            values,
+            onConflict: args.onConflict,
+            pkNames,
+            uniqueSets,
+            excludedRef: excludedColumnRef,
+            withTarget: true,
+            buildWhere: (where) => extractFilters(table, tableName, where, relationFilterCtx(filterCtx, tableName)),
+          });
+
+          let query = target.insert(table).values(values).returning(returning);
+          // On conflict the statement updates a row that already exists, so the scope applies
+          // to it exactly as it would to `update<Table>`: a conflicting row the caller cannot
+          // see is left alone rather than taken over.
+          const setWhere = withScope(scope, tableName, table, plan.setWhere);
+          query =
+            plan.action === 'NOTHING'
+              ? (query.onConflictDoNothing(plan.target ? { target: plan.target } : undefined) as any)
+              : (query.onConflictDoUpdate({ target: plan.target!, set: plan.set, setWhere }) as any);
+
+          return (await query) as Record<string, any>[];
+        };
+
+        const result = nestedEntries
+          ? await writeWithNestedOps({
+              executor,
+              runtime: nested!,
+              tableName,
+              entries: nestedEntries,
+              remapValues: (values) =>
+                applyContextValues(remapFromGraphQLSingleInput(values, table), contextColumns, context),
+              write: (tx, values) => runUpsert(tx, [values]),
+              context,
+            })
+          : await runUpsert(executor, input);
+
+        await after(result);
+
+        if (single && !result[0]) {
+          return undefined;
+        }
+
+        const enriched = hasRelations
+          ? await eagerLoadMutationRelations(executor, tableName, result, pkNames, withParams)
+          : result;
+
+        return single
+          ? remapToGraphQLSingleOutput(enriched[0], tableName, table, relationMap)
+          : remapToGraphQLArrayOutput(enriched, tableName, table, relationMap);
+      },
+    });
   };
 
   const generateUpdate = (
@@ -562,145 +477,117 @@ export const buildWriteResolvers = (primaryKeyPropNames: PrimaryKeyPropNames) =>
 
     // Derived once at build time — PK prop names don't change per request.
     const pkNames = primaryKeyPropNames(table);
-    const hooks = policies?.onWrite?.(tableName, 'update');
-    const errorCtx: DrizzleErrorContext = { table: tableName, operation: 'update', field: fieldName };
 
-    return {
-      name: fieldName,
-      resolver: async (_source, args: { where?: Filters<Table>; set: Record<string, any> }, context, info) => {
-        try {
-          return await runMutation(
-            db,
-            context,
-            info,
-            txCtx,
-            async (executor) => {
-              const { where, set } = args;
-              const scope = policies?.scope?.(context);
-              await runWriteHook(hooks, 'before', {
-                table: tableName,
-                operation: 'update',
-                single,
-                args,
-                context,
-                info,
-                tx: executor,
-              });
-
-              const parsedInfo = parseResolveInfo(info, {
-                deep: true,
-              }) as ResolveTree;
-
-              const { columns, hasRelations, withParams } = prepareMutationRelationColumns({
-                relationMap,
-                tables,
-                tableName,
-                typeName,
-                typeNameMapper,
-                resolveName,
-                table,
-                pkNames,
-                parsedInfo,
-                limits,
-                scope,
-                defaultOrderBy: policies?.defaultOrderBy,
-              });
-
-              const entry = nested?.enabled(tableName) ? nested.split(tableName, set) : undefined;
-              const nestedOps = entry && nested!.hasOps(entry.ops) ? entry.ops : undefined;
-              // A context-derived column is the server's to set, so an update never reassigns
-              // one — that is what stops a row being handed to another owner.
-              const input = stripContextValues(
-                remapUpdateInput(entry ? entry.columns : set, table, tableName),
-                policies?.contextValues?.(tableName),
-              );
-              // A `set` that carries only nested operations is a legitimate update — of the
-              // relation rather than of the row — so it is only empty when neither is present.
-              if (!Object.keys(input).length && !nestedOps) {
-                throw drizzleError('Unable to update with no values specified!', { code: 'DRIZZLE_NO_VALUES' });
-              }
-
-              const relationCtx = relationFilterCtx(filterCtx, tableName);
-              // The scope is ANDed on last, so a caller-supplied `where` can only narrow it.
-              const filters = withScope(
-                scope,
-                tableName,
-                table,
-                single || requireWhere
-                  ? extractRequiredFilters(table, tableName, where, relationCtx)
-                  : where
-                    ? extractFilters(table, tableName, where, relationCtx)
-                    : undefined,
-              );
-
-              if (single) {
-                await assertSingleMatch(executor, table, filters!);
-              }
-
-              const returning = nestedOps
-                ? nested!.withJoinColumns(tableName, nestedOps, { ...columns }, table)
-                : columns;
-
-              const runUpdate = async (target: any, values: Record<string, any>) => {
-                // Nothing to write to the row itself: the operations attach to whatever the
-                // `where` matched, so the rows are read rather than rewritten.
-                const writes = Object.keys(values).length > 0;
-                let query = writes ? target.update(table).set(values) : target.select(returning).from(table);
-                if (filters) {
-                  query = query.where(filters) as any;
-                }
-                return (await (writes ? (query.returning(returning) as any) : query)) as Record<string, any>[];
-              };
-
-              const result = nestedOps
-                ? await updateWithNestedOps({
-                    executor,
-                    runtime: nested!,
-                    tableName,
-                    columns: input,
-                    ops: nestedOps,
-                    remapValues: (values) => values,
-                    write: runUpdate,
-                    context,
-                  })
-                : await runUpdate(executor, input);
-
-              await runWriteHook(hooks, 'after', {
-                table: tableName,
-                operation: 'update',
-                single,
-                args,
-                rows: result,
-                context,
-                info,
-                tx: executor,
-              });
-
-              if (single && result.length > 1) {
-                // A row started matching between the pre-check and the write.
-                throw drizzleError("'where' matched more than one row!", { code: 'DRIZZLE_MULTI_ROW_MATCH' });
-              }
-
-              if (single && !result[0]) {
-                return undefined;
-              }
-
-              const enriched = hasRelations
-                ? await eagerLoadMutationRelations(executor, tableName, result, pkNames, withParams)
-                : result;
-
-              return single
-                ? remapToGraphQLSingleOutput(enriched[0], tableName, table, relationMap)
-                : remapToGraphQLArrayOutput(enriched, tableName, table, relationMap);
-            },
-            !!hooks,
-          );
-        } catch (e) {
-          throw withErrorContext(toGraphQLError(e), errorCtx);
-        }
-      },
+    return writeResolver<{ where?: Filters<Table>; set: Record<string, any> }>({
+      db,
+      tableName,
+      operation: 'update',
+      single,
+      fieldName,
+      txCtx,
+      policies,
       args: queryArgs,
-    };
+      run: async ({ executor, args, context, info, before, after }) => {
+        const { where, set } = args;
+        const scope = policies?.scope?.(context);
+        await before();
+
+        const parsedInfo = parseResolveInfo(info, {
+          deep: true,
+        }) as ResolveTree;
+
+        const { columns, hasRelations, withParams } = prepareMutationRelationColumns({
+          relationMap,
+          tables,
+          tableName,
+          typeName,
+          typeNameMapper,
+          resolveName,
+          table,
+          pkNames,
+          parsedInfo,
+          limits,
+          scope,
+          defaultOrderBy: policies?.defaultOrderBy,
+        });
+
+        const entry = nested?.enabled(tableName) ? nested.split(tableName, set) : undefined;
+        const nestedOps = entry && nested!.hasOps(entry.ops) ? entry.ops : undefined;
+        // A context-derived column is the server's to set, so an update never reassigns
+        // one — that is what stops a row being handed to another owner.
+        const input = stripContextValues(
+          remapUpdateInput(entry ? entry.columns : set, table, tableName),
+          policies?.contextValues?.(tableName),
+        );
+        // A `set` that carries only nested operations is a legitimate update — of the
+        // relation rather than of the row — so it is only empty when neither is present.
+        if (!Object.keys(input).length && !nestedOps) {
+          throw drizzleError('Unable to update with no values specified!', { code: 'DRIZZLE_NO_VALUES' });
+        }
+
+        const relationCtx = relationFilterCtx(filterCtx, tableName);
+        // The scope is ANDed on last, so a caller-supplied `where` can only narrow it.
+        const filters = withScope(
+          scope,
+          tableName,
+          table,
+          single || requireWhere
+            ? extractRequiredFilters(table, tableName, where, relationCtx)
+            : where
+              ? extractFilters(table, tableName, where, relationCtx)
+              : undefined,
+        );
+
+        if (single) {
+          await assertSingleMatch(executor, table, filters!);
+        }
+
+        const returning = nestedOps ? nested!.withJoinColumns(tableName, nestedOps, { ...columns }, table) : columns;
+
+        const runUpdate = async (target: any, values: Record<string, any>) => {
+          // Nothing to write to the row itself: the operations attach to whatever the
+          // `where` matched, so the rows are read rather than rewritten.
+          const writes = Object.keys(values).length > 0;
+          let query = writes ? target.update(table).set(values) : target.select(returning).from(table);
+          if (filters) {
+            query = query.where(filters) as any;
+          }
+          return (await (writes ? (query.returning(returning) as any) : query)) as Record<string, any>[];
+        };
+
+        const result = nestedOps
+          ? await updateWithNestedOps({
+              executor,
+              runtime: nested!,
+              tableName,
+              columns: input,
+              ops: nestedOps,
+              remapValues: (values) => values,
+              write: runUpdate,
+              context,
+            })
+          : await runUpdate(executor, input);
+
+        await after(result);
+
+        if (single && result.length > 1) {
+          // A row started matching between the pre-check and the write.
+          throw drizzleError("'where' matched more than one row!", { code: 'DRIZZLE_MULTI_ROW_MATCH' });
+        }
+
+        if (single && !result[0]) {
+          return undefined;
+        }
+
+        const enriched = hasRelations
+          ? await eagerLoadMutationRelations(executor, tableName, result, pkNames, withParams)
+          : result;
+
+        return single
+          ? remapToGraphQLSingleOutput(enriched[0], tableName, table, relationMap)
+          : remapToGraphQLArrayOutput(enriched, tableName, table, relationMap);
+      },
+    });
   };
 
   /**
@@ -734,8 +621,6 @@ export const buildWriteResolvers = (primaryKeyPropNames: PrimaryKeyPropNames) =>
   ): CreatedResolver => {
     const softDelete = policies?.softDelete?.(tableName);
     const operation: WriteOperation = restore ? 'restore' : 'delete';
-    const hooks = policies?.onWrite?.(tableName, operation);
-    const errorCtx: DrizzleErrorContext = { table: tableName, operation, field: fieldName };
     // Only a soft-deleting table that opted in gets the argument, so the schema itself says
     // which tables can be purged — and `restore` never takes one, having nothing to remove.
     const canHardDelete = !restore && softDelete?.hardDelete === true;
@@ -746,108 +631,84 @@ export const buildWriteResolvers = (primaryKeyPropNames: PrimaryKeyPropNames) =>
       ...(canHardDelete ? { hard: hardDeleteArg } : {}),
     } as GraphQLFieldConfigArgumentMap;
 
-    return {
-      name: fieldName,
-      resolver: async (_source, args: { where?: Filters<Table>; hard?: boolean }, context, info) => {
-        try {
-          return await runMutation(
-            db,
-            context,
-            info,
-            txCtx,
-            async (executor) => {
-              const { where } = args;
-              // `canHardDelete` decides whether the argument exists; this decides what it does,
-              // so a stitched-in `hard: true` on a table that never opted in stays a soft delete.
-              const hard = canHardDelete && args.hard === true;
-              const scope = policies?.scope?.(context);
-              await runWriteHook(hooks, 'before', {
-                table: tableName,
-                operation,
-                single,
-                args,
-                context,
-                info,
-                tx: executor,
-              });
-
-              const parsedInfo = parseResolveInfo(info, {
-                deep: true,
-              }) as ResolveTree;
-
-              const columns = extractSelectedColumnsFromTreeSQLFormat(
-                parsedInfo.fieldsByTypeName[applyObjectTypeName(typeName, tableName, resolveName)]!,
-                table,
-                selectionCtx,
-              );
-
-              const relationCtx = relationFilterCtx(filterCtx, tableName);
-              // Same rule as update: the scope is ANDed on last, so a delete can only ever reach
-              // rows inside it — an out-of-scope row is not matched rather than being refused.
-              // A soft-deleting table adds the marker predicate the same way: `delete` only sees
-              // rows that are not already marked, `restore` only sees the ones that are.
-              const filters = withScope(
-                scope,
-                tableName,
-                table,
-                single || requireWhere
-                  ? extractRequiredFilters(table, tableName, where, relationCtx)
-                  : where
-                    ? extractFilters(table, tableName, where, relationCtx)
-                    : undefined,
-                // A hard delete reads at INCLUDE: the rows it mostly exists to remove are the
-                // ones already marked, which the default EXCLUDE could not reach at all.
-                restore ? 'ONLY' : hard ? 'INCLUDE' : undefined,
-              );
-
-              if (single) {
-                await assertSingleMatch(executor, table, filters!);
-              }
-
-              let query =
-                softDelete && !hard
-                  ? executor.update(table).set({
-                      [softDelete.columnName]: restore ? softDelete.writeRestored : softDelete.writeDeleted(),
-                    })
-                  : executor.delete(table);
-              if (filters) {
-                query = query.where(filters) as any;
-              }
-
-              query = query.returning(columns) as any;
-
-              const result = await query;
-
-              await runWriteHook(hooks, 'after', {
-                table: tableName,
-                operation,
-                single,
-                args,
-                rows: result,
-                context,
-                info,
-                tx: executor,
-              });
-
-              if (single && result.length > 1) {
-                // A row started matching between the pre-check and the write.
-                throw drizzleError("'where' matched more than one row!", { code: 'DRIZZLE_MULTI_ROW_MATCH' });
-              }
-
-              if (single) {
-                return result[0] ? remapToGraphQLSingleOutput(result[0], tableName, table) : undefined;
-              }
-
-              return remapToGraphQLArrayOutput(result, tableName, table);
-            },
-            !!hooks,
-          );
-        } catch (e) {
-          throw withErrorContext(toGraphQLError(e), errorCtx);
-        }
-      },
+    return writeResolver<{ where?: Filters<Table>; hard?: boolean }>({
+      db,
+      tableName,
+      operation,
+      single,
+      fieldName,
+      txCtx,
+      policies,
       args: queryArgs,
-    };
+      run: async ({ executor, args, context, info, before, after }) => {
+        const { where } = args;
+        // `canHardDelete` decides whether the argument exists; this decides what it does,
+        // so a stitched-in `hard: true` on a table that never opted in stays a soft delete.
+        const hard = canHardDelete && args.hard === true;
+        const scope = policies?.scope?.(context);
+        await before();
+
+        const parsedInfo = parseResolveInfo(info, {
+          deep: true,
+        }) as ResolveTree;
+
+        const columns = extractSelectedColumnsFromTreeSQLFormat(
+          parsedInfo.fieldsByTypeName[applyObjectTypeName(typeName, tableName, resolveName)]!,
+          table,
+          selectionCtx,
+        );
+
+        const relationCtx = relationFilterCtx(filterCtx, tableName);
+        // Same rule as update: the scope is ANDed on last, so a delete can only ever reach
+        // rows inside it — an out-of-scope row is not matched rather than being refused.
+        // A soft-deleting table adds the marker predicate the same way: `delete` only sees
+        // rows that are not already marked, `restore` only sees the ones that are.
+        const filters = withScope(
+          scope,
+          tableName,
+          table,
+          single || requireWhere
+            ? extractRequiredFilters(table, tableName, where, relationCtx)
+            : where
+              ? extractFilters(table, tableName, where, relationCtx)
+              : undefined,
+          // A hard delete reads at INCLUDE: the rows it mostly exists to remove are the
+          // ones already marked, which the default EXCLUDE could not reach at all.
+          restore ? 'ONLY' : hard ? 'INCLUDE' : undefined,
+        );
+
+        if (single) {
+          await assertSingleMatch(executor, table, filters!);
+        }
+
+        let query =
+          softDelete && !hard
+            ? executor.update(table).set({
+                [softDelete.columnName]: restore ? softDelete.writeRestored : softDelete.writeDeleted(),
+              })
+            : executor.delete(table);
+        if (filters) {
+          query = query.where(filters) as any;
+        }
+
+        query = query.returning(columns) as any;
+
+        const result = await query;
+
+        await after(result);
+
+        if (single && result.length > 1) {
+          // A row started matching between the pre-check and the write.
+          throw drizzleError("'where' matched more than one row!", { code: 'DRIZZLE_MULTI_ROW_MATCH' });
+        }
+
+        if (single) {
+          return result[0] ? remapToGraphQLSingleOutput(result[0], tableName, table) : undefined;
+        }
+
+        return remapToGraphQLArrayOutput(result, tableName, table);
+      },
+    });
   };
   return { generateInsertArray, generateInsertSingle, generateUpsert, generateUpdate, generateDelete };
 };

--- a/src/util/extensions.ts
+++ b/src/util/extensions.ts
@@ -104,6 +104,12 @@ export const tableFieldExtensions =
   });
 
 /**
+ * One table's bound extension builder — what {@link tableFieldExtensions} returns. Named so
+ * the shared build helpers can take one without restating the signature.
+ */
+export type TableFieldExtensionFactory = ReturnType<typeof tableFieldExtensions>;
+
+/**
  * The parts of a mutation's identity that differ between mutations. Dialect builders that
  * assign every mutation in one loop pair each generated mutation with one of these.
  */

--- a/tests/pglite/mysql-unique-key-filters.test.ts
+++ b/tests/pglite/mysql-unique-key-filters.test.ts
@@ -1,0 +1,60 @@
+// @ts-nocheck — the mock db doesn't satisfy MySqlDatabase, which is fine: no resolver runs here.
+// MySQL builds its schema through the same shared helpers as PostgreSQL and SQLite, so a table
+// feature added there has to reach it too. It did not always: `uniqueKeyFilters` shipped while
+// MySQL had its own copy of the build, and MySQL accepted the option and generated nothing.
+
+import { buildRelations } from 'drizzle-orm';
+import { int, mysqlTable, uniqueIndex, varchar } from 'drizzle-orm/mysql-core';
+import { printType } from 'graphql';
+import { describe, expect, it } from 'vitest';
+import { generateMySQL } from '@/util/builders';
+
+const Stock = mysqlTable(
+  'stock',
+  {
+    id: int('id').primaryKey(),
+    itemId: varchar('item_id', { length: 64 }).notNull(),
+    locationId: varchar('location_id', { length: 64 }).notNull(),
+  },
+  (t) => [uniqueIndex('stock_item_location').on(t.itemId, t.locationId)],
+);
+
+const tables = { Stock };
+const relations = buildRelations(tables, { Stock: {} });
+
+const mockDb: any = { query: { Stock: { findMany: async () => [], findFirst: async () => null } } };
+
+const generate = (uniqueKeyFilters: boolean) =>
+  generateMySQL(mockDb, tables, relations, {
+    relationsDepthLimit: undefined,
+    prefixes: { insert: 'create', delete: 'delete', update: 'update' },
+    suffixes: { list: '', single: 'Single' },
+    conflictDoNothing: false,
+    shouldEagerLoad: () => true,
+    features: {
+      aggregates: true,
+      relationAggregates: true,
+      distinct: true,
+      insert: true,
+      update: true,
+      delete: true,
+      upsert: false,
+      uniqueKeyFilters,
+    },
+  }) as any;
+
+describe('MySQL unique key filters', () => {
+  it('offers a key field on the filter input when enabled', () => {
+    const { inputs } = generate(true);
+    expect(printType(inputs['StockFilters']!)).toContain('itemId_locationId: StockItemIdLocationIdKey');
+    // The key type is reachable only through the field, not registered top-level.
+    const keyType = inputs['StockFilters']!.getFields()['itemId_locationId']!.type as any;
+    expect(printType(keyType)).toContain('itemId: String!');
+    expect(printType(keyType)).toContain('locationId: String!');
+  });
+
+  it('generates nothing when the feature is off', () => {
+    const { inputs } = generate(false);
+    expect(printType(inputs['StockFilters']!)).not.toContain('itemId_locationId');
+  });
+});


### PR DESCRIPTION
Two refactors that collapse the MySQL builder's duplicated copy of the schema build into the shared path, plus one bug the duplication was hiding.

## 1. The dialect-independent stretches of a build (`c8a63ef`)

MySQL carried its own copy of the whole build. Only its mutation half is genuinely different — its writes return no rows, so every mutation reports `{ isSuccess }` instead of the rows it touched. Everything else was a copy: table discovery, the relation graph, the per-build registries and type cache, the filter context, each table's types, the read fields, and the relation resolvers at the end.

Those three stretches move to `build-context.ts` — `prepareBuild`, `addReadFields`, `finalizeBuild` — behind a `SchemaBuildAdapter` whose `returnsRows` flag decides whether a table's types carry the `${Table}Item` outputs.

`addReadFields` returns the types it built rather than registering them: MySQL has no `${Table}Item` output to interleave them with, and registering centrally would reorder the schema type map and drift the printed SDL.

**Fixes a real bug.** The copy is what made #90 ship half-delivered — MySQL accepted `features.uniqueKeyFilters` and generated nothing, because the unique-key map was only ever built in the other builder. `tests/pglite/mysql-unique-key-filters.test.ts` now covers both the enabled and disabled shapes.

## 2. The mutation scaffolding (`c3c7ac4`)

Twelve generated mutation resolvers — six MySQL, five shared pg/SQLite, one shared `updateMany` — each spelled out the same four things by hand: look up the table's `onWrite` hooks, run the statement through `runMutation`, emit the before/after hooks with an identical payload, and tag anything that escapes with the field's error context.

`common/write-scaffold.ts` holds that once. `writeResolver({ ..., run })` takes the statement and hands it `before()` / `after(rows)`.

What stays split is the statement itself — the one real difference. Merging *that* would have meant threading a returning-strategy through every body.

## Net

−1,949 lines across the builders, +639 of shared code.

## Verification

- `biome check` clean (the one remaining warning is the pre-existing `select.ts:174` unused-param baseline)
- `tsc --noEmit` clean for both `src/` and `tests/`
- Full suite green: **81 files / 1296 tests**, which includes the Docker-backed suites — `tests/mysql.test.ts` (73), `tests/mysql-custom.test.ts` (25), `tests/pg.test.ts` (58), `tests/pg-custom.test.ts` (24). So the 98 MySQL resolver tests did exercise the rewritten build path and all six rewritten mutation resolvers against a real MySQL 8 container.

Worth noting separately: CI runs none of this on a pull request — `release.yaml` is the only workflow, it triggers on push to `main`, and its test step runs a hand-listed subset that omits the four Docker suites. A follow-up branch fixes that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)