### PR TITLE
ci: verify pull requests, and stop skipping the Docker suites

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,0 +1,44 @@
+# Everything that has to hold before a change lands, in one place so the pull-request
+# workflow and the release workflow cannot drift apart. Both call this.
+name: Checks
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    # The suite starts MySQL 8 and PostgreSQL containers and waits on them, so it is
+    # minutes rather than seconds. Well clear of that, but not open-ended.
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npx biome check .
+
+      - name: Type check (src)
+        run: npx tsc --noEmit
+
+      # Type-checks tests/ too, which is what makes the `expectTypeOf` assertions
+      # in the dialect suites actually fail the build when the public types drift.
+      - name: Type check (tests)
+        run: npx tsc --noEmit -p tests/tsconfig.json
+
+      # The whole suite, MySQL and PostgreSQL included. Those four files bring their own
+      # containers up through dockerode, so the runner's Docker daemon is all they need —
+      # no service block, no compose file.
+      - name: Test
+        run: npx vitest run

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,11 @@
+# Runs the checks on every pull request, so a change is verified before it is merged
+# rather than after. The release workflow runs the same checks again on `main`.
+name: CI
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  checks:
+    uses: ./.github/workflows/checks.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,13 @@ on:
       - main
 
 jobs:
+  # The same checks the pull request ran. Repeating them on `main` is what makes the
+  # release gate real: a merge commit is not the commit either branch was tested as.
+  checks:
+    uses: ./.github/workflows/checks.yaml
+
   release:
+    needs: checks
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -26,20 +32,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Lint
-        run: npx biome check .
-
-      - name: Type check (src)
-        run: npx tsc --noEmit
-
-      # Type-checks tests/ too, which is what makes the `expectTypeOf` assertions
-      # in the dialect suites actually fail the build when the public types drift.
-      - name: Type check (tests)
-        run: npx tsc --noEmit -p tests/tsconfig.json
-
-      - name: Test (PGlite + SQLite — no Docker required)
-        run: npx vitest run tests/pglite tests/sqlite.test.ts tests/sqlite-conflict.test.ts tests/sqlite-custom.test.ts tests/sqlite-groupby.test.ts tests/sqlite-nested-writes.test.ts tests/sqlite-on-write.test.ts tests/sqlite-soft-delete.test.ts tests/sqlite-tenancy.test.ts tests/sqlite-update-ops-counts.test.ts tests/sqlite-upsert.test.ts
 
       - name: Release
         run: npx semantic-release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,10 @@ drizzle-graphql/
 ├── scripts/
 │   └── build.ts                     # tsup build script (ESM + CJS + types)
 ├── dist/                            # Build output
-├── .github/workflows/release.yaml   # Automated release via semantic-release
+├── .github/workflows/
+│   ├── checks.yaml              # Lint + typecheck + full suite; called by both below
+│   ├── ci.yaml                  # Runs the checks on every pull request
+│   └── release.yaml             # Checks, then semantic-release, on push to main
 ├── .releaserc.json                  # semantic-release config
 ├── biome.json                       # Linter + formatter config
 ├── vitest.config.ts                 # Vitest config


### PR DESCRIPTION
`release.yaml` was the only workflow in the repo. Two consequences:

1. **A pull request got no verification at all.** The workflow triggers on push to `main`, so checks ran only after a merge.
2. **The four Docker-backed suites ran nowhere.** Its test step listed files by hand:
   ```
   npx vitest run tests/pglite tests/sqlite.test.ts tests/sqlite-conflict.test.ts ... (9 more)
   ```
   That list omits `tests/pg.test.ts`, `tests/pg-custom.test.ts`, `tests/mysql.test.ts` and `tests/mysql-custom.test.ts` — 180 tests, and the only ones that run a dialect builder's resolvers against a real PostgreSQL or MySQL server. Everything the list *did* cover is PGlite or SQLite.

## What this does

- **`checks.yaml`** — a reusable workflow (`on: workflow_call`) holding lint → typecheck (src) → typecheck (tests) → test. One copy, so the PR and release paths cannot drift apart.
- **`ci.yaml`** — calls it on every `pull_request` (plus `workflow_dispatch`).
- **`release.yaml`** — calls it too, and `release` now `needs: checks`. The release gate is real, and it runs on the merge commit rather than on whatever each branch was last tested as.

The test step is plain `npx vitest run`. The Docker files bring their own containers up through `dockerode`, so a runner's Docker daemon is all they need — no service block, no compose file, and no file list to keep in sync as tests are added. `timeout-minutes: 30` bounds it; locally the full suite is ~100s once images are cached.

## Verification

`vitest.config.ts` already includes `tests/**/*.test.ts`, so `npx vitest run` picks up all 81 files — confirmed locally: 81 files / 1296 tests pass, `tests/mysql.test.ts` (73) and `tests/pg.test.ts` (58) among them. The hand-written subset in `release.yaml` was the only thing narrowing it.

Workflow YAML parses; the reusable-workflow wiring is exercised the first time this runs, which is on this PR.

Stacked note: independent of #107 — no file overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)