### PR TITLE
fix(release): detect breaking changes marked with `!`

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,8 +1,18 @@
 {
   "branches": ["main"],
   "plugins": [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
     "@semantic-release/changelog",
     "@semantic-release/npm",
     [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,6 +219,15 @@ All commits must follow the [Conventional Commits](https://www.conventionalcommi
 | `ci` | none | CI/CD changes |
 | `build` | none | build system changes |
 
+The `!` marker only works because `.releaserc.json` sets both `commit-analyzer` and
+`release-notes-generator` to the `conventionalcommits` preset. semantic-release defaults to the
+`angular` preset, whose header pattern is `/^(\w*)(?:\((.*)\))?: (.*)$/` — it does not allow a
+`!`, so under that default a `fix(deps)!:` header parses to a `null` type and the commit becomes
+invisible to *both* plugins: no version bump, and no changelog entry either. That is not
+hypothetical; it is how the drizzle-orm rc.4 peer-floor bump shipped as 8.2.1. Do not remove the
+preset, and if you are ever unsure, add an explicit `BREAKING CHANGE:` footer as well — the footer
+is parsed independently of the header and works under either preset.
+
 **Examples:**
 ```
 feat: add singularTypes option to BuildSchemaConfig

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vantreeseba/drizzle-graphql",
-  "version": "8.1.0",
+  "version": "8.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vantreeseba/drizzle-graphql",
-      "version": "8.1.0",
+      "version": "8.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "pluralize": "^8.0.0"
@@ -24,6 +24,7 @@
         "@types/pg": "^8.11.6",
         "@types/pluralize": "^0.0.33",
         "axios": "^1.6.8",
+        "conventional-changelog-conventionalcommits": "^10.4.0",
         "dockerode": "^5.0.1",
         "drizzle-kit": "^0.31.10",
         "drizzle-orm": "1.0.0-rc.4",
@@ -305,6 +306,16 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@conventional-changelog/template": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.4.0.tgz",
+      "integrity": "sha512-aalGyl7dbB5PArRebDIX43ZvBlXrYm9uWzGJ26t+4SzJVPsOuvfILGGbw5X4yX7i50YEmJ8zvbiWnqH/AAnZqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@drizzle-team/brocli": {
@@ -3825,6 +3836,19 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.4.0.tgz",
+      "integrity": "sha512-Rriac6ZrAlVm6cy9Bz4NSp+WMHpwNXoPIYex+HjCgduAVUSbnew29DQjQw0C4g9u3HtSYzGiGY+pdBXAZo+4aA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@conventional-changelog/template": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/conventional-changelog-writer": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@types/pg": "^8.11.6",
     "@types/pluralize": "^0.0.33",
     "axios": "^1.6.8",
+    "conventional-changelog-conventionalcommits": "^10.4.0",
     "dockerode": "^5.0.1",
     "drizzle-kit": "^0.31.10",
     "drizzle-orm": "1.0.0-rc.4",


### PR DESCRIPTION
Cuts the 9.0.0 that 8.2.1 should have been, and fixes the reason it wasn't.

### The bug

`.releaserc.json` left `commit-analyzer` and `release-notes-generator` on semantic-release's default preset, which is `angular`. Its header pattern is:

```
/^(\w*)(?:\((.*)\))?: (.*)$/
```

No `!`. So a `fix(deps)!:` header does not match at all, and the commit parses with a null type — which makes it invisible to *both* plugins at once. Not "treated as a fix instead of a breaking change": absent. No version bump, and no changelog entry either.

Measured on the actual commit that shipped:

```
"fix(deps)!: require drizzle-orm 1.0.0-rc.4"  => type: undefined  scope: undefined  notes: 0
"fix(deps): bound the graphql peer below 17"  => type: fix        scope: deps       notes: 0
```

and at the analyzer level, on a bang-only commit body:

```
bang-only, conventionalcommits => major
bang-only, angular default     => null
```

### What it cost

8.2.1 moved the `drizzle-orm` peer floor from `^1.0.0-rc.2` to `^1.0.0-rc.4` — rc.4 renamed `MySqlDatabase` and `BaseSQLiteDatabase`, dropped the MySQL `mode` option, and removed the constructor's separate `schema` argument along with `_.fullSchema`. A consumer pinned to rc.2 or rc.3 gets a peer-resolution failure from what semver called a patch. Its release notes mention only "bound the graphql peer below 17"; the rc.4 change is not in the changelog at all.

The repo's earlier `!` commits (`974ad87`, `e0a776f`) cut their majors only because they *also* carried a `BREAKING CHANGE:` footer, which is parsed independently of the header. Nothing was ever validating the marker itself, so the gap stayed invisible until a `!` commit arrived without a footer.

### The fix

Both plugins move to the `conventionalcommits` preset, which parses `!` and synthesizes the breaking-change note from it. `conventional-changelog-conventionalcommits` is added as a devDependency — the preset is not bundled.

This commit carries an explicit `BREAKING CHANGE:` footer as well, so it cuts 9.0.0 under either preset rather than depending on the fix it is shipping. AGENTS.md's Semantic Commits section now records why the preset is load-bearing and recommends the footer whenever there is doubt.

### Verification

`biome check` (1 pre-existing warning), both `tsc --noEmit` projects, `npm run build`, and the full suite: 1328 tests across 83 files, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
