### PR TITLE
feat(errors): classify the value-coercion errors a client can hit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1818,10 +1818,22 @@ to match on prose:
 
 -   `code` classifies the failure — `DRIZZLE_MULTI_ROW_MATCH`, `DRIZZLE_WHERE_REQUIRED`,
     `DRIZZLE_LIMIT_EXCEEDED`, `DRIZZLE_NO_VALUES`, `DRIZZLE_INVALID_FILTER`,
-    `DRIZZLE_INVALID_CURSOR`, and so on. The full union is exported as `DrizzleErrorCode`.
+    `DRIZZLE_INVALID_CURSOR`, `DRIZZLE_INVALID_INPUT_VALUE`, and so on. The full union is
+    exported as `DrizzleErrorCode`.
 -   `drizzle` says what it was about: the Drizzle schema key of the `table`, the `operation`,
     the generated `field`, and the `relation` for a relation field. The type is exported as
     `DrizzleErrorContext`.
+
+A value the request could not supply is `DRIZZLE_INVALID_INPUT_VALUE` — a date that does not
+parse, a `BigInt` argument that is not an integer, a malformed JSON column value — and a write
+naming something that is not a column of its table is `DRIZZLE_UNKNOWN_COLUMN`. The mirror
+image, a stored value the scalar transporting it cannot represent, is
+`DRIZZLE_UNREPRESENTABLE_VALUE`; it says the data is out of range, not that the request was
+wrong.
+
+The `drizzle` block is only on errors raised from inside a field. An argument rejected while
+GraphQL coerces the request — a `BigInt` variable that is not an integer, say — is rejected
+before any resolver runs, so it carries its `code` but no `drizzle` and no `path`.
 
 The **generated** field name is in `extensions.drizzle.field` rather than in the message on
 purpose. A schema that republishes these fields under other names — `RenameRootFields`, a

--- a/src/util/builders/common/errors.ts
+++ b/src/util/builders/common/errors.ts
@@ -1,7 +1,7 @@
 // The `onError` boundary: what a resolver's throw is turned into, the default mapper, and the
 // plumbing that lets a caller replace it.
 
-import { GraphQLError } from 'graphql';
+import { type ASTNode, GraphQLError } from 'graphql';
 import type { DrizzleFieldOperation } from '../../extensions.ts';
 
 /**
@@ -42,6 +42,12 @@ export type DrizzleErrorCode =
   | 'DRIZZLE_INVALID_DISTINCT'
   /** An `onConflict` named a target or update column the upsert cannot use. */
   | 'DRIZZLE_INVALID_ON_CONFLICT'
+  /** A written value could not be converted to what its column stores. */
+  | 'DRIZZLE_INVALID_INPUT_VALUE'
+  /** A write's input named a key that is not a column of the table. */
+  | 'DRIZZLE_UNKNOWN_COLUMN'
+  /** A stored value could not be represented by the scalar that transports it. */
+  | 'DRIZZLE_UNREPRESENTABLE_VALUE'
   /** The request's shared mutation transaction was rolled back, so this field never ran. */
   | 'DRIZZLE_TRANSACTION_ABORTED';
 
@@ -71,9 +77,18 @@ export type DrizzleErrorContext = {
  */
 export const drizzleError = (
   message: string,
-  { code, ...context }: DrizzleErrorContext & { code: DrizzleErrorCode },
+  {
+    code,
+    nodes,
+    ...context
+  }: DrizzleErrorContext & {
+    code: DrizzleErrorCode;
+    /** The AST the error is about, where the throw site has one — it becomes the `locations`. */
+    nodes?: ASTNode | readonly ASTNode[];
+  },
 ): GraphQLError =>
   new GraphQLError(message, {
+    nodes,
     extensions: Object.keys(context).length ? { code, drizzle: context } : { code },
   });
 

--- a/src/util/data-mappers/index.ts
+++ b/src/util/data-mappers/index.ts
@@ -1,5 +1,5 @@
 import { type Column, getTableColumns, is, One, type Table } from 'drizzle-orm';
-import { GraphQLError } from 'graphql';
+import { drizzleError } from '../builders/common/errors.ts';
 import type { TableNamedRelations } from '../builders/index.ts';
 import { getColumnScalarOverride } from '../type-converter/index.ts';
 
@@ -177,7 +177,7 @@ export const remapFromGraphQLCore = (value: any, column: Column, columnName: str
   if (isTimestampColumn) {
     const formatted = new Date(value);
     if (Number.isNaN(formatted.getTime())) {
-      throw new GraphQLError(`Field '${columnName}' is not a valid date!`);
+      throw drizzleError(`Field '${columnName}' is not a valid date!`, { code: 'DRIZZLE_INVALID_INPUT_VALUE' });
     }
 
     return formatted;
@@ -192,7 +192,7 @@ export const remapFromGraphQLCore = (value: any, column: Column, columnName: str
     // Validate it's a real date by parsing
     const check = new Date(dateOnly!);
     if (Number.isNaN(check.getTime())) {
-      throw new GraphQLError(`Field '${columnName}' is not a valid date!`);
+      throw drizzleError(`Field '${columnName}' is not a valid date!`, { code: 'DRIZZLE_INVALID_INPUT_VALUE' });
     }
 
     return dateOnly;
@@ -203,7 +203,7 @@ export const remapFromGraphQLCore = (value: any, column: Column, columnName: str
     try {
       return BigInt(value);
     } catch {
-      throw new GraphQLError(`Field '${columnName}' is not a BigInt!`);
+      throw drizzleError(`Field '${columnName}' is not a BigInt!`, { code: 'DRIZZLE_INVALID_INPUT_VALUE' });
     }
   }
 
@@ -219,7 +219,7 @@ export const remapFromGraphQLCore = (value: any, column: Column, columnName: str
     case 'date': {
       const formatted = new Date(value);
       if (Number.isNaN(formatted.getTime())) {
-        throw new GraphQLError(`Field '${columnName}' is not a valid date!`);
+        throw drizzleError(`Field '${columnName}' is not a valid date!`, { code: 'DRIZZLE_INVALID_INPUT_VALUE' });
       }
 
       return formatted;
@@ -227,7 +227,7 @@ export const remapFromGraphQLCore = (value: any, column: Column, columnName: str
 
     case 'buffer': {
       if (!Array.isArray(value)) {
-        throw new GraphQLError(`Field '${columnName}' is not an array!`);
+        throw drizzleError(`Field '${columnName}' is not an array!`, { code: 'DRIZZLE_INVALID_INPUT_VALUE' });
       }
 
       return Buffer.from(value);
@@ -241,20 +241,24 @@ export const remapFromGraphQLCore = (value: any, column: Column, columnName: str
       try {
         return JSON.parse(value);
       } catch (e) {
-        throw new GraphQLError(
+        throw drizzleError(
           `Invalid JSON in field '${columnName}':\n${e instanceof Error ? e.message : 'Unknown error'}`,
+          {
+            code: 'DRIZZLE_INVALID_INPUT_VALUE',
+          },
         );
       }
     }
 
     case 'array': {
       if (!Array.isArray(value)) {
-        throw new GraphQLError(`Field '${columnName}' is not an array!`);
+        throw drizzleError(`Field '${columnName}' is not an array!`, { code: 'DRIZZLE_INVALID_INPUT_VALUE' });
       }
 
       if (column.columnType === 'PgGeometry' && value.length !== 2) {
-        throw new GraphQLError(
+        throw drizzleError(
           `Invalid float tuple in field '${columnName}': expected array with length of 2, received ${value.length}`,
+          { code: 'DRIZZLE_INVALID_INPUT_VALUE' },
         );
       }
 
@@ -265,7 +269,7 @@ export const remapFromGraphQLCore = (value: any, column: Column, columnName: str
       try {
         return BigInt(value);
       } catch (_error) {
-        throw new GraphQLError(`Field '${columnName}' is not a BigInt!`);
+        throw drizzleError(`Field '${columnName}' is not a BigInt!`, { code: 'DRIZZLE_INVALID_INPUT_VALUE' });
       }
     }
 
@@ -289,7 +293,7 @@ export const remapFromGraphQLSingleInput = (queryInput: Record<string, any>, tab
     } else {
       const column = getTableColumns(table)[key];
       if (!column) {
-        throw new GraphQLError(`Unknown column: ${key}`);
+        throw drizzleError(`Unknown column: ${key}`, { code: 'DRIZZLE_UNKNOWN_COLUMN' });
       }
 
       if (value === null && column.notNull) {

--- a/src/util/scalars/index.ts
+++ b/src/util/scalars/index.ts
@@ -1,32 +1,46 @@
-import { GraphQLError, GraphQLScalarType, Kind } from 'graphql';
+import { GraphQLScalarType, Kind } from 'graphql';
 import { GraphQLDate, GraphQLDateTime, GraphQLJSON, GraphQLUUID } from 'graphql-scalars';
+import { type DrizzleErrorCode, drizzleError } from '../builders/common/errors.ts';
 
-const asDecimalString = (value: unknown): string => {
-  if (typeof value === 'bigint') {
-    return value.toString();
-  }
+// Both scalars below coerce the same way in both directions, so each helper is built once per
+// direction with the code that direction reports: a rejected argument is the client's value to
+// fix, while a rejected column value is the stored data's. graphql-js wraps a `parseValue`
+// throw when it coerces variables, but the wrapper inherits the original's `extensions`, so
+// the code survives that trip.
+const INVALID_INPUT: DrizzleErrorCode = 'DRIZZLE_INVALID_INPUT_VALUE';
+const UNREPRESENTABLE: DrizzleErrorCode = 'DRIZZLE_UNREPRESENTABLE_VALUE';
 
-  if (typeof value === 'number') {
-    if (!Number.isInteger(value)) {
-      throw new GraphQLError(`BigInt cannot represent non-integer value: ${value}`);
+const decimalString =
+  (code: DrizzleErrorCode) =>
+  (value: unknown): string => {
+    if (typeof value === 'bigint') {
+      return value.toString();
     }
-    if (!Number.isSafeInteger(value)) {
-      throw new GraphQLError(
-        `BigInt cannot represent the number ${value} without precision loss — pass it as a string instead`,
-      );
-    }
-    return String(value);
-  }
 
-  if (typeof value === 'string') {
-    if (!/^-?\d+$/.test(value)) {
-      throw new GraphQLError(`BigInt cannot represent non-integer value: "${value}"`);
+    if (typeof value === 'number') {
+      if (!Number.isInteger(value)) {
+        throw drizzleError(`BigInt cannot represent non-integer value: ${value}`, { code });
+      }
+      if (!Number.isSafeInteger(value)) {
+        throw drizzleError(
+          `BigInt cannot represent the number ${value} without precision loss — pass it as a string instead`,
+          { code },
+        );
+      }
+      return String(value);
     }
-    return value;
-  }
 
-  throw new GraphQLError(`BigInt cannot represent value: ${JSON.stringify(value)}`);
-};
+    if (typeof value === 'string') {
+      if (!/^-?\d+$/.test(value)) {
+        throw drizzleError(`BigInt cannot represent non-integer value: "${value}"`, { code });
+      }
+      return value;
+    }
+
+    throw drizzleError(`BigInt cannot represent value: ${JSON.stringify(value)}`, { code });
+  };
+
+const parseDecimal = decimalString(INVALID_INPUT);
 
 /**
  * A 64-bit integer. Always transported as a decimal string, in both directions, so no value
@@ -39,13 +53,13 @@ export const GraphQLBigIntString = new GraphQLScalarType<string, string>({
   description:
     'A 64-bit integer, transported as a decimal string so that values beyond ' +
     "JavaScript's safe integer range survive the round-trip intact.",
-  serialize: asDecimalString,
-  parseValue: asDecimalString,
+  serialize: decimalString(UNREPRESENTABLE),
+  parseValue: parseDecimal,
   parseLiteral: (ast) => {
     if (ast.kind !== Kind.STRING && ast.kind !== Kind.INT) {
-      throw new GraphQLError(`BigInt cannot represent a ${ast.kind}`, { nodes: ast });
+      throw drizzleError(`BigInt cannot represent a ${ast.kind}`, { code: INVALID_INPUT, nodes: ast });
     }
-    return asDecimalString(ast.value);
+    return parseDecimal(ast.value);
   },
 });
 
@@ -54,27 +68,31 @@ export const GraphQLBigIntString = new GraphQLScalarType<string, string>({
 // even though some databases would accept them.
 const numericStringPattern = /^[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?$/;
 
-const asNumericString = (value: unknown): string => {
-  if (typeof value === 'bigint') {
-    return value.toString();
-  }
-
-  if (typeof value === 'number') {
-    if (!Number.isFinite(value)) {
-      throw new GraphQLError(`Decimal cannot represent non-finite value: ${value}`);
+const numericString =
+  (code: DrizzleErrorCode) =>
+  (value: unknown): string => {
+    if (typeof value === 'bigint') {
+      return value.toString();
     }
-    return String(value);
-  }
 
-  if (typeof value === 'string') {
-    if (!numericStringPattern.test(value)) {
-      throw new GraphQLError(`Decimal cannot represent non-numeric value: "${value}"`);
+    if (typeof value === 'number') {
+      if (!Number.isFinite(value)) {
+        throw drizzleError(`Decimal cannot represent non-finite value: ${value}`, { code });
+      }
+      return String(value);
     }
-    return value;
-  }
 
-  throw new GraphQLError(`Decimal cannot represent value: ${JSON.stringify(value)}`);
-};
+    if (typeof value === 'string') {
+      if (!numericStringPattern.test(value)) {
+        throw drizzleError(`Decimal cannot represent non-numeric value: "${value}"`, { code });
+      }
+      return value;
+    }
+
+    throw drizzleError(`Decimal cannot represent value: ${JSON.stringify(value)}`, { code });
+  };
+
+const parseNumeric = numericString(INVALID_INPUT);
 
 /**
  * An arbitrary-precision decimal (`numeric` / `decimal` columns). Always transported as a
@@ -87,13 +105,13 @@ export const GraphQLDecimalString = new GraphQLScalarType<string, string>({
   description:
     'An arbitrary-precision decimal, transported as a numeric string so that values ' +
     "beyond JavaScript's double-precision range survive the round-trip intact.",
-  serialize: asNumericString,
-  parseValue: asNumericString,
+  serialize: numericString(UNREPRESENTABLE),
+  parseValue: parseNumeric,
   parseLiteral: (ast) => {
     if (ast.kind !== Kind.STRING && ast.kind !== Kind.INT && ast.kind !== Kind.FLOAT) {
-      throw new GraphQLError(`Decimal cannot represent a ${ast.kind}`, { nodes: ast });
+      throw drizzleError(`Decimal cannot represent a ${ast.kind}`, { code: INVALID_INPUT, nodes: ast });
     }
-    return asNumericString(ast.value);
+    return parseNumeric(ast.value);
   },
 });
 

--- a/tests/pglite/error-codes.test.ts
+++ b/tests/pglite/error-codes.test.ts
@@ -1,0 +1,148 @@
+import { rm } from 'node:fs/promises';
+import { PGlite } from '@electric-sql/pglite';
+import { buildRelations, sql } from 'drizzle-orm';
+import { bigint, numeric, pgTable, timestamp, uuid } from 'drizzle-orm/pg-core';
+import { drizzle } from 'drizzle-orm/pglite';
+import { type GraphQLSchema, graphql } from 'graphql';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildSchema, GraphQLBigIntString, GraphQLDecimalString } from '@/index';
+import { remapFromGraphQLSingleInput } from '@/util/data-mappers/index';
+
+// ── A table with one column per coercion path the codes below classify ───────
+const Readings = pgTable('readings', {
+  id: uuid('id').primaryKey(),
+  counter: bigint('counter', { mode: 'bigint' }),
+  amount: numeric('amount'),
+  takenAt: timestamp('taken_at'),
+});
+const relations = buildRelations({ Readings }, {});
+const schema = { Readings, relations };
+
+const DATA_DIR = `./tests/.temp/pgdata-error-codes-${Date.now()}`;
+const UUID_A = '11111111-1111-4111-8111-111111111111';
+
+let pglite: PGlite;
+let gqlSchema: GraphQLSchema;
+
+const run = (source: string, variableValues?: Record<string, any>) =>
+  graphql({ schema: gqlSchema, source, contextValue: {}, variableValues });
+
+beforeAll(async () => {
+  pglite = new PGlite(DATA_DIR);
+  await pglite.waitReady;
+  const db = (drizzle as any)({ client: pglite, schema, relations, logger: !!process.env['LOG_SQL'] });
+
+  await db.execute(
+    sql`CREATE TABLE "readings" (
+      "id" uuid PRIMARY KEY NOT NULL,
+      "counter" bigint,
+      "amount" numeric,
+      "taken_at" timestamp
+    );`,
+  );
+
+  gqlSchema = buildSchema(db).schema;
+});
+
+afterAll(async () => {
+  await pglite?.close().catch(() => {});
+  await rm(DATA_DIR, { recursive: true, force: true }).catch(() => {});
+});
+
+/**
+ * Everything a client can get wrong about a *value* answers with one code, so a consumer can
+ * tell "you sent something this column cannot take" apart from the failures that already had
+ * codes — a refused write, a bad cursor, a rejected filter — without reading prose.
+ */
+describe.sequential('invalid input values are classified', () => {
+  it('classifies a BigInt literal that is not an integer', async () => {
+    const res = await run(`mutation {
+      createReadingsSingle(values: { id: "${UUID_A}", counter: "1.5" }) { id }
+    }`);
+
+    expect(res.errors![0]!.message).toMatch(/BigInt cannot represent/);
+    expect(res.errors![0]!.extensions?.['code']).toBe('DRIZZLE_INVALID_INPUT_VALUE');
+  });
+
+  // A variable is coerced before any resolver runs, and graphql-js wraps the scalar's throw in
+  // an error of its own. The wrapper inherits the original's extensions, so the code survives.
+  it('keeps the code on a BigInt variable, which graphql-js rejects before the resolver', async () => {
+    const res = await run(
+      `mutation ($counter: BigInt) {
+        createReadingsSingle(values: { id: "${UUID_A}", counter: $counter }) { id }
+      }`,
+      { counter: 'twelve' },
+    );
+
+    expect(res.errors![0]!.extensions?.['code']).toBe('DRIZZLE_INVALID_INPUT_VALUE');
+    // Raised outside a field, so there is no `drizzle` block to say which one.
+    expect(res.errors![0]!.extensions?.['drizzle']).toBeUndefined();
+  });
+
+  it('classifies a Decimal that is not a number', async () => {
+    const res = await run(`mutation {
+      createReadingsSingle(values: { id: "${UUID_A}", amount: "NaN" }) { id }
+    }`);
+
+    expect(res.errors![0]!.message).toMatch(/Decimal cannot represent/);
+    expect(res.errors![0]!.extensions?.['code']).toBe('DRIZZLE_INVALID_INPUT_VALUE');
+  });
+
+  it('classifies a value of the wrong kind entirely', async () => {
+    const res = await run(`mutation {
+      createReadingsSingle(values: { id: "${UUID_A}", counter: true }) { id }
+    }`);
+
+    expect(res.errors![0]!.extensions?.['code']).toBe('DRIZZLE_INVALID_INPUT_VALUE');
+  });
+});
+
+/**
+ * The remaining coercion guards sit below the scalars, where a generated schema cannot reach
+ * them: they are what catches a hand-built input, or a scalar override that lets more through
+ * than the column can store. They are exercised directly for the same reason.
+ */
+describe('input remapping raises coded errors', () => {
+  it('classifies a date that does not parse', () => {
+    expect(() => remapFromGraphQLSingleInput({ takenAt: 'not-a-date' }, Readings)).toThrowError(
+      expect.objectContaining({ extensions: { code: 'DRIZZLE_INVALID_INPUT_VALUE' } }),
+    );
+  });
+
+  it('classifies a bigint that does not convert', () => {
+    expect(() => remapFromGraphQLSingleInput({ counter: 'twelve' }, Readings)).toThrowError(
+      expect.objectContaining({ extensions: { code: 'DRIZZLE_INVALID_INPUT_VALUE' } }),
+    );
+  });
+
+  it('separates a key that is not a column of the table', () => {
+    expect(() => remapFromGraphQLSingleInput({ nope: 1 }, Readings)).toThrowError(
+      expect.objectContaining({ extensions: { code: 'DRIZZLE_UNKNOWN_COLUMN' } }),
+    );
+  });
+});
+
+/**
+ * The mirror image: a stored value the scalar cannot transport is the data's problem, not the
+ * request's, and says so with its own code — a client retrying with a different argument would
+ * get the same answer.
+ */
+describe('unrepresentable stored values are classified apart', () => {
+  it('classifies a bigint column value the scalar cannot represent', () => {
+    expect(() => GraphQLBigIntString.serialize(1.5)).toThrowError(
+      expect.objectContaining({ extensions: { code: 'DRIZZLE_UNREPRESENTABLE_VALUE' } }),
+    );
+  });
+
+  it('classifies a numeric column value the scalar cannot represent', () => {
+    expect(() => GraphQLDecimalString.serialize(Number.POSITIVE_INFINITY)).toThrowError(
+      expect.objectContaining({ extensions: { code: 'DRIZZLE_UNREPRESENTABLE_VALUE' } }),
+    );
+  });
+
+  it('reports the same value as an invalid input when it arrives as an argument', () => {
+    expect(() => GraphQLBigIntString.parseValue(1.5)).toThrowError(
+      expect.objectContaining({ extensions: { code: 'DRIZZLE_INVALID_INPUT_VALUE' } }),
+    );
+  });
+});


### PR DESCRIPTION
Closes the last gap behind #106.

## What was already there

The bulk of #106 shipped in 8.0.0, after the 7.9.1 the issue was filed against: `DrizzleErrorCode` is exported, 67 throw sites across the library carry one, and both families the issue names by hand are covered — `DRIZZLE_LIMIT_EXCEEDED` for the limit rejection, `DRIZZLE_INVALID_FILTER` / `DRIZZLE_INVALID_ORDER_BY` for the `WHERE` and `ORDER BY` ones. `extensions.drizzle` says which table, operation and generated field it came from.

## What was still uncoded

The coercion layer underneath the resolvers. `src/util/scalars/index.ts` and `src/util/data-mappers/index.ts` between them threw 19 bare `GraphQLError`s, so a client that got `Field 'takenAt' is not a valid date!` had nothing to match on but the prose — and since `withErrorContext` only re-wraps errors whose code starts with `DRIZZLE_`, those errors picked up no `extensions.drizzle` either.

## Three codes

| code | what it says |
| --- | --- |
| `DRIZZLE_INVALID_INPUT_VALUE` | the request supplied a value the column or its scalar cannot take |
| `DRIZZLE_UNKNOWN_COLUMN` | a write's input named a key that is not a column of its table |
| `DRIZZLE_UNREPRESENTABLE_VALUE` | a **stored** value the scalar transporting it cannot represent |

The third is deliberately not the input code. `BigInt` and `Decimal` coerce identically in both directions, and the same helper backs `serialize` and `parseValue` — but a rejected argument is the client's value to fix, while a rejected column value is the data's. A client retrying with a different argument would get the same answer, so the two say so differently. Each helper is now built once per direction with the code that direction reports.

`drizzleError` gained an optional `nodes`, which is what lets the `parseLiteral` guards keep the source locations they used to carry.

## The one thing worth knowing

A scalar rejects an argument *before any resolver runs*, so those errors carry a code but no `drizzle` block and no `path` — there is no field yet to name. graphql-js wraps a `parseValue` throw when it coerces variables, and the wrapper inherits the original's `extensions`; that inheritance is what carries the code out to the client, and there is a test pinning it so a graphql-js change cannot quietly drop it.

Both facts are documented in the README's *What an error carries* section.

## Reachability

The scalar guards are reachable from any generated schema and are tested end-to-end against PGlite. Most of the remapper guards are not — a generated input type is closed, and the scalars validate ahead of them — so they are what catches a hand-built input or a scalar override that lets more through than the column can store. Those are exercised directly, for that reason.

## Verification

`npx biome check .` (clean but for the one pre-existing `select.ts` warning), `npx tsc --noEmit`, `npx tsc --noEmit -p tests/tsconfig.json`, and the full `npx vitest run` — **81 files, 1304 tests, all passing**, Docker-backed MySQL and PostgreSQL suites included. 10 of those tests are new.
