### PR TITLE
fix(build): make the packaging paths describe what is actually shipped

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsdown",
     "b": "npm run build",
     "prepare": "npm run build",
-    "pack": "(cd dist && npm pack --pack-destination ..) && rm -f package.tgz && mv *.tgz package.tgz",
+    "pack": "npm pack --pack-destination . && rm -f package.tgz && mv *.tgz package.tgz",
     "test": "vitest run",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tests/tsconfig.json",
     "server-test:pg": "DB_TYPE=pg tsx watch server/server.ts",
@@ -27,7 +27,7 @@
         "default": "./dist/index.js"
       },
       "require": {
-        "types": "./dist/index.d.cjs",
+        "types": "./dist/index.d.cts",
         "default": "./dist/index.cjs"
       }
     }

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -11,7 +11,4 @@ export default defineConfig({
   // tsdown would otherwise emit `.mjs` / `.d.mts` for ESM. The `exports` map in
   // package.json is the published contract, so pin the names it already points at.
   outExtensions: ({ format }) => (format === 'cjs' ? { js: '.cjs', dts: '.d.cts' } : { js: '.js', dts: '.d.ts' }),
-  // The published tarball is expected to be self-contained: `dist/` carries its
-  // own copy of the manifest and the readme.
-  copy: ['package.json', 'README.md'],
 });


### PR DESCRIPTION
Stacked on #121 — base is `chore/tsdown-typescript-7`, so review it after that one. GitHub retargets this to `main` when #121 merges.

Both issues survive the tsdown migration untouched: #121 swaps `fs.copyFileSync` for tsdown's `copy:`, which is the same verbatim copy, and it never touches the `exports` map. So neither is fixed by it, and both are cheapest to fix on top of it.

Closes #124, closes #123.

## `require.types` names a file that is never emitted

`exports["."].require.types` pointed at `./dist/index.d.cjs`; the build emits `index.d.cts`.

This is latent, not breaking. With the declared path absent, TypeScript falls back to guessing a declaration beside the JS entry and lands on the right file by luck — `attw` reports no problems before *or* after, and a real CJS consumer typechecks clean against a packed tarball either way. Worth fixing because the contract should describe what ships rather than lean on a fallback.

## `npm run pack` never produced a tarball

The documented emergency release path ran `npm pack` inside `dist/`. That directory carried a copy of the root manifest, so npm ran its `prepare` — `npm run build` — and the bundler started from `dist/` and died before emitting anything:

```
npm error command sh -c npm run build
npm error path .../dist
```

Packing from `dist/` was the wrong premise. Publishing is `@semantic-release/npm` with no `pkgRoot`, so releases pack from the repo root, where `files: ["dist"]` and the root-relative `exports` map apply. Packing from `dist/` could not have produced that layout even if `prepare` hadn't aborted it. Packing at the root makes the fallback produce the same tarball the pipeline does — which is the only thing that makes it a fallback.

With that corrected, the copies into `dist/` have no consumer. They were not free: **every published tarball has been carrying a duplicate README — 100.4 kB of a 663.5 kB package — plus a stray nested manifest whose `prepare` runs for anyone installing from inside it.**

| | before | after |
|---|---|---|
| files | 11 | 9 |
| package size | 663.5 kB | 630.3 kB |

## Verification

- `npm run pack` succeeds and writes `package.tgz`.
- `attw` on that tarball: 🟢 node10, node16 CJS, node16 ESM, bundler.
- `npm run typecheck` clean; `biome check .` shows only the `select.ts:174` warning that #122 removes separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbQroMwKrEdCsANtuCn4Gv