### PR TITLE
feat(deps)!: vendor the resolve-info parser and support graphql 17

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -5,6 +5,13 @@ name: Checks
 on:
   workflow_call:
     inputs:
+      graphql:
+        description: >-
+          Version range to install over the lockfile's, so the peer range can be checked
+          against a major the lockfile does not pin. Empty means use the lockfile.
+        type: string
+        required: false
+        default: ''
       graphql-scalars:
         description: >-
           Version range to install over the lockfile's, so the peer range can be checked
@@ -35,7 +42,18 @@ jobs:
         run: npm ci
 
       # Not saved: the lockfile stays the source of truth for everything else, and only
-      # this one package is swapped for the run.
+      # the package a leg names is swapped for the run.
+      #
+      # graphql 17 needs no extra setup here, but it is worth knowing why: it routes a
+      # `development` export condition to a second complete copy of itself, and Vite sets that
+      # condition while Node does not — so the repo's sources and `graphql-scalars` can end up
+      # holding different instances of one installed package, surfacing as `Cannot use
+      # GraphQLScalarType "JSON" from another module or realm`. `vitest.config.ts` aliases
+      # `graphql` to the file Node itself resolves, which settles it for both majors.
+      - name: Install graphql ${{ inputs.graphql }}
+        if: inputs.graphql != ''
+        run: npm install --no-save graphql@"${{ inputs.graphql }}"
+
       - name: Install graphql-scalars ${{ inputs.graphql-scalars }}
         if: inputs.graphql-scalars != ''
         run: npm install --no-save graphql-scalars@"${{ inputs.graphql-scalars }}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,8 +13,20 @@ jobs:
   # `graphql-scalars` is a peer dependency whose range admits both majors, and a lockfile can
   # only pin one of them. The job above runs against the pinned one; this runs the same checks
   # against the other, so the range stays something we test rather than something we assert.
-  # It costs runner minutes, not wall clock — the two jobs run side by side.
+  # It costs runner minutes, not wall clock — the jobs run side by side.
   checks-graphql-scalars-v1:
     uses: ./.github/workflows/checks.yaml
     with:
       graphql-scalars: ^1.25.0
+
+  # Same argument for `graphql`, whose peer range has had no upper bound since the resolve-info
+  # parser was vendored in. The lockfile pins 16 — deliberately, via a `^16` devDependency that
+  # exists only to stop npm's peer auto-install floating an unbounded range up to the newest
+  # major — so the default leg keeps testing 16, which leaves 17 tested only here. This is
+  # the leg that would catch graphql 17 changing the resolve-info shape out from under the
+  # vendored parser, and it type-checks too: 17 brands its type classes, so a `GraphQLNonNull`
+  # handed somewhere a nullable type is expected is an error there and not under 16.
+  checks-graphql-17:
+    uses: ./.github/workflows/checks.yaml
+    with:
+      graphql: ^17.0.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ drizzle-graphql/
 │       │   └── types.ts             # Builder-specific types
 │       ├── case-ops/index.ts        # String case utilities
 │       ├── data-mappers/index.ts    # Maps Drizzle row data to GraphQL types
+│       ├── parse-resolve-info.ts    # Vendored resolve-info walker (see Peer dependencies)
 │       └── type-converter/          # Converts Drizzle column types to GraphQL scalars
 ├── tests/
 │   ├── schema/                      # Drizzle schema fixtures for tests
@@ -30,7 +31,7 @@ drizzle-graphql/
 │   │   ├── mysql.ts                 # MySQL test schema
 │   │   └── sqlite.ts                # SQLite test schema
 │   ├── pglite/                      # PGlite integration tests (no Docker required)
-│   ├── util/                        # Test helpers (GraphQL query client)
+│   ├── util/                        # Test helpers (GraphQL query client, message matchers)
 │   ├── pg.test.ts                   # PostgreSQL integration tests (Docker)
 │   ├── pg-custom.test.ts            # PostgreSQL custom resolver tests (Docker)
 │   ├── mysql.test.ts                # MySQL integration tests (Docker)
@@ -42,7 +43,7 @@ drizzle-graphql/
 ├── dist/                            # Build output
 ├── .github/workflows/
 │   ├── checks.yaml              # Lint + typecheck + full suite; called by both below
-│   ├── ci.yaml                  # Checks on every PR, once per graphql-scalars major
+│   ├── ci.yaml                  # Checks on every PR, once per graphql / graphql-scalars major
 │   └── release.yaml             # Checks, then semantic-release, on push to main
 ├── .releaserc.json                  # semantic-release config
 ├── biome.json                       # Linter + formatter config
@@ -150,6 +151,7 @@ npx vitest run -t "some test name"     # filter by name
 - Use `beforeEach` / `afterEach` for table setup and teardown between tests
 - Create a fresh `Context` object per test file for isolation
 - Use `describe.sequential` when tests share mutable database state
+- Never assert a graphql validation error verbatim: 16 and 17 word them differently and the suite runs against both. `tests/util/validation-messages.ts` has matchers for the ones already hit; add to it rather than pinning a sentence
 
 ### Test types
 | Test | Infrastructure | Speed |
@@ -327,9 +329,17 @@ The `exports` field in `package.json` is the authoritative routing table. Never 
 Not yet. Both tsconfig projects typecheck clean under 7.0, and `tsconfig.json` has already dropped the removed `baseUrl` in favour of a relative `paths` entry, which 5.x accepts too. What blocks the bump is the build: `tsup` bundles `rollup-plugin-dts` 6.1.1, which throws `Cannot read properties of undefined (reading 'useCaseSensitiveFileNames')` on a TS 7 compiler, so `dist/*.d.ts` never gets written. `rollup-plugin-dts` 6.5+ supports 7, but tsup has to ship it — an override cannot reach a vendored copy. Retry when tsup releases past 8.5.1.
 
 ### Peer dependencies
-`drizzle-orm`, `graphql`, `graphql-parse-resolve-info`, and `graphql-scalars` are peer dependencies — they must be provided by the consumer. The library has zero production runtime dependencies except `pluralize`.
+`drizzle-orm`, `graphql`, and `graphql-scalars` are peer dependencies — they must be provided by the consumer. The library has zero production runtime dependencies except `pluralize`.
 
-`graphql` is peered at `>=16.3.0 <17`, and the upper bound is not caution. `graphql-parse-resolve-info` — also a peer here, and used on every resolver — peers `graphql` at `^16.3.0` with no 17 entry, so a consumer on graphql 17 cannot get a working install of this library's own required peer; npm refuses the combination outright. Lift the bound when `graphql-parse-resolve-info` ships 17 support.
+`graphql` is peered at `>=16.4.0`, with no upper bound: both 16 and 17 work, and CI runs the whole suite against each. It used to be capped below 17, because `graphql-parse-resolve-info` was a fourth peer, used on every resolver, and peered `graphql` at `^16.3.0` with no 17 entry. That package is now vendored — `src/util/parse-resolve-info.ts` — and the peer is gone.
+
+Vendoring was not impatience. Upstream is dead (4.14.1, unchanged since 2025-04-27, and its own peer range stops at 16), and the package fails under 17 without saying so. It is CommonJS, so it reaches graphql through `require`, and it asks "does this field have sub-selections?" with an `instanceof` against whatever that `require` returned. graphql 17 ships several builds of itself from one package — a `development` export condition routes to a whole second copy under `__dev__/`, and `.js`/`.mjs` sit behind the format conditions — so any loader that resolves the CommonJS graph differently from the ESM one hands it a *different* instance of the same version than the one that built the schema. The `instanceof` then answers "no", the walk returns `fieldsByTypeName: {}`, and every resolver reads a selection of nothing: schema build and validation pass, and the first query dies in `extractSelectedColumnsFromTree` on `Object.entries(undefined)`. Plain `node` happens to resolve both graphs to one instance, so the failure looks intermittent rather than absent — under `tsx` it reproduces on this repo's own schema, and adding `--conditions=development` escalates it to a thrown `Cannot use GraphQLNonNull "[Users!]!" from another module or realm`. The vendored parser asks the same questions structurally (`getFields` / `getTypes` / `ofType`), so it cannot disagree with whichever instance is executing.
+
+The floor is 16.4.0, not 16.3.0, and that one minor is deliberate: the parser uses graphql's own `getArgumentValues` rather than re-deriving argument coercion, and 16.3.0 is the last release that does not re-export it from the package root. It is reachable there only at the internal `graphql/execution/values` path — exactly the kind of deep import that produced the problem above. 16.4.0 is April 2022; re-deriving spec-correct coercion for variables, defaults, enums, input objects and list/non-null wrapping to reach it would be trading a real correctness risk for a theoretical install.
+
+`graphql` is also carried as a `^16` devDependency even though it is a peer. Without it npm's peer auto-install resolves the unbounded range to the newest major and the lockfile floats to 17, which would leave 16 — the major most consumers are on — untested. The lockfile pins 16; the `checks-graphql-17` leg in `ci.yaml` covers the other side.
+
+Under Vitest the same split is why `vitest.config.ts` aliases `graphql` to `createRequire(import.meta.url).resolve('graphql')` — the one file Node itself would load. Vitest transforms the repo's own sources but leaves `graphql-scalars` and `graphql-yoga` to Node, and Vite and Node disagree about which of the several files the package ships is the entry: under 16 there is no `exports` map, so Vite follows `module` to `index.mjs` while Node follows `main` to `index.js`; under 17 there is one, and it routes a `development` condition — Vite sets it, Node does not — to a whole second copy under `__dev__/`. Either way the two sides end up holding different instances and every schema dies on `Cannot use GraphQLScalarType "JSON" from another module or realm`. The alias used to be the hard-coded `graphql/index.js`, which was right for 16 by luck and wrong for 17; resolving it makes it right for both. This is a harness artifact — plain Node has one resolver for the whole graph and never sees it.
 
 `drizzle-orm` is peered at `^1.0.0-rc.4`, and the floor is deliberate rather than cautious: rc.4 renamed `MySqlDatabase` to `MySqlAsyncDatabase` and `BaseSQLiteDatabase` to `SQLiteAsyncDatabase`, dropped the MySQL `mode` option, and finished removing the drizzle constructor's separate `schema` argument, so rc.2 and rc.3 genuinely do not work. Widening the floor back means restoring those names. Note also that a prerelease range admits drizzle's snapshot builds — `1.0.0-rc.4-5d5b77c` sorts *above* `1.0.0-rc.4`, because an alphanumeric prerelease identifier outranks a numeric one — so a consumer on `^1.0.0-rc.4` can land on a build nobody tested. That is why the devDependency is pinned exactly — `npm update` against the caret range really does pull the latest snapshot, and the lockfile has to stay on the version CI runs.
 

