### PR TITLE
feat(deps): admit graphql-scalars 2 in the peer range

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -4,6 +4,14 @@ name: Checks
 
 on:
   workflow_call:
+    inputs:
+      graphql-scalars:
+        description: >-
+          Version range to install over the lockfile's, so the peer range can be checked
+          against a major the lockfile does not pin. Empty means use the lockfile.
+        type: string
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -25,6 +33,12 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      # Not saved: the lockfile stays the source of truth for everything else, and only
+      # this one package is swapped for the run.
+      - name: Install graphql-scalars ${{ inputs.graphql-scalars }}
+        if: inputs.graphql-scalars != ''
+        run: npm install --no-save graphql-scalars@"${{ inputs.graphql-scalars }}"
 
       - name: Lint
         run: npx biome check .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,3 +9,12 @@ on:
 jobs:
   checks:
     uses: ./.github/workflows/checks.yaml
+
+  # `graphql-scalars` is a peer dependency whose range admits both majors, and a lockfile can
+  # only pin one of them. The job above runs against the pinned one; this runs the same checks
+  # against the other, so the range stays something we test rather than something we assert.
+  # It costs runner minutes, not wall clock — the two jobs run side by side.
+  checks-graphql-scalars-v1:
+    uses: ./.github/workflows/checks.yaml
+    with:
+      graphql-scalars: ^1.25.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ drizzle-graphql/
 ├── dist/                            # Build output
 ├── .github/workflows/
 │   ├── checks.yaml              # Lint + typecheck + full suite; called by both below
-│   ├── ci.yaml                  # Runs the checks on every pull request
+│   ├── ci.yaml                  # Checks on every PR, once per graphql-scalars major
 │   └── release.yaml             # Checks, then semantic-release, on push to main
 ├── .releaserc.json                  # semantic-release config
 ├── biome.json                       # Linter + formatter config
@@ -310,3 +310,5 @@ The `exports` field in `package.json` is the authoritative routing table. Never 
 
 ### Peer dependencies
 `drizzle-orm`, `graphql`, `graphql-parse-resolve-info`, and `graphql-scalars` are peer dependencies — they must be provided by the consumer. The library has zero production runtime dependencies except `pluralize`.
+
+`graphql-scalars` is peered at `^1.25.0 || ^2.0.0`. The lockfile pins v2; CI runs the whole suite a second time against v1, so widening or narrowing that range means changing the matrix in `ci.yaml` too.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vantreeseba/drizzle-graphql",
-  "version": "7.8.0",
+  "version": "8.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vantreeseba/drizzle-graphql",
-      "version": "7.8.0",
+      "version": "8.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "pluralize": "^8.0.0"
@@ -31,7 +31,7 @@
         "get-port": "^7.0.0",
         "glob": "^10.3.10",
         "graphql-parse-resolve-info": "^4.14.1",
-        "graphql-scalars": "^1.25.0",
+        "graphql-scalars": "^2.0.0",
         "graphql-yoga": "^5.1.1",
         "mysql2": "^3.9.2",
         "pg": "^8.12.0",
@@ -6069,9 +6069,9 @@
       }
     },
     "node_modules/graphql-scalars": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/graphql-scalars/-/graphql-scalars-1.25.0.tgz",
-      "integrity": "sha512-b0xyXZeRFkne4Eq7NAnL400gStGqG/Sx9VqX0A05nHyEbv57UJnWKsjNnrpVqv5e/8N1MUxkt0wwcRXbiyKcFg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/graphql-scalars/-/graphql-scalars-2.0.0.tgz",
+      "integrity": "sha512-tCd2ddcxlbz5rG7xsfDbjvIssR9c/5EauDYt272pxfxpUNBjFMpnDwukuA3rm1O/9michQDxFfPPAeoQjZtJVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6081,7 +6081,7 @@
         "node": ">=10"
       },
       "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+        "graphql": "^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/graphql-yoga": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "get-port": "^7.0.0",
     "glob": "^10.3.10",
     "graphql-parse-resolve-info": "^4.14.1",
-    "graphql-scalars": "^1.25.0",
+    "graphql-scalars": "^2.0.0",
     "graphql-yoga": "^5.1.1",
     "mysql2": "^3.9.2",
     "pg": "^8.12.0",
@@ -102,7 +102,7 @@
     "drizzle-orm": "^1.0.0-rc.2",
     "graphql": ">=16.3.0",
     "graphql-parse-resolve-info": "^4.13.0",
-    "graphql-scalars": "^1.25.0"
+    "graphql-scalars": "^1.25.0 || ^2.0.0"
   },
   "dependencies": {
     "pluralize": "^8.0.0"


### PR DESCRIPTION
## The problem

`graphql-scalars` **2.0.0** shipped; our peer range still said `^1.25.0`. A consumer already on v2 hits a peer conflict installing this package — the only item on the current backlog that affects users rather than us.

## The change

```diff
-"graphql-scalars": "^1.25.0"
+"graphql-scalars": "^1.25.0 || ^2.0.0"
```

Nothing we import from it changed. We consume four values — `GraphQLDate`, `GraphQLDateTime`, `GraphQLJSON`, `GraphQLUUID` — and v2 still peers `graphql: ^16 || ^17`, same as us. The full suite passes on both majors, **print-schema snapshot included**, which is the assertion that would catch a scalar renaming itself or losing its description.

Verified locally both ways before writing the CI job:

| | tsc (src + tests) | `npx vitest run` |
| --- | --- | --- |
| graphql-scalars 2.0.0 | clean | 82 files, 1306 tests |
| graphql-scalars 1.26.0 | clean | 82 files, 1306 tests |

## Keeping the range honest

A lockfile can only pin one major, so a two-major peer range is a claim with one major's worth of evidence behind it. `ci.yaml` now calls `checks.yaml` twice — once on the lockfile's v2, once with v1 installed over it:

```yaml
  checks-graphql-scalars-v1:
    uses: ./.github/workflows/checks.yaml
    with:
      graphql-scalars: ^1.25.0
```

`checks.yaml` gained an optional `graphql-scalars` input for this; empty (the default) means use the lockfile, so `release.yaml` is unaffected. The override installs with `--no-save`, so the lockfile stays the source of truth for everything else.

This costs runner minutes, not wall clock — the two jobs run side by side, and the previous CI run was 3m31s.

`AGENTS.md` records that widening or narrowing the range means changing the matrix too, so the two cannot drift.
