### PR TITLE
fix(release): pin the conventionalcommits preset to v9

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,6 +228,12 @@ hypothetical; it is how the drizzle-orm rc.4 peer-floor bump shipped as 8.2.1. D
 preset, and if you are ever unsure, add an explicit `BREAKING CHANGE:` footer as well — the footer
 is parsed independently of the header and works under either preset.
 
+The preset is pinned to `conventional-changelog-conventionalcommits@9` on purpose. Version 10
+requires `conventional-changelog-writer@9` or newer, and semantic-release 25 resolves
+`conventional-changelog-writer@8`, so v10 throws `Missing helper` at the `generateNotes` step —
+*after* `analyzeCommits` has already succeeded, which means a dry run that only checks the computed
+version will not catch it. Bump the preset past 9 only once semantic-release ships a writer 9.
+
 **Examples:**
 ```
 feat: add singularTypes option to BuildSchemaConfig

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@types/pg": "^8.11.6",
         "@types/pluralize": "^0.0.33",
         "axios": "^1.6.8",
-        "conventional-changelog-conventionalcommits": "^10.4.0",
+        "conventional-changelog-conventionalcommits": "^9.3.1",
         "dockerode": "^5.0.1",
         "drizzle-kit": "^0.31.10",
         "drizzle-orm": "1.0.0-rc.4",
@@ -306,16 +306,6 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
-      }
-    },
-    "node_modules/@conventional-changelog/template": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.4.0.tgz",
-      "integrity": "sha512-aalGyl7dbB5PArRebDIX43ZvBlXrYm9uWzGJ26t+4SzJVPsOuvfILGGbw5X4yX7i50YEmJ8zvbiWnqH/AAnZqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=22"
       }
     },
     "node_modules/@drizzle-team/brocli": {
@@ -3839,16 +3829,16 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.4.0.tgz",
-      "integrity": "sha512-Rriac6ZrAlVm6cy9Bz4NSp+WMHpwNXoPIYex+HjCgduAVUSbnew29DQjQw0C4g9u3HtSYzGiGY+pdBXAZo+4aA==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@conventional-changelog/template": "^1.4.0"
+        "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-changelog-writer": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@types/pg": "^8.11.6",
     "@types/pluralize": "^0.0.33",
     "axios": "^1.6.8",
-    "conventional-changelog-conventionalcommits": "^10.4.0",
+    "conventional-changelog-conventionalcommits": "^9.3.1",
     "dockerode": "^5.0.1",
     "drizzle-kit": "^0.31.10",
     "drizzle-orm": "1.0.0-rc.4",


### PR DESCRIPTION
#114 fixed the analyzer but broke the writer, so the 9.0.0 release run failed and nothing published. `main` currently has a red release workflow.

### What happened

`conventional-changelog-conventionalcommits` resolved to v10, which requires `conventional-changelog-writer@9` or newer. semantic-release 25 resolves writer 8:

```
semantic-release@25.0.9
├─┬ @semantic-release/commit-analyzer@13.0.1
│ └── conventional-changelog-writer@8.4.0
└─┬ @semantic-release/release-notes-generator@14.1.1
    └── conventional-changelog-writer@8.4.0 deduped
```

so `generateNotes` threw:

```
Missing helper: "conventional-changelog-conventionalcommits requires
conventional-changelog-writer@9 or newer ..."
```

### Why the verification missed it

`analyzeCommits` runs first and had already succeeded — the run log reads `The next release version is 9.0.0` — before the writer was ever loaded. The check I ran on #114 asserted the computed release type and stopped there, so it was green against a config that could not render a changelog. The step that fails is the one that has to be exercised.

This time `generateNotes` itself was run against the real commit range, and its output checked:

```
## [9.0.0](.../compare/v8.2.1...v9.0.0) (2026-08-29)

### ⚠ BREAKING CHANGES

* **release:** the drizzle-orm peer range is `^1.0.0-rc.4`. ...

### Bug Fixes

* **release:** detect breaking changes marked with `!` (abc1234)
```

and separately on a bang-only commit with no footer — the case that started all of this — which now yields `major`, a `BREAKING CHANGES` section, and a `Bug Fixes` entry.

### The fix

Pin to `^9.3.1`, which renders against writer 8. AGENTS.md records the constraint and the condition for lifting it: semantic-release shipping writer 9.

Once this merges, the release run picks up both this commit and #114's and cuts **9.0.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