--- a/context7.json
+++ b/context7.json
@@ -24,7 +24,7 @@
     "Per-parent paginated to-many relations (relation fields using `limit`/`offset`) require window functions: PostgreSQL, MySQL 8.0+, or SQLite 3.25+.",
     "Standalone request-batched relation resolvers are exported as `entities.fieldResolvers[TableName][relationName]` and dedupe sibling loads into one `IN (...)` query keyed on the GraphQL context.",
     "Configure naming and behavior via `BuildSchemaConfig`: `mutations` (false to omit), `relationsDepthLimit`, `prefixes`, `suffixes`, `typeNameMapper`, `conflictDoNothing` (PG only), and `eagerLoadRelations`.",
-    "Peer dependencies: drizzle-orm ^1.0.0-rc.2, graphql >=16.3.0, graphql-parse-resolve-info ^4.13.0, graphql-scalars ^1.25.0."
+    "Peer dependencies: drizzle-orm ^1.0.0-rc.4, graphql >=16.4.0 (16 and 17 both supported), graphql-scalars ^1.25.0 || ^2.0.0."
   ],
   "previousVersions": []
 }

--- a/llms.txt
+++ b/llms.txt
@@ -9,7 +9,7 @@ Key facts:
 - `buildSchema(db, config?)` returns `{ schema, entities }`.
 - `schema` is a `graphql` `GraphQLSchema` — usable directly by any server that consumes one (e.g. GraphQL Yoga, Apollo).
 - `entities` is `{ queries, mutations, inputs, types, fieldResolvers }` for building a custom schema by hand.
-- Peer dependencies: `drizzle-orm ^1.0.0-rc.2`, `graphql >=16.3.0`, `graphql-parse-resolve-info ^4.13.0`, `graphql-scalars ^1.25.0`.
+- Peer dependencies: `drizzle-orm ^1.0.0-rc.4`, `graphql >=16.4.0` (16 and 17 both supported), `graphql-scalars ^1.25.0 || ^2.0.0`.
 
 ## Quick start
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vantreeseba/drizzle-graphql",
-  "version": "8.2.1",
+  "version": "9.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vantreeseba/drizzle-graphql",
-      "version": "8.2.1",
+      "version": "9.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "pluralize": "^8.0.0"
@@ -29,7 +29,7 @@
         "drizzle-kit": "^0.31.10",
         "drizzle-orm": "1.0.0-rc.4",
         "get-port": "^7.0.0",
-        "graphql-parse-resolve-info": "^4.14.1",
+        "graphql": "^16.14.2",
         "graphql-scalars": "^2.0.0",
         "graphql-yoga": "^5.1.1",
         "mysql2": "^3.9.2",
@@ -46,8 +46,7 @@
       },
       "peerDependencies": {
         "drizzle-orm": "^1.0.0-rc.4",
-        "graphql": ">=16.3.0 <17",
-        "graphql-parse-resolve-info": "^4.13.0",
+        "graphql": ">=16.4.0",
         "graphql-scalars": "^1.25.0 || ^2.0.0"
       }
     },
@@ -5938,27 +5937,10 @@
       "version": "16.14.2",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
       "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
-    "node_modules/graphql-parse-resolve-info": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/graphql-parse-resolve-info/-/graphql-parse-resolve-info-4.14.1.tgz",
-      "integrity": "sha512-WKHukfEuZamP1ZONR84b8iT+4sJgEhtXMDArm1jpXEsU2vTb5EgkCZ4Obfl+v09oNTKXm0CJjPfBUZ5jcJ2Ykg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "tslib": "^2.0.1"
-      },
       "engines": {
-        "node": ">=8.6"
-      },
-      "peerDependencies": {
-        "graphql": ">=0.9 <0.14 || ^14.0.2 || ^15.4.0 || ^16.3.0"
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
     "node_modules/graphql-scalars": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "drizzle-kit": "^0.31.10",
     "drizzle-orm": "1.0.0-rc.4",
     "get-port": "^7.0.0",
-    "graphql-parse-resolve-info": "^4.14.1",
+    "graphql": "^16.14.2",
     "graphql-scalars": "^2.0.0",
     "graphql-yoga": "^5.1.1",
     "mysql2": "^3.9.2",
@@ -98,8 +98,7 @@
   "homepage": "https://github.com/cubicecho/drizzle-graphql",
   "peerDependencies": {
     "drizzle-orm": "^1.0.0-rc.4",
-    "graphql": ">=16.3.0 <17",
-    "graphql-parse-resolve-info": "^4.13.0",
+    "graphql": ">=16.4.0",
     "graphql-scalars": "^1.25.0 || ^2.0.0"
   },
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,8 @@ export type {
   IdentifiedRows,
 } from './util/extensions.ts';
 export { drizzleExtension, identifyRows, isDrizzleFieldExtension } from './util/extensions.ts';
+export type { FieldsByTypeName, ParseResolveInfoOptions, ResolveTree } from './util/parse-resolve-info.ts';
+export { parseResolveInfo } from './util/parse-resolve-info.ts';
 export {
   GraphQLBigIntString,
   GraphQLDate,

--- a/src/util/builders/aggregates.ts
+++ b/src/util/builders/aggregates.ts
@@ -27,11 +27,11 @@ import {
   GraphQLNonNull,
   GraphQLObjectType,
 } from 'graphql';
-import type { ResolveTree } from 'graphql-parse-resolve-info';
-import { parseResolveInfo } from 'graphql-parse-resolve-info';
 import { getOrCreateLoader } from '../batch-loader/index.ts';
 import { capitalize } from '../case-ops/index.ts';
 import { remapToGraphQLCore } from '../data-mappers/index.ts';
+import type { ResolveTree } from '../parse-resolve-info.ts';
+import { parseResolveInfo } from '../parse-resolve-info.ts';
 import { drizzleColumnToGraphQLType } from '../type-converter/index.ts';
 import type { ConvertedColumn } from '../type-converter/types.ts';
 import {

--- a/src/util/builders/common/column-filters.ts
+++ b/src/util/builders/common/column-filters.ts
@@ -24,7 +24,7 @@ import {
   GraphQLUUID,
 } from '../../scalars/index.ts';
 import { drizzleColumnToGraphQLType, getColumnScalarOverride } from '../../type-converter/index.ts';
-import type { ConvertedColumn } from '../../type-converter/types.ts';
+import type { ConvertedColumn, NullableConvertedColumnType } from '../../type-converter/types.ts';
 import type { TypeCacheCtx } from './type-cache.ts';
 import { sharedType, type TypeNameResolver } from './type-names.ts';
 
@@ -335,7 +335,9 @@ export const generateColumnFilterValues = (
     return cached;
   }
 
-  const colType = columnGraphQLType.type;
+  // Built with `forceNullable`, so the value is never a `GraphQLNonNull` — only the union is
+  // wide enough to say so, and graphql 17's branded constructor cares.
+  const colType = columnGraphQLType.type as NullableConvertedColumnType<true>;
   const colArr = new GraphQLList(new GraphQLNonNull(colType));
 
   // Uuid and numeric filters omit the string pattern operators

--- a/src/util/builders/common/cursor.ts
+++ b/src/util/builders/common/cursor.ts
@@ -3,7 +3,7 @@
 
 import type { Table } from 'drizzle-orm';
 import { and, eq, getColumns, gt, isNotNull, isNull, lt, or, type SQL, sql } from 'drizzle-orm';
-import type { ResolveTree } from 'graphql-parse-resolve-info';
+import type { ResolveTree } from '../../parse-resolve-info.ts';
 import { drizzleError } from './errors.ts';
 import type { OrderNullsOption } from './order-by.ts';
 import { orderByEntries, orderExpressions } from './order-by.ts';

--- a/src/util/builders/common/mutation-helpers.ts
+++ b/src/util/builders/common/mutation-helpers.ts
@@ -5,8 +5,8 @@ import type { Column, Table } from 'drizzle-orm';
 import { type SQL, sql } from 'drizzle-orm';
 import type { GraphQLFieldConfigArgumentMap } from 'graphql';
 import { GraphQLBoolean, GraphQLInputObjectType, GraphQLNonNull } from 'graphql';
-import type { ResolveTree } from 'graphql-parse-resolve-info';
 import { capitalize } from '../../case-ops/index.ts';
+import type { ResolveTree } from '../../parse-resolve-info.ts';
 import { remapUpdateInput } from '../field-updates.ts';
 // Type-only: the nested-write module imports this one at runtime, so the dependency has to
 // stay one-directional. The implementation is injected by the dialect builder.

--- a/src/util/builders/common/relation-params.ts
+++ b/src/util/builders/common/relation-params.ts
@@ -3,7 +3,7 @@
 
 import type { Table } from 'drizzle-orm';
 import { is, One } from 'drizzle-orm';
-import type { ResolveTree } from 'graphql-parse-resolve-info';
+import type { ResolveTree } from '../../parse-resolve-info.ts';
 import type { ProcessedTableSelectArgs, TableNamedRelations, TableSelectArgs } from '../types.ts';
 import { isCursorFieldSelected } from './cursor.ts';
 import { primaryKeyOrderExprs } from './keys.ts';
@@ -50,7 +50,7 @@ export const extractRelationsParamsInner = (
     // The relation field resolves to the target table's own type, e.g. "Posts" not "UsersPostsRelation".
     const relTypeName = resolveObjectTypeName(targetTableName, typeNameMapper, resolveName);
     // Look up by field name OR by alias (when the caller uses an alias for the relation).
-    // graphql-parse-resolve-info keys fieldsByTypeName entries by alias.
+    // The parsed tree keys fieldsByTypeName entries by response key, which is the alias.
     const field = baseField[relName] ?? Object.values(baseField).find((f) => (f as ResolveTree).name === relName);
     if (!field) {
       continue;

--- a/src/util/builders/common/select-runtime.ts
+++ b/src/util/builders/common/select-runtime.ts
@@ -3,8 +3,8 @@
 
 import type { Table } from 'drizzle-orm';
 import { and, inArray, type SQL, sql } from 'drizzle-orm';
-import type { ResolveTree } from 'graphql-parse-resolve-info';
 import { remapToGraphQLArrayOutput, remapToGraphQLSingleOutput } from '../../data-mappers/index.ts';
+import type { ResolveTree } from '../../parse-resolve-info.ts';
 import type { ProcessedTableSelectArgs, TableNamedRelations } from '../types.ts';
 import type { CursorOrderEntry, NullOrdering } from './cursor.ts';
 import {

--- a/src/util/builders/common/selected-columns.ts
+++ b/src/util/builders/common/selected-columns.ts
@@ -3,7 +3,7 @@
 
 import type { Column, Table } from 'drizzle-orm';
 import { getColumns } from 'drizzle-orm';
-import type { ResolveTree } from 'graphql-parse-resolve-info';
+import type { ResolveTree } from '../../parse-resolve-info.ts';
 import type { SelectedColumnsRaw, SelectedSQLColumns, TableNamedRelations } from '../types.ts';
 import { extractRelationJoinColumns } from './relations.ts';
 

--- a/src/util/builders/common/unique-keys.ts
+++ b/src/util/builders/common/unique-keys.ts
@@ -13,7 +13,7 @@ import { GraphQLInputObjectType, GraphQLNonNull } from 'graphql';
 import { capitalize } from '../../case-ops/index.ts';
 import { remapFromGraphQLCore } from '../../data-mappers/index.ts';
 import { drizzleColumnToGraphQLType } from '../../type-converter/index.ts';
-import type { ConvertedInputColumn } from '../../type-converter/types.ts';
+import type { ConvertedInputColumn, NullableConvertedColumnType } from '../../type-converter/types.ts';
 import { drizzleError } from './errors.ts';
 import { visibleColumns } from './exclusions.ts';
 import type { TypeNameMapper } from './naming.ts';
@@ -82,8 +82,11 @@ export const generateUniqueKeyFilterFields = (
           members.map((member) => [
             member,
             {
+              // `forceNullable` is on, so the conversion never returns an already-wrapped type;
+              // the cast is only to narrow the union graphql 17 refuses to wrap.
               type: new GraphQLNonNull(
-                drizzleColumnToGraphQLType(columns[member]!, member, tableName, true, false, true).type,
+                drizzleColumnToGraphQLType(columns[member]!, member, tableName, true, false, true)
+                  .type as NullableConvertedColumnType<true>,
               ),
             },
           ]),

--- a/src/util/builders/select.ts
+++ b/src/util/builders/select.ts
@@ -10,8 +10,6 @@
 import type { Table } from 'drizzle-orm';
 import type { RelationalQueryBuilder } from 'drizzle-orm/mysql-core/query-builders/query';
 import type { GraphQLInputObjectType } from 'graphql';
-import type { ResolveTree } from 'graphql-parse-resolve-info';
-import { parseResolveInfo } from 'graphql-parse-resolve-info';
 import {
   applyLimitPolicy,
   type DrizzleErrorContext,
@@ -31,6 +29,8 @@ import {
   withDefaultOrderBy,
   withErrorContext,
 } from '../builders/common.ts';
+import type { ResolveTree } from '../parse-resolve-info.ts';
+import { parseResolveInfo } from '../parse-resolve-info.ts';
 import { missingQueryBuilderError } from './errors.ts';
 import type { CreatedResolver, TableNamedRelations, TableSelectArgs } from './types.ts';
 

--- a/src/util/builders/update-many.ts
+++ b/src/util/builders/update-many.ts
@@ -12,8 +12,6 @@
 import type { Table } from 'drizzle-orm';
 import type { GraphQLFieldConfigArgumentMap, GraphQLInputObjectType } from 'graphql';
 import { GraphQLList, GraphQLNonNull } from 'graphql';
-import type { ResolveTree } from 'graphql-parse-resolve-info';
-import { parseResolveInfo } from 'graphql-parse-resolve-info';
 import {
   drizzleError,
   eagerLoadMutationRelations,
@@ -31,6 +29,8 @@ import {
   writeResolver,
 } from '../builders/common.ts';
 import { remapToGraphQLSingleOutput } from '../data-mappers/index.ts';
+import type { ResolveTree } from '../parse-resolve-info.ts';
+import { parseResolveInfo } from '../parse-resolve-info.ts';
 import { remapUpdateInput } from './field-updates.ts';
 import { mergedOps, type NestedWriteRuntime } from './nested-writes.ts';
 import type { UpdateManyGenerator } from './schema-data.ts';

--- a/src/util/builders/write-resolvers.ts
+++ b/src/util/builders/write-resolvers.ts
@@ -14,14 +14,14 @@ import type { Table } from 'drizzle-orm';
 import type { PgAsyncDatabase } from 'drizzle-orm/pg-core';
 import type { SQLiteAsyncDatabase } from 'drizzle-orm/sqlite-core';
 import { type GraphQLFieldConfigArgumentMap, type GraphQLInputObjectType, GraphQLList, GraphQLNonNull } from 'graphql';
-import type { ResolveTree } from 'graphql-parse-resolve-info';
-import { parseResolveInfo } from 'graphql-parse-resolve-info';
 import {
   remapFromGraphQLArrayInput,
   remapFromGraphQLSingleInput,
   remapToGraphQLArrayOutput,
   remapToGraphQLSingleOutput,
 } from '../data-mappers/index.ts';
+import type { ResolveTree } from '../parse-resolve-info.ts';
+import { parseResolveInfo } from '../parse-resolve-info.ts';
 import {
   applyContextValues,
   applyContextValuesAll,

--- a/src/util/parse-resolve-info.ts
+++ b/src/util/parse-resolve-info.ts
@@ -1,0 +1,337 @@
+// A resolver's `info` carries the query AST, not the selection: reading which fields were
+// actually asked for means walking `fieldNodes`, resolving fragments against `info.fragments`,
+// honouring `@include` / `@skip`, and coercing each field's arguments. Every generated
+// resolver in this library needs that walk before it can decide which columns to SELECT and
+// which relations to join, so it happens on every request.
+//
+// This is an in-repo replacement for `graphql-parse-resolve-info`, which used to be a required
+// peer dependency. That package is CommonJS, so it reaches graphql through `require`, and it
+// decides whether a field has sub-selections with `instanceof` against whatever that `require`
+// returned. graphql 17 ships several builds of itself out of one package — a `development`
+// export condition routes to a whole second copy under `__dev__/`, with `.js`/`.mjs` behind the
+// format conditions — so any loader that resolves the CommonJS graph differently from the ESM
+// one hands it a different instance than the one that built the schema. The `instanceof` then
+// answers "not composite", the walk returns `fieldsByTypeName: {}` instead of throwing, and
+// every resolver downstream reads a selection of nothing. Upstream is dead (4.14.1, unchanged
+// since 2025-04-27) and its own peer range stops at 16, so npm refuses the install as well.
+//
+// The replacement keeps the `ResolveTree` shape byte-for-byte so nothing downstream moves, and
+// answers the "is this composite / what are its fields" questions structurally instead of by
+// `instanceof`, so it cannot silently disagree with the graphql copy that is executing the
+// query. Argument coercion is still graphql's own `getArgumentValues` — spec-correct handling
+// of variables, defaults, enums, input objects and list/non-null wrapping is not worth
+// re-deriving, and passing `info.variableValues` straight through works under both majors
+// (graphql 16 hands resolvers a plain map, graphql 17 a `{ sources, coerced }` record, and each
+// major's `getArgumentValues` expects its own).
+
+import type { DirectiveNode, GraphQLResolveInfo, NamedTypeNode, SelectionNode, ValueNode } from 'graphql';
+import { getArgumentValues, Kind } from 'graphql';
+
+/**
+ * The selections made against one concrete type, keyed by the *response key* — the field's
+ * alias when it has one, otherwise its name. A selection spanning an abstract type has one
+ * entry per type condition it was written against (the interface or union itself included,
+ * when fields were selected directly on it).
+ */
+export interface FieldsByTypeName {
+  [typeName: string]: {
+    [responseKey: string]: ResolveTree;
+  };
+}
+
+/** One selected field: what was asked for, under what alias, with which arguments. */
+export interface ResolveTree {
+  /** The field name as declared in the schema. */
+  name: string;
+  /** The response key — the alias when the selection carried one, otherwise `name`. */
+  alias: string;
+  /** The field's arguments, coerced by graphql's own `getArgumentValues`. */
+  args: {
+    [argName: string]: unknown;
+  };
+  /** The field's own sub-selections, keyed by the type they were written against. */
+  fieldsByTypeName: FieldsByTypeName;
+}
+
+/** Options accepted by {@link parseResolveInfo}. */
+export interface ParseResolveInfoOptions {
+  /**
+   * Whether to descend into sub-selections and fragments. Defaults to `true`; `false` reads
+   * only the root field's own name, alias and arguments.
+   */
+  deep?: boolean;
+}
+
+/**
+ * A GraphQL type as this module needs to see it. Deliberately structural: the type objects on
+ * `info` come from whichever copy of graphql is executing the query, which is not necessarily
+ * the copy this module imported, so `instanceof` is not a question that can be asked here.
+ */
+type TypeLike = {
+  name?: string;
+  ofType?: TypeLike;
+  getFields?: () => Record<string, { type?: TypeLike }>;
+  getTypes?: () => unknown[];
+};
+
+/** Unwraps `[T]!`-style wrappers down to the named type. `getNamedType` without the realm tie. */
+const namedTypeOf = (type: TypeLike | undefined): TypeLike | undefined => {
+  let current = type;
+  while (current?.ofType) {
+    current = current.ofType;
+  }
+  return current;
+};
+
+/**
+ * Whether a field's named output type has sub-selections. Object types and interfaces expose
+ * `getFields`, unions expose `getTypes`; scalars and enums expose neither. Input object types
+ * also expose `getFields`, but an input type can never be a field's output type, so there is
+ * nothing here for that to collide with.
+ */
+const isCompositeLike = (type: TypeLike | undefined): boolean =>
+  !!type && (typeof type.getFields === 'function' || typeof type.getTypes === 'function');
+
+/**
+ * The fields declared on a type, or `undefined` when it has none to declare. A union is the
+ * case that matters: it has no fields of its own, so a selection directly against one resolves
+ * to nothing and is dropped — only the inline fragments underneath contribute.
+ */
+const fieldsOf = (type: TypeLike | undefined): Record<string, { type?: TypeLike }> | undefined =>
+  typeof type?.getFields === 'function' ? type.getFields() : undefined;
+
+/**
+ * The runtime variable values, in the plain-map form the directive check wants. graphql 17
+ * wraps them in `{ sources, coerced }`; graphql 16 hands over the map itself.
+ */
+const coercedVariables = (info: GraphQLResolveInfo): Record<string, unknown> => {
+  const values = info.variableValues as unknown;
+  if (values && typeof values === 'object' && 'coerced' in (values as Record<string, unknown>)) {
+    return ((values as { coerced?: Record<string, unknown> }).coerced ?? {}) as Record<string, unknown>;
+  }
+  return (values ?? {}) as Record<string, unknown>;
+};
+
+/** The value of a `@skip` / `@include` `if:` argument — a literal or a variable reference. */
+const directiveIfValue = (info: GraphQLResolveInfo, value: ValueNode): unknown => {
+  if (value.kind === Kind.VARIABLE) {
+    return coercedVariables(info)[value.name.value];
+  }
+  if (value.kind === Kind.BOOLEAN) {
+    return value.value;
+  }
+  return undefined;
+};
+
+/**
+ * Whether `@skip` / `@include` on this selection exclude it. Applies to fields, fragment
+ * spreads and inline fragments alike, which is where graphql puts them.
+ */
+const isExcluded = (
+  info: GraphQLResolveInfo,
+  node: { readonly directives?: ReadonlyArray<DirectiveNode> },
+): boolean => {
+  for (const directive of node.directives ?? []) {
+    const directiveName = directive.name.value;
+    if (directiveName !== 'skip' && directiveName !== 'include') {
+      continue;
+    }
+    const ifArgument = directive.arguments?.find((argument) => argument.name.value === 'if');
+    if (!ifArgument) {
+      continue;
+    }
+    const value = directiveIfValue(info, ifArgument.value);
+    if (directiveName === 'skip' ? !!value : !value) {
+      return true;
+    }
+  }
+  return false;
+};
+
+/** The type a fragment's `on Type` condition names, looked up in the executing schema. */
+const typeFromCondition = (info: GraphQLResolveInfo, condition: NamedTypeNode): TypeLike | undefined =>
+  info.schema.getType(condition.name.value) as TypeLike | undefined;
+
+/**
+ * Introspection meta-fields are not schema fields and never reach the database. `__typename` is
+ * the one that turns up in practice; `__id` is excluded from the rule because a schema is free
+ * to declare a field by that name.
+ */
+const isMetaField = (name: string): boolean => name.startsWith('__') && name !== '__id';
+
+/**
+ * Merges one selection set into `tree`, which is a `fieldsByTypeName` map — the caller owns the
+ * level, this owns the entries under `parentType`'s name.
+ *
+ * `activeFragments` is the set of fragment names on the current spread path. A document that
+ * passed validation cannot contain a fragment cycle, but this parser also runs on trees a
+ * caller assembled by hand, and an unbounded walk would hang rather than fail.
+ */
+const collectSelections = (
+  selections: ReadonlyArray<SelectionNode>,
+  info: GraphQLResolveInfo,
+  tree: FieldsByTypeName,
+  parentType: TypeLike | undefined,
+  deep: boolean,
+  activeFragments: Set<string>,
+): FieldsByTypeName => {
+  const parentTypeName = parentType?.name;
+  if (!parentTypeName) {
+    return tree;
+  }
+  // Seeded even when nothing under it survives, so a consumer can tell "selected nothing on
+  // this type" from "never reached this type" — the shape `graphql-parse-resolve-info` produced.
+  let fields = tree[parentTypeName];
+  if (!fields) {
+    fields = {};
+    tree[parentTypeName] = fields;
+  }
+
+  for (const selection of selections) {
+    if (isExcluded(info, selection)) {
+      continue;
+    }
+
+    if (selection.kind === Kind.FIELD) {
+      const name = selection.name.value;
+      if (isMetaField(name)) {
+        continue;
+      }
+
+      const fieldDef = fieldsOf(parentType)?.[name];
+      // A field the parent type does not declare: either a union's own selection set, which
+      // carries nothing but meta-fields, or a document that never passed validation.
+      if (!fieldDef) {
+        continue;
+      }
+
+      const fieldType = namedTypeOf(fieldDef.type);
+      if (!fieldType) {
+        continue;
+      }
+      const composite = isCompositeLike(fieldType);
+
+      const alias = selection.alias?.value || name;
+      let node = fields[alias];
+      if (!node) {
+        node = {
+          name,
+          alias,
+          // Spread out of the null-prototype object graphql returns, so downstream code can
+          // treat it as an ordinary record. The casts are on the installed major's own
+          // signature: graphql 17 brands its field type and takes a `{ sources, coerced }`
+          // variables record where 16 takes a plain map, and `info` carries whichever shape
+          // that major's executor produced.
+          args: {
+            ...getArgumentValues(
+              fieldDef as unknown as Parameters<typeof getArgumentValues>[0],
+              selection,
+              info.variableValues as unknown as Parameters<typeof getArgumentValues>[2],
+            ),
+          },
+          fieldsByTypeName: composite && fieldType.name ? { [fieldType.name]: {} } : {},
+        };
+        fields[alias] = node;
+      }
+
+      // Two selections of the same response key merge, exactly as execution merges them: the
+      // first one's arguments stand (validation requires them to be identical) and both
+      // sub-selections are collected into the one node.
+      if (selection.selectionSet && deep && composite) {
+        collectSelections(
+          selection.selectionSet.selections,
+          info,
+          node.fieldsByTypeName,
+          fieldType,
+          deep,
+          activeFragments,
+        );
+      }
+      continue;
+    }
+
+    if (!deep) {
+      continue;
+    }
+
+    if (selection.kind === Kind.FRAGMENT_SPREAD) {
+      const fragmentName = selection.name.value;
+      const fragment = info.fragments?.[fragmentName];
+      if (!fragment) {
+        throw new Error(
+          `Drizzle-GraphQL Error: unknown fragment '${fragmentName}' — it is spread in the query but not defined in the document.`,
+        );
+      }
+      if (activeFragments.has(fragmentName)) {
+        continue;
+      }
+
+      const fragmentType = fragment.typeCondition ? typeFromCondition(info, fragment.typeCondition) : parentType;
+      if (!isCompositeLike(fragmentType)) {
+        continue;
+      }
+
+      activeFragments.add(fragmentName);
+      try {
+        // Spread into the *caller's* level, not a nested one: a fragment contributes its fields
+        // to the selection it was spread into, keyed by its own type condition.
+        collectSelections(fragment.selectionSet.selections, info, tree, fragmentType, deep, activeFragments);
+      } finally {
+        activeFragments.delete(fragmentName);
+      }
+      continue;
+    }
+
+    if (selection.kind === Kind.INLINE_FRAGMENT) {
+      const fragmentType = selection.typeCondition ? typeFromCondition(info, selection.typeCondition) : parentType;
+      if (!isCompositeLike(fragmentType)) {
+        continue;
+      }
+      collectSelections(selection.selectionSet.selections, info, tree, fragmentType, deep, activeFragments);
+    }
+  }
+
+  return tree;
+};
+
+const firstKey = (object: Record<string, unknown>): string | undefined => Object.keys(object)[0];
+
+/**
+ * Reads the selection under a resolver's own field out of its `info`, as a tree of
+ * {@link ResolveTree} nodes.
+ *
+ * ```ts
+ * const parsed = parseResolveInfo(info, { deep: true })!;
+ * const selected = parsed.fieldsByTypeName['Users']; // keyed by response key
+ * ```
+ *
+ * Returns `undefined` when the resolver's field produced no node at all, which in practice
+ * means `info` carried no field nodes.
+ */
+export const parseResolveInfo = (
+  info: GraphQLResolveInfo,
+  options: ParseResolveInfoOptions = {},
+): ResolveTree | undefined => {
+  const fieldNodes = info.fieldNodes;
+  if (!fieldNodes) {
+    throw new Error(
+      'Drizzle-GraphQL Error: resolve info carries no fieldNodes, so no selection could be read from it.',
+    );
+  }
+
+  const tree = collectSelections(
+    fieldNodes,
+    info,
+    {},
+    info.parentType as unknown as TypeLike,
+    options.deep ?? true,
+    new Set(),
+  );
+
+  // Every field node handed to one resolver shares one response key under one parent type, so
+  // the tree has exactly one entry at each of its two top levels — which is the node wanted.
+  const typeKey = firstKey(tree);
+  const fields = typeKey === undefined ? undefined : tree[typeKey];
+  const fieldKey = fields && firstKey(fields);
+  return fieldKey === undefined ? undefined : fields?.[fieldKey];
+};

--- a/src/util/selection.ts
+++ b/src/util/selection.ts
@@ -3,7 +3,6 @@ import { getTableConfig as getMySqlTableConfig, MySqlAsyncDatabase } from 'drizz
 import { getTableConfig as getPgTableConfig, PgAsyncDatabase } from 'drizzle-orm/pg-core';
 import { getTableConfig as getSQLiteTableConfig, SQLiteAsyncDatabase } from 'drizzle-orm/sqlite-core';
 import type { GraphQLResolveInfo } from 'graphql';
-import { parseResolveInfo, type ResolveTree } from 'graphql-parse-resolve-info';
 import type { AnyDrizzleDB } from '../types.ts';
 import {
   attachTargetPrimaryKeys,
@@ -19,6 +18,7 @@ import {
   type TypeNameResolver,
 } from './builders/common.ts';
 import type { TableNamedRelations } from './builders/types.ts';
+import { parseResolveInfo, type ResolveTree } from './parse-resolve-info.ts';
 
 /**
  * Everything the translation needs about a drizzle instance: the tables it holds, the

--- a/src/util/type-converter/index.ts
+++ b/src/util/type-converter/index.ts
@@ -30,6 +30,7 @@ import type {
   ColumnTypeMapper,
   ConvertedColumn,
   EnumNameMapper,
+  NullableConvertedColumnType,
   ScalarOverride,
   ScalarOverridesConfig,
 } from './types.ts';
@@ -384,7 +385,9 @@ export const drizzleColumnToGraphQLType = <TColumn extends Column, TIsInput exte
   }
   if (column.notNull && !(defaultIsNullable && (column.hasDefault || column.defaultFn))) {
     return {
-      type: new GraphQLNonNull(typeDesc.type),
+      // Neither branch above wraps, so this is the only wrapper the column ever gets; the cast
+      // narrows the declared union to the nullable half graphql 17's constructor accepts.
+      type: new GraphQLNonNull(typeDesc.type as NullableConvertedColumnType<boolean>),
       typeLabel: typeDesc.typeLabel,
     } as ConvertedColumn<TIsInput>;
   }

--- a/src/util/type-converter/types.ts
+++ b/src/util/type-converter/types.ts
@@ -113,6 +113,27 @@ export type SchemaDocs = {
   deprecateColumn?: ColumnDeprecator;
 };
 
+/**
+ * The nullable half of a {@link ConvertedColumn} `type` union — what `new GraphQLNonNull(...)`
+ * accepts.
+ *
+ * graphql 17 brands its type classes, so its `GraphQLNonNull` constructor rejects an argument
+ * whose type still admits `GraphQLNonNull` members. graphql 16's `GraphQLList` and
+ * `GraphQLNonNull` are structurally identical, so the same call type-checked there by accident.
+ * A call site that knows it holds an unwrapped column type narrows to this before wrapping.
+ *
+ * Spelled out member by member rather than derived as `Exclude<..., GraphQLNonNull<any>>`:
+ * under graphql 16 that would strip the `GraphQLList` members too, for the same reason.
+ */
+export type NullableConvertedColumnType<TIsInput extends boolean = false> =
+  | GraphQLScalarType
+  | GraphQLEnumType
+  | GraphQLList<GraphQLScalarType>
+  | GraphQLList<GraphQLNonNull<GraphQLScalarType>>
+  | (TIsInput extends true
+      ? GraphQLInputObjectType | GraphQLList<GraphQLInputObjectType>
+      : GraphQLObjectType | GraphQLList<GraphQLObjectType>);
+
 export type ConvertedColumn<TIsInput extends boolean = false> = {
   type:
     | GraphQLScalarType

--- a/tests/parse-resolve-info.test.ts
+++ b/tests/parse-resolve-info.test.ts
@@ -1,0 +1,300 @@
+// Unit tests for the vendored resolve-info parser. These run entirely on graphql — no
+// database — because the shape they pin down (aliases, fragments, directives, argument
+// coercion, abstract types) is the contract every generated resolver reads its column and
+// relation selection out of. The integration suites exercise the happy path; a fragment or
+// directive edge that quietly drops a field would still return data, just the wrong columns.
+
+import type { GraphQLResolveInfo, GraphQLSchema } from 'graphql';
+import { buildSchema, execute, graphql, parse } from 'graphql';
+import { describe, expect, it } from 'vitest';
+import type { ResolveTree } from '@/util/parse-resolve-info';
+import { parseResolveInfo } from '@/util/parse-resolve-info';
+
+const SDL = /* GraphQL */ `
+  enum Colour {
+    RED
+    BLUE
+  }
+
+  input Filter {
+    name: String
+    tags: [String!]
+    nested: Filter
+  }
+
+  interface Node {
+    id: Int!
+  }
+
+  type Post implements Node {
+    id: Int!
+    title: String
+    author: User
+  }
+
+  type Comment implements Node {
+    id: Int!
+    body: String
+  }
+
+  union Feed = Post | Comment
+
+  type User implements Node {
+    id: Int!
+    name: String
+    colour: Colour
+    posts(limit: Int = 3, filter: Filter, ids: [Int!]!, colour: Colour): [Post!]!
+    feed: [Feed!]!
+  }
+
+  type Query {
+    users(limit: Int = 10): [User!]!
+    nodes: [Node!]!
+    feed: [Feed!]!
+  }
+`;
+
+const schemaFor = (): GraphQLSchema => buildSchema(SDL);
+
+/**
+ * Runs `source` against the SDL above with a resolver on `field` that parses its own resolve
+ * info, and hands back the tree. The resolver returns `[]`, so nothing below the root is ever
+ * resolved — the parse is the whole point.
+ */
+const parseAt = async (
+  source: string,
+  options: { field?: string; variables?: Record<string, unknown>; deep?: boolean; validate?: boolean } = {},
+): Promise<ResolveTree | undefined> => {
+  const { field = 'users', variables, deep, validate = true } = options;
+  const schema = schemaFor();
+  let captured: ResolveTree | undefined;
+  const queryField = schema.getQueryType()!.getFields()[field]!;
+  queryField.resolve = (_source: unknown, _args: unknown, _context: unknown, info: GraphQLResolveInfo) => {
+    captured = parseResolveInfo(info, deep === undefined ? { deep: true } : { deep });
+    return [];
+  };
+
+  const result = validate
+    ? await graphql({ schema, source, variableValues: variables })
+    : await execute({ schema, document: parse(source), variableValues: variables });
+  if ('errors' in result && result.errors?.length) {
+    throw result.errors[0];
+  }
+  return captured;
+};
+
+/** The response keys selected on `typeName`, which is what the column extractors iterate. */
+const keysOn = (tree: ResolveTree | undefined, typeName: string): string[] =>
+  Object.keys(tree?.fieldsByTypeName[typeName] ?? {});
+
+describe('parseResolveInfo', () => {
+  it('reads the root field with its name, alias and coerced arguments', async () => {
+    const tree = await parseAt('{ users(limit: 5) { id } }');
+    expect(tree?.name).toBe('users');
+    expect(tree?.alias).toBe('users');
+    expect(tree?.args).toEqual({ limit: 5 });
+    expect(keysOn(tree, 'User')).toEqual(['id']);
+  });
+
+  it('applies a schema default for an omitted argument', async () => {
+    const tree = await parseAt('{ users { id } }');
+    expect(tree?.args).toEqual({ limit: 10 });
+  });
+
+  it('walks nested selections to arbitrary depth', async () => {
+    const tree = await parseAt('{ users { posts(ids: [1]) { author { posts(ids: [2]) { title } } } } }');
+    const posts = tree!.fieldsByTypeName['User']!['posts']!;
+    const author = posts.fieldsByTypeName['Post']!['author']!;
+    const innerPosts = author.fieldsByTypeName['User']!['posts']!;
+    expect(Object.keys(innerPosts.fieldsByTypeName['Post']!)).toEqual(['title']);
+  });
+
+  it('keys entries by response key and keeps the schema name separately', async () => {
+    const tree = await parseAt('{ users { handle: name } }');
+    const entry = tree!.fieldsByTypeName['User']!['handle']!;
+    expect(entry.alias).toBe('handle');
+    expect(entry.name).toBe('name');
+    expect(tree!.fieldsByTypeName['User']!['name']).toBeUndefined();
+  });
+
+  it('keeps one entry per alias when the same field is selected twice', async () => {
+    const tree = await parseAt('{ users { a: posts(ids: [1]) { id } b: posts(ids: [2]) { title } } }');
+    const fields = tree!.fieldsByTypeName['User']!;
+    expect(Object.keys(fields).sort()).toEqual(['a', 'b']);
+    expect(fields['a']!.args).toEqual({ ids: [1], limit: 3 });
+    expect(fields['b']!.args).toEqual({ ids: [2], limit: 3 });
+    expect(Object.keys(fields['a']!.fieldsByTypeName['Post']!)).toEqual(['id']);
+    expect(Object.keys(fields['b']!.fieldsByTypeName['Post']!)).toEqual(['title']);
+  });
+
+  it('merges the sub-selections of two selections that share a response key', async () => {
+    const tree = await parseAt('{ users { posts(ids: [1]) { id } posts(ids: [1]) { title } } }');
+    const posts = tree!.fieldsByTypeName['User']!['posts']!;
+    expect(Object.keys(posts.fieldsByTypeName['Post']!).sort()).toEqual(['id', 'title']);
+  });
+
+  it('resolves named fragment spreads into the level they were spread at', async () => {
+    const tree = await parseAt(`
+      { users { ...UserFields } }
+      fragment UserFields on User { id name }
+    `);
+    expect(keysOn(tree, 'User').sort()).toEqual(['id', 'name']);
+  });
+
+  it('resolves fragments spread inside other fragments', async () => {
+    const tree = await parseAt(`
+      { users { ...Outer } }
+      fragment Outer on User { id ...Inner }
+      fragment Inner on User { name posts(ids: [1]) { ...PostFields } }
+      fragment PostFields on Post { title }
+    `);
+    expect(keysOn(tree, 'User').sort()).toEqual(['id', 'name', 'posts']);
+    const posts = tree!.fieldsByTypeName['User']!['posts']!;
+    expect(Object.keys(posts.fieldsByTypeName['Post']!)).toEqual(['title']);
+  });
+
+  it('resolves inline fragments on the same type', async () => {
+    const tree = await parseAt('{ users { id ... on User { name } } }');
+    expect(keysOn(tree, 'User').sort()).toEqual(['id', 'name']);
+  });
+
+  it('resolves an inline fragment with no type condition against the enclosing type', async () => {
+    const tree = await parseAt('{ users { id ... @include(if: true) { name } } }');
+    expect(keysOn(tree, 'User').sort()).toEqual(['id', 'name']);
+  });
+
+  it('keys a selection over an interface by every type condition it was written against', async () => {
+    const tree = await parseAt('{ nodes { id ... on Post { title } ... on Comment { body } } }', { field: 'nodes' });
+    expect(keysOn(tree, 'Node')).toEqual(['id']);
+    expect(keysOn(tree, 'Post')).toEqual(['title']);
+    expect(keysOn(tree, 'Comment')).toEqual(['body']);
+  });
+
+  it('keys a union selection by its concrete members', async () => {
+    const tree = await parseAt('{ feed { __typename ... on Post { title } ... on Comment { body } } }', {
+      field: 'feed',
+    });
+    // The union itself declares no fields, so its own entry stays empty.
+    expect(keysOn(tree, 'Feed')).toEqual([]);
+    expect(keysOn(tree, 'Post')).toEqual(['title']);
+    expect(keysOn(tree, 'Comment')).toEqual(['body']);
+  });
+
+  it('drops __typename and other meta fields', async () => {
+    const tree = await parseAt('{ users { __typename id } }');
+    expect(keysOn(tree, 'User')).toEqual(['id']);
+  });
+
+  it('seeds an empty entry for a composite field whose selection contributed nothing', async () => {
+    const tree = await parseAt('{ users { __typename } }');
+    expect(tree?.fieldsByTypeName).toEqual({ User: {} });
+  });
+
+  describe('directives', () => {
+    it('honours a literal @skip and @include on a field', async () => {
+      const tree = await parseAt('{ users { id name @skip(if: true) colour @include(if: false) } }');
+      expect(keysOn(tree, 'User')).toEqual(['id']);
+    });
+
+    it('honours a variable-driven @skip on a field', async () => {
+      const tree = await parseAt('query ($s: Boolean!) { users { id name @skip(if: $s) } }', {
+        variables: { s: true },
+      });
+      expect(keysOn(tree, 'User')).toEqual(['id']);
+      const kept = await parseAt('query ($s: Boolean!) { users { id name @skip(if: $s) } }', {
+        variables: { s: false },
+      });
+      expect(keysOn(kept, 'User').sort()).toEqual(['id', 'name']);
+    });
+
+    it('honours a variable-driven @include on a field', async () => {
+      const tree = await parseAt('query ($i: Boolean!) { users { id name @include(if: $i) } }', {
+        variables: { i: false },
+      });
+      expect(keysOn(tree, 'User')).toEqual(['id']);
+    });
+
+    it('honours directives on a fragment spread', async () => {
+      const source = `
+        query ($i: Boolean!) { users { id ...UserFields @include(if: $i) } }
+        fragment UserFields on User { name }
+      `;
+      expect(keysOn(await parseAt(source, { variables: { i: false } }), 'User')).toEqual(['id']);
+      expect(keysOn(await parseAt(source, { variables: { i: true } }), 'User').sort()).toEqual(['id', 'name']);
+    });
+
+    it('honours directives on an inline fragment', async () => {
+      const source = 'query ($s: Boolean!) { users { id ... on User @skip(if: $s) { name } } }';
+      expect(keysOn(await parseAt(source, { variables: { s: true } }), 'User')).toEqual(['id']);
+      expect(keysOn(await parseAt(source, { variables: { s: false } }), 'User').sort()).toEqual(['id', 'name']);
+    });
+  });
+
+  describe('argument coercion', () => {
+    it('coerces variables, enums, input objects, lists and defaults', async () => {
+      const tree = await parseAt(
+        `query ($limit: Int!, $name: String) {
+           users { posts(limit: $limit, ids: [1, 2], colour: RED, filter: { name: $name, tags: ["a"] }) { id } }
+         }`,
+        { variables: { limit: 7, name: 'ada' } },
+      );
+      const posts = tree!.fieldsByTypeName['User']!['posts']!;
+      expect(posts.args).toEqual({
+        limit: 7,
+        ids: [1, 2],
+        colour: 'RED',
+        filter: { name: 'ada', tags: ['a'] },
+      });
+    });
+
+    it('coerces a single value into a list argument, as the spec requires', async () => {
+      const tree = await parseAt('{ users { posts(ids: 1) { id } } }');
+      expect(tree!.fieldsByTypeName['User']!['posts']!.args['ids']).toEqual([1]);
+    });
+
+    it('coerces a nested input object through a variable', async () => {
+      const tree = await parseAt('query ($f: Filter) { users { posts(ids: [1], filter: $f) { id } } }', {
+        variables: { f: { name: 'x', nested: { name: 'y' } } },
+      });
+      expect(tree!.fieldsByTypeName['User']!['posts']!.args['filter']).toEqual({
+        name: 'x',
+        nested: { name: 'y' },
+      });
+    });
+
+    it('returns plain objects, not null-prototype ones', async () => {
+      const tree = await parseAt('{ users(limit: 1) { id } }');
+      expect(Object.getPrototypeOf(tree!.args)).toBe(Object.prototype);
+    });
+  });
+
+  describe('deep: false', () => {
+    it('reads the root field only', async () => {
+      const tree = await parseAt('{ users(limit: 2) { id posts(ids: [1]) { title } } }', { deep: false });
+      expect(tree?.args).toEqual({ limit: 2 });
+      // The composite entry is still seeded; nothing under it is walked.
+      expect(tree?.fieldsByTypeName).toEqual({ User: {} });
+    });
+  });
+
+  describe('malformed documents', () => {
+    it('throws on a fragment spread with no definition', async () => {
+      await expect(
+        parseAt(
+          `{ users { ...Missing } }
+           fragment Unused on User { id }`,
+          { validate: false },
+        ),
+      ).rejects.toThrow(/unknown fragment 'Missing'/);
+    });
+
+    it('terminates on a self-referential fragment instead of recursing forever', async () => {
+      const tree = await parseAt(
+        `{ users { ...Loop } }
+         fragment Loop on User { id ...Loop }`,
+        { validate: false },
+      );
+      expect(keysOn(tree, 'User')).toEqual(['id']);
+    });
+  });
+});

--- a/tests/pglite/exclusions.test.ts
+++ b/tests/pglite/exclusions.test.ts
@@ -12,6 +12,7 @@ import {
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { buildSchema, type SchemaExclusions } from '@/index';
 import * as schema from '../schema/pg';
+import { unknownInputField } from '../util/validation-messages';
 import { setupTables } from './common';
 
 const DATA_DIR = `./tests/.temp/pgdata-exclusions-${Date.now()}`;
@@ -171,7 +172,7 @@ describe.sequential('schema exclusions', () => {
       expect(selected.errors?.[0]?.message).toMatch(/Cannot query field "content"/);
 
       const filtered = await run(gqlSchema, `{ posts(where: { content: { eq: "1MESSAGE" } }) { id } }`);
-      expect(filtered.errors?.[0]?.message).toMatch(/Field "content" is not defined/);
+      expect(filtered.errors?.[0]?.message).toMatch(unknownInputField('content'));
     });
 
     it('leaves the rest of the table working, including inserts', async () => {

--- a/tests/pglite/filter-types.test.ts
+++ b/tests/pglite/filter-types.test.ts
@@ -5,6 +5,7 @@ import { drizzle } from 'drizzle-orm/pglite';
 import { type GraphQLInputObjectType, type GraphQLSchema, graphql } from 'graphql';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { buildSchema } from '@/index';
+import { unknownInputField } from '../util/validation-messages';
 
 // ── Schema mixing id-named columns of different data types ────────────────────
 // The filter a column gets must follow its data type, never its name: a
@@ -160,7 +161,7 @@ describe.sequential('filter selection by column type', () => {
     });
 
     expect(result.errors).toBeDefined();
-    expect(result.errors![0]!.message).toMatch(/field "like" is not defined/i);
+    expect(result.errors![0]!.message).toMatch(unknownInputField('like'));
   });
 
   it('still filters an integer id column by equality and range at runtime', async () => {

--- a/tests/pglite/json-array-filters.test.ts
+++ b/tests/pglite/json-array-filters.test.ts
@@ -6,6 +6,7 @@ import { drizzle } from 'drizzle-orm/pglite';
 import { type GraphQLInputObjectType, type GraphQLSchema, graphql } from 'graphql';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { buildSchema } from '@/index';
+import { unknownInputField } from '../util/validation-messages';
 
 // ── Schema covering json + int/text array columns ────────────────────────────
 const Items = pgTable('items', {
@@ -153,7 +154,7 @@ describe.sequential('filter input shape', () => {
     // (whole-array IN) and covered by the string-array regression tests for issue #15.
     for (const where of ['{ meta: { like: "x" } }', '{ nums: { lt: [1] } }']) {
       const res = await run(`{ items(where: ${where}) { id } }`);
-      expect(res.errors?.[0]?.message).toMatch(/is not defined by type/);
+      expect(res.errors?.[0]?.message).toMatch(unknownInputField(where.includes('like') ? 'like' : 'lt'));
     }
   });
 });

--- a/tests/pglite/unique-key-filters.test.ts
+++ b/tests/pglite/unique-key-filters.test.ts
@@ -6,6 +6,7 @@ import { drizzle } from 'drizzle-orm/pglite';
 import { type GraphQLSchema, graphql, printType } from 'graphql';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { buildSchema } from '@/index';
+import { missingRequiredInputField, unknownInputField } from '../util/validation-messages';
 
 // ── One table per shape a unique constraint comes in ──────────────────────────
 const Stock = pgTable(
@@ -135,7 +136,7 @@ describe.sequential('unique key filters', () => {
     const res = await run(`{ stockSingle(where: { itemId_locationId: { itemId: "widget" } }) { id } }`);
 
     expect(res.data).toBeUndefined();
-    expect(res.errors?.[0]?.message).toContain('Field "StockItemIdLocationIdKey.locationId" of required type');
+    expect(res.errors?.[0]?.message).toMatch(missingRequiredInputField('StockItemIdLocationIdKey', 'locationId'));
   });
 
   it('takes the key from variables', async () => {
@@ -223,6 +224,6 @@ describe.sequential('unique key filters', () => {
       contextValue: {},
     });
 
-    expect(res.errors?.[0]?.message).toContain('Field "itemId_locationId" is not defined');
+    expect(res.errors?.[0]?.message).toMatch(unknownInputField('itemId_locationId'));
   });
 });

--- a/tests/util/validation-messages.ts
+++ b/tests/util/validation-messages.ts
@@ -1,0 +1,22 @@
+/**
+ * Matchers for graphql's own input-coercion validation errors.
+ *
+ * The suite runs against both graphql majors, and 17 reworded these messages: where 16 says
+ * `Field "x" is not defined by type "T".`, 17 says `Expected value of type "T" not to include
+ * unknown field "x", found: …`. The assertions care that the right field on the right type was
+ * rejected, not which sentence the installed major phrases it in, so they match on the parts
+ * the two wordings share.
+ */
+
+const quoteForRegex = (literal: string): string => literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/** An input field the type does not declare was supplied. */
+export const unknownInputField = (field: string): RegExp =>
+  new RegExp(`(?:Field "${quoteForRegex(field)}" is not defined|unknown field "${quoteForRegex(field)}")`, 'i');
+
+/** A required input field was left out. */
+export const missingRequiredInputField = (type: string, field: string): RegExp =>
+  new RegExp(
+    `(?:Field "${quoteForRegex(type)}\\.${quoteForRegex(field)}" of required type` +
+      `|type "${quoteForRegex(type)}" to include required field "${quoteForRegex(field)}")`,
+  );

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,8 @@
+import { createRequire } from 'node:module';
 import { viteCommonjs } from '@originjs/vite-plugin-commonjs';
 import { defineConfig } from 'vitest/config';
+
+const GRAPHQL_ENTRY = createRequire(import.meta.url).resolve('graphql');
 
 export default defineConfig({
   test: {
@@ -19,5 +22,15 @@ export default defineConfig({
   },
   plugins: [viteCommonjs()],
   // Vite resolves `@/*` from tsconfig natively since 7.2; `vite-tsconfig-paths` used to do it.
-  resolve: { tsconfigPaths: true, alias: { graphql: 'graphql/index.js' } },
+  //
+  // `graphql` is aliased to the one file Node itself would load, because Vite and Node do not
+  // agree on which of the several files the package ships is *the* one. Both majors offer more
+  // than one: 16 has no `exports` map, so Vite follows `module` to `index.mjs` while Node
+  // follows `main` to `index.js`; 17 has one, and routes a `development` condition — which Vite
+  // sets and Node does not — to a second complete copy under `__dev__/`. Vitest transforms the
+  // repo's own sources but leaves `graphql-scalars` and `graphql-yoga` to Node, so without the
+  // alias the two sides hold different instances of the same installed version and every schema
+  // dies on `Cannot use GraphQLScalarType "JSON" from another module or realm`. Resolving it
+  // here, rather than hard-coding a path, is what makes it hold across both majors.
+  resolve: { tsconfigPaths: true, alias: { graphql: GRAPHQL_ENTRY } },
 });


### PR DESCRIPTION
Closes #118

`graphql-parse-resolve-info` was a required peer dependency used by every generated resolver, it peers `graphql` at `^16.3.0` with no 17 entry, and upstream has not published since 2025-04-27. It is now vendored as `src/util/parse-resolve-info.ts`, the peer is gone, and the `graphql` peer range is `>=16.4.0` with no upper bound.

## Why it had to be vendored, not just pinned

The package is CommonJS, so it reaches graphql through `require`, and it decides whether a field has sub-selections with `instanceof` against whatever that `require` returned. graphql 17 ships several builds of itself out of one package: a `development` export condition routes to a second complete copy under `__dev__/`, and `.js`/`.mjs` sit behind the format conditions. Any loader that resolves the CommonJS graph differently from the ESM one therefore hands it a *different instance* of the same installed version than the one that built the schema — the `instanceof` answers "not composite", and the walk returns `fieldsByTypeName: {}` **without throwing**.

Reproduced on this repo's own SQLite fixture, in plain Node under `tsx`, against graphql 17.0.2:

```
gpri : {"name":"users","alias":"users","args":{},"fieldsByTypeName":{}}
ours : {"name":"users","alias":"users","args":{},"fieldsByTypeName":{"Users":{"id":…,"posts":{…}}}}
```

Adding `--conditions=development` escalates the same run to a thrown `Cannot use GraphQLNonNull "[Users!]!" from another module or realm`. Bare `node` happens to resolve both graphs to one instance, which is why the failure reads as intermittent rather than absent — and why a build-and-validate check proves nothing here.

## The vendored parser's contract

`parseResolveInfo(info, { deep = true })` returns the `ResolveTree` for the resolver's own field, or `undefined` when `info` produced no node.

```ts
interface ResolveTree {
  name: string;              // field name as declared in the schema
  alias: string;             // response key — the alias, or `name`
  args: Record<string, unknown>;
  fieldsByTypeName: { [typeName: string]: { [responseKey: string]: ResolveTree } };
}
```

- **Shape is unchanged** from the package it replaces, so none of the 39 `ResolveTree` references or 15 `parseResolveInfo` call sites moved.
- **Nesting** to arbitrary depth; `deep: false` reads only the root field's name, alias and args.
- **Fragments** — named spreads, spreads nested inside other fragments, and inline fragments with or without a type condition — contribute their fields to the level they were spread into, keyed by their own type condition.
- **`@include(if:)` / `@skip(if:)`** on fields, spreads and inline fragments alike, evaluating both literals and variables.
- **Aliases**: the inner map is keyed by *response key*; `name` carries the schema field name. Two selections sharing a response key merge into one node, exactly as execution merges them.
- **Arguments** are coerced by graphql's own `getArgumentValues` — variables, schema defaults, enums, input objects, list and non-null wrapping — with `info.variableValues` passed straight through, because 16 hands resolvers a plain map and 17 a `{ sources, coerced }` record and each major's coercion expects its own. The result is spread into a plain-prototype object.
- **Abstract types**: a selection spanning an interface or union gets one `fieldsByTypeName` entry per type condition it was written against. A composite field whose selection contributed nothing still gets an empty seeded entry, so "selected nothing here" stays distinguishable from "never reached here".
- **Meta-fields** (`__typename` and friends) are dropped; `__id` is exempted so a schema may declare it.
- **Realm-independent**: "is this composite / what are its fields" is answered structurally via `getFields` / `getTypes` / `ofType`, never `instanceof`, so the parser cannot disagree with the graphql instance that is executing.
- **Two behaviours the original left implicit**: an unknown fragment spread throws naming the fragment instead of silently contributing nothing, and a self-referential fragment terminates via a path-scoped guard instead of recursing forever.

`ResolveTree` appears in the public signatures of `resolveSelection` and `selectionToWith`, where it used to come from the peer dependency, so `parseResolveInfo`, `ResolveTree`, `FieldsByTypeName` and `ParseResolveInfoOptions` are now exported from the package root.

## graphql 17 type errors

Five sites, not the three the issue counted — `main` grew two more since it was filed. All the same cause: 17 brands its type classes, so `new GraphQLNonNull(x)` rejects an `x` whose declared type still admits a `GraphQLNonNull`. Every one of them already holds an unwrapped column type; only the union was wider than the code path. `NullableConvertedColumnType` names that nullable half. It is spelled out member by member rather than derived as `Exclude<…, GraphQLNonNull<any>>`, which under 16 would strip the `GraphQLList` members too — 16's `GraphQLList` and `GraphQLNonNull` are structurally identical, which is exactly why the same code type-checked there.

## Test harness

Two changes were needed to run the suite against both majors:

- `vitest.config.ts` aliased `graphql` to the hard-coded `graphql/index.js`. That was right for 16 by luck and wrong for 17. It now resolves the entry the way Node does (`createRequire(import.meta.url).resolve('graphql')`), so the repo's transformed sources and the untransformed `graphql-scalars` / `graphql-yoga` land on one instance under either major. Removing the alias outright breaks graphql **16** — it has no `exports` map, so Vite follows `module` to `index.mjs` while Node follows `main` to `index.js`.
- Five assertions matched graphql's input-coercion error messages verbatim and 17 reworded them (`Field "x" is not defined by type "T"` → `Expected value of type "T" not to include unknown field "x"`). `tests/util/validation-messages.ts` matches the parts both wordings share.

## Verified

| | graphql 16.14.2 (lockfile) | graphql 17.0.2 (`npm install --no-save graphql@17`) |
|---|---|---|
| `npx biome check .` | clean¹ | clean¹ |
| `npx tsc --noEmit` | clean | clean |
| `npx tsc --noEmit -p tests/tsconfig.json` | clean | clean |
| `npx vitest run` (full suite, Docker legs included) | 84 files / 1354 tests passing | 84 files / 1354 tests passing |
| `npm run build` (tsup ESM + CJS + DTS) | clean | clean |
| plain-Node acceptance run | PASS | PASS |
| plain-Node acceptance run, `--conditions=development` | n/a | PASS |

¹ one pre-existing warning at `src/util/builders/select.ts:174`, untouched by this branch.

The acceptance run is a `tsx` script outside Vitest — the original failure passed schema build *and* validation, so only executing a real query proves anything. It builds the schema over a SQLite database, wraps the `users` resolver to capture `parseResolveInfo(info, { deep: true })`, and executes a query using aliases, `@include(if:$withEmail)`, `@skip(if:$skipRole)`, a named fragment containing a nested fragment, `__typename`, a to-many relation and a to-one relation. It asserts a populated `fieldsByTypeName` and ten specific facts about the returned rows.

Parity with the package being replaced was also checked differentially over 30 documents under graphql 16 — nesting, aliases, duplicate and merged response keys, named/nested/inline fragments, interfaces, unions, literal and variable-driven directives, and the argument-coercion surface — byte-identical on all 30. `tests/parse-resolve-info.test.ts` (26 tests, no database) covers the same ground as a permanent regression net.

## Not verified

- Only graphql 17.0.2 was exercised; the CI leg floats on `^17.0.0`.
- The acceptance run and the differential parity run are throwaway scripts and are not in the tree. The unit tests are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbQroMwKrEdCsANtuCn4Gv
