### PR TITLE
test: integration suites for real-world client and composition patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Automatically create GraphQL schema or customizable schema config fields from Dr
                 // Create a custom one
                 customUsers: {
                     // You can reuse and customize types from original schema
-                    type: new GraphQLList(new GraphQLNonNull(entities.types.UsersItem)),
+                    type: new GraphQLList(new GraphQLNonNull(entities.types.Users)),
                     args: {
                         // You can reuse inputs as well
                         where: {
@@ -79,11 +79,19 @@ Automatically create GraphQL schema or customizable schema config fields from Dr
     const yoga = createYoga({
         schema
     })
+    const server = createServer(yoga)
 
     server.listen(4000, () => {
         console.info('Server is running on http://localhost:4000/graphql')
     })
     ```
+
+    The keys on `entities` follow the naming rules below: with the defaults, table `users`
+    gives type `entities.types.Users`, inputs `entities.inputs.UsersFilters` /
+    `UsersOrderBy` / `CreateUsersInput` / `UpdateUsersInput`, queries
+    `entities.queries.users` / `usersSingle`, and mutations
+    `entities.mutations.createUsers` / `updateUsers` / `deleteUsers`. A `typeNameMapper`
+    changes these keys too, so a composed schema has to use the mapped names.
 
 ## Naming the generated types and fields
 

--- a/tests/pglite/integration-composition.test.ts
+++ b/tests/pglite/integration-composition.test.ts
@@ -1,0 +1,330 @@
+import { createServer, type Server } from 'node:http';
+import { PGlite } from '@electric-sql/pglite';
+import { drizzle } from 'drizzle-orm/pglite';
+import { GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLSchema } from 'graphql';
+import { createYoga } from 'graphql-yoga';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { buildSchema, type GeneratedEntities } from '@/index';
+import { GraphQLClient } from '../util/query';
+import { schema, setupTables, sql, type TestDatabase, teardownTables } from './common';
+
+/**
+ * The other integration suite covers how consumers *query* the generated schema. This one
+ * covers how they *assemble* it.
+ *
+ * Handing `buildSchema(db).schema` straight to a server is the getting-started path;
+ * anything past a prototype instead takes `entities` and composes: exposing a subset of
+ * the generated fields, renaming them, and adding hand-written fields that reuse the
+ * generated types and inputs. That is the second example in the README and, judging by
+ * how the library is used, the shape most real deployments end up with.
+ *
+ * It also exercises the library through a different door. The generated root resolvers
+ * pre-fetch relations with Drizzle's `with:`; a hand-written resolver returning bare rows
+ * does not, so the generated object type has to resolve its own relation fields. Both
+ * paths have to produce the same answer, or composing means silently losing relations.
+ *
+ * Everything here uses the *default* naming — no `typeNameMapper` — because that is what a
+ * consumer following the README gets, and it pins the documented entity keys against
+ * drift.
+ */
+
+const DATA_DIR = `./tests/.temp/pgdata-integration-composition-${Date.now()}`;
+
+let pglite: PGlite;
+let db: TestDatabase;
+let entities: GeneratedEntities<TestDatabase>;
+let server: Server;
+let gql: GraphQLClient;
+
+// `setupTables` / `teardownTables` only need `db`, and this suite deliberately does not
+// build the default schema that `setupServer` would.
+const tableCtx = () => ({ db }) as any;
+
+beforeAll(async () => {
+  pglite = new PGlite(DATA_DIR);
+  await pglite.waitReady;
+  db = drizzle({ client: pglite, relations: schema.relations, logger: !!process.env['LOG_SQL'] });
+
+  await db.execute(
+    sql`DO $$ BEGIN CREATE TYPE "role" AS ENUM('admin', 'user');
+        EXCEPTION WHEN duplicate_object THEN null; END $$;`,
+  );
+
+  entities = buildSchema(db).entities;
+
+  const composed = new GraphQLSchema({
+    query: new GraphQLObjectType({
+      name: 'Query',
+      fields: {
+        // Only a subset of the generated queries is exposed, and one of them under a
+        // different name than it was generated with.
+        users: entities.queries['users']!,
+        customer: entities.queries['customersSingle']!,
+
+        // A hand-written field reusing the generated object type and filter input. Its
+        // resolver returns bare rows with no relation pre-fetching, which is what a
+        // consumer writing their own `db.select()` produces.
+        engineers: {
+          type: new GraphQLList(new GraphQLNonNull(entities.types['Users'] as GraphQLObjectType)) as any,
+          args: { where: { type: entities.inputs['UsersFilters']! } },
+          resolve: async () => db.select().from(schema.Users).where(sql`${schema.Users.profession} = 'FirstUserProf'`),
+        },
+      },
+    }),
+    mutation: new GraphQLObjectType({
+      name: 'Mutation',
+      fields: entities.mutations as any,
+    }),
+    types: [...Object.values(entities.types), ...Object.values(entities.inputs)],
+  });
+
+  server = createServer(createYoga({ schema: composed }));
+  server.listen(5281);
+  gql = new GraphQLClient('http://localhost:5281/graphql');
+});
+
+afterAll(async () => {
+  await pglite?.close().catch(console.error);
+  await new Promise<void>((resolve) => server?.close(() => resolve()));
+  const { rm } = await import('node:fs/promises');
+  await rm(DATA_DIR, { recursive: true, force: true }).catch(console.error);
+});
+
+beforeEach(async () => {
+  await setupTables(tableCtx());
+});
+afterEach(async () => {
+  await teardownTables(tableCtx());
+});
+
+describe.sequential('the entity keys the README tells consumers to reach for', () => {
+  it('exposes queries, mutations, types and inputs under their documented default names', () => {
+    // A composed schema is written against these keys by hand, so a rename is a silent
+    // `undefined` at schema-construction time rather than a type error.
+    expect(Object.keys(entities.queries)).toEqual(
+      expect.arrayContaining(['users', 'usersSingle', 'usersAggregate', 'usersGroupBy']),
+    );
+    expect(Object.keys(entities.mutations)).toEqual(
+      expect.arrayContaining([
+        'createUsers',
+        'createUsersSingle',
+        'updateUsers',
+        'updateUsersSingle',
+        'deleteUsers',
+        'deleteUsersSingle',
+      ]),
+    );
+    expect(Object.keys(entities.types)).toEqual(expect.arrayContaining(['Users', 'Posts']));
+    expect(Object.keys(entities.inputs)).toEqual(
+      expect.arrayContaining(['UsersFilters', 'UsersOrderBy', 'CreateUsersInput', 'UpdateUsersInput']),
+    );
+  });
+});
+
+describe.sequential('exposing a subset of the generated fields', () => {
+  it('serves only the fields the composed schema declares', async () => {
+    const res = await gql.queryGql(/* GraphQL */ `
+			{
+				__schema {
+					queryType {
+						fields {
+							name
+						}
+					}
+				}
+			}
+		`);
+
+    const names = res.data.__schema.queryType.fields.map((f: { name: string }) => f.name).sort();
+    expect(names).toEqual(['customer', 'engineers', 'users']);
+    // The generated queries left out must not leak in through the `types:` array.
+    expect(names).not.toContain('posts');
+    expect(names).not.toContain('usersSingle');
+  });
+
+  it('keeps a generated query fully functional under a different field name', async () => {
+    const res = await gql.queryGql(/* GraphQL */ `
+			{
+				customer(where: { id: { eq: 1 } }) {
+					id
+					address
+					user {
+						id
+						name
+					}
+				}
+			}
+		`);
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data.customer).toEqual({
+      id: 1,
+      address: 'AdOne',
+      user: { id: 1, name: 'FirstUser' },
+    });
+  });
+
+  it('resolves relations through a generated query that was cherry-picked', async () => {
+    const res = await gql.queryGql(/* GraphQL */ `
+			{
+				users(where: { id: { eq: 1 } }) {
+					id
+					posts(orderBy: { id: { priority: 1, direction: asc } }) {
+						id
+						content
+					}
+				}
+			}
+		`);
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data.users).toEqual([
+      {
+        id: 1,
+        posts: [
+          { id: 1, content: '1MESSAGE' },
+          { id: 2, content: '2MESSAGE' },
+          { id: 3, content: '3MESSAGE' },
+          { id: 6, content: '4MESSAGE' },
+        ],
+      },
+    ]);
+  });
+});
+
+describe.sequential('a hand-written field built on the generated types', () => {
+  it('resolves scalars off rows a custom resolver returned', async () => {
+    const res = await gql.queryGql(/* GraphQL */ `
+			{
+				engineers {
+					id
+					name
+					profession
+				}
+			}
+		`);
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data.engineers).toEqual([{ id: 1, name: 'FirstUser', profession: 'FirstUserProf' }]);
+  });
+
+  it('resolves relation fields on rows that were never pre-fetched with `with:`', async () => {
+    // The custom resolver returns bare `db.select()` rows carrying no `posts` key at all.
+    // The generated object type has to go and fetch the relation itself; if it only ever
+    // read a pre-fetched key, composing would quietly return null here.
+    const res = await gql.queryGql(/* GraphQL */ `
+			{
+				engineers {
+					id
+					posts(orderBy: { id: { priority: 1, direction: asc } }) {
+						id
+					}
+				}
+			}
+		`);
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data.engineers).toEqual([{ id: 1, posts: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 6 }] }]);
+  });
+
+  it('agrees with the generated query it sits alongside', async () => {
+    // Same rows, same relation, two different resolution paths in one document.
+    const res = await gql.queryGql(/* GraphQL */ `
+			{
+				generated: users(where: { id: { eq: 1 } }) {
+					id
+					name
+					posts(orderBy: { id: { priority: 1, direction: asc } }) {
+						id
+					}
+				}
+				engineers {
+					id
+					name
+					posts(orderBy: { id: { priority: 1, direction: asc } }) {
+						id
+					}
+				}
+			}
+		`);
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data.engineers).toEqual(res.data.generated);
+  });
+
+  it('accepts the reused generated filter input as its own argument type', async () => {
+    // `UsersFilters` has to be a valid argument type outside the field it was generated
+    // for — including as a variable, which is how a client would send it.
+    const res = await gql.queryGql(
+      /* GraphQL */ `
+				query Custom($where: UsersFilters) {
+					engineers(where: $where) {
+						id
+					}
+				}
+			`,
+      { where: { id: { eq: 1 } } },
+    );
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data.engineers).toEqual([{ id: 1 }]);
+  });
+});
+
+describe.sequential('spreading the generated mutations wholesale', () => {
+  it('round-trips a row through mutations taken straight from `entities.mutations`', async () => {
+    const created = await gql.queryGql(
+      /* GraphQL */ `
+				mutation Create($values: CreateUsersInput!) {
+					createUsersSingle(values: $values) {
+						id
+						name
+						profession
+					}
+				}
+			`,
+      { values: { id: 200, name: 'Composed', profession: 'FirstUserProf' } },
+    );
+    expect(created.errors).toBeUndefined();
+    expect(created.data.createUsersSingle).toEqual({
+      id: 200,
+      name: 'Composed',
+      profession: 'FirstUserProf',
+    });
+
+    // The hand-written field reads the same table, so the write has to be visible to it.
+    const listed = await gql.queryGql(/* GraphQL */ `
+			{
+				engineers {
+					id
+				}
+			}
+		`);
+    expect(listed.data.engineers.map((u: { id: number }) => u.id).sort((a: number, b: number) => a - b)).toEqual([
+      1, 200,
+    ]);
+
+    const deleted = await gql.queryGql(/* GraphQL */ `
+			mutation {
+				deleteUsersSingle(where: { id: { eq: 200 } }) {
+					id
+				}
+			}
+		`);
+    expect(deleted.errors).toBeUndefined();
+    expect(deleted.data.deleteUsersSingle).toEqual({ id: 200 });
+  });
+
+  it('still surfaces write rejections as coded errors inside a composed schema', async () => {
+    const res = await gql.queryGql(/* GraphQL */ `
+			mutation {
+				updateUsersSingle(where: { id: { eq: 1 } }, set: { name: null }) {
+					id
+				}
+			}
+		`);
+
+    expect(res.errors).toBeDefined();
+    expect(res.errors[0].extensions?.code).toBe('DRIZZLE_NOT_NULL');
+  });
+});

--- a/tests/pglite/integration.test.ts
+++ b/tests/pglite/integration.test.ts
@@ -1,0 +1,639 @@
+import { buildClientSchema, getIntrospectionQuery, printSchema } from 'graphql';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { type Context, createCtx, setupServer, setupTables, teardownServer, teardownTables } from './common';
+
+/**
+ * End-to-end tests written from the client's side of the wire.
+ *
+ * The rest of the suite covers each generated feature directly. What this file covers is
+ * the shape of the requests real consumers actually send: documents produced by Apollo,
+ * Relay, urql and graphql-codegen rather than written by hand. Those tools lean on parts
+ * of GraphQL the per-feature tests never exercise — introspection, multi-operation
+ * documents selected by `operationName`, arguments passed as variables, `@skip`/`@include`,
+ * aliases and fragment composition — and they issue requests concurrently.
+ *
+ * That distinction is not cosmetic. `parseResolveInfo` is vendored in this repo, and it is
+ * what turns a selection set into the Drizzle `with:` tree, so a document that merely
+ * *reaches* the same fields by a different syntactic route is a genuinely different path
+ * through the library.
+ *
+ * Every test runs against the shared fixture `setupTables` installs: users 1 `FirstUser`,
+ * 2 `SecondUser` and 5 `FifthUser`; posts 1, 2, 3 and 6 belong to user 1, posts 4 and 5 to
+ * user 5, and user 2 has none.
+ */
+
+const DATA_DIR = `./tests/.temp/pgdata-integration-${Date.now()}`;
+const ctx: Context = createCtx();
+
+beforeAll(async () => {
+  await setupServer(ctx, 5280, DATA_DIR);
+});
+afterAll(async () => {
+  await teardownServer(ctx, DATA_DIR);
+});
+beforeEach(async () => {
+  await setupTables(ctx);
+});
+afterEach(async () => {
+  await teardownTables(ctx);
+});
+
+describe.sequential('introspection, as codegen and IDE tooling perform it', () => {
+  it('answers the full introspection query and rebuilds into a usable client schema', async () => {
+    const res = await ctx.gql.queryGql(getIntrospectionQuery());
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data.__schema).toBeDefined();
+
+    // This is the graphql-codegen / Apollo CLI path: the introspection result has to be
+    // complete enough to reconstruct the schema, which fails loudly on a malformed or
+    // partially described type.
+    const clientSchema = buildClientSchema(res.data);
+
+    expect(Object.keys(clientSchema.getQueryType()!.getFields()).sort()).toEqual(
+      Object.keys(ctx.schema.getQueryType()!.getFields()).sort(),
+    );
+    expect(Object.keys(clientSchema.getMutationType()!.getFields()).sort()).toEqual(
+      Object.keys(ctx.schema.getMutationType()!.getFields()).sort(),
+    );
+  });
+
+  it('round-trips to an SDL that still declares the generated inputs and enums', async () => {
+    const res = await ctx.gql.queryGql(getIntrospectionQuery());
+    const sdl = printSchema(buildClientSchema(res.data));
+
+    // A client that only ever sees the introspection result must still be able to write
+    // filters, ordering and writes against it.
+    expect(sdl).toContain('input UserFilters');
+    expect(sdl).toContain('input UserOrderBy');
+    expect(sdl).toContain('input CreateUserInput');
+    expect(sdl).toContain('enum RoleEnum');
+    expect(sdl).toContain('type User');
+  });
+});
+
+describe.sequential('documents carrying more than one operation', () => {
+  const DOCUMENT = /* GraphQL */ `
+		query ListUsers($limit: Int) {
+			users(limit: $limit, orderBy: { id: { priority: 1, direction: asc } }) {
+				id
+				name
+			}
+		}
+
+		query ListPosts($limit: Int) {
+			posts(limit: $limit, orderBy: { id: { priority: 1, direction: asc } }) {
+				id
+				content
+			}
+		}
+
+		mutation AddUser($values: CreateUserInput!) {
+			createUser(values: $values) {
+				id
+				name
+			}
+		}
+	`;
+
+  it('runs only the operation named by operationName', async () => {
+    const users = await ctx.gql.queryGql(DOCUMENT, { limit: 2 }, 'ListUsers');
+
+    expect(users.errors).toBeUndefined();
+    expect(users.data).toEqual({
+      users: [
+        { id: 1, name: 'FirstUser' },
+        { id: 2, name: 'SecondUser' },
+      ],
+    });
+    // The sibling operations must not contribute to the response at all.
+    expect(users.data.posts).toBeUndefined();
+    expect(users.data.createUser).toBeUndefined();
+
+    const posts = await ctx.gql.queryGql(DOCUMENT, { limit: 1 }, 'ListPosts');
+    expect(posts.errors).toBeUndefined();
+    expect(posts.data).toEqual({ posts: [{ id: 1, content: '1MESSAGE' }] });
+  });
+
+  it('leaves the database untouched when a query is selected out of a document that also defines a mutation', async () => {
+    await ctx.gql.queryGql(DOCUMENT, { limit: 5 }, 'ListUsers');
+
+    // If operation selection leaked, `AddUser` would have inserted a row.
+    const after = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				users {
+					id
+				}
+			}
+		`);
+    expect(after.data.users).toHaveLength(3);
+  });
+
+  it('selects the mutation from the same document when it is the one named', async () => {
+    const created = await ctx.gql.queryGql(DOCUMENT, { values: { id: 4, name: 'FourthUser' } }, 'AddUser');
+
+    expect(created.errors).toBeUndefined();
+    expect(created.data.createUser).toEqual({ id: 4, name: 'FourthUser' });
+  });
+
+  it('rejects an unnamed request against a multi-operation document', async () => {
+    const res = await ctx.gql.queryGql(DOCUMENT, { limit: 1 });
+
+    // Per the spec this is a request error, and it has to surface as one rather than the
+    // server silently picking an operation.
+    expect(res.errors).toBeDefined();
+    expect(res.data).toBeFalsy();
+  });
+});
+
+describe.sequential('arguments supplied as variables', () => {
+  it('drives filtering, ordering and pagination entirely from variables', async () => {
+    const res = await ctx.gql.queryGql(
+      /* GraphQL */ `
+				query Page($where: UserFilters, $orderBy: UserOrderBy, $limit: Int, $offset: Int) {
+					users(where: $where, orderBy: $orderBy, limit: $limit, offset: $offset) {
+						id
+						name
+					}
+				}
+			`,
+      {
+        where: { id: { gt: 1 } },
+        orderBy: { id: { priority: 1, direction: 'desc' } },
+        limit: 1,
+        offset: 0,
+      },
+    );
+
+    expect(res.errors).toBeUndefined();
+    // Users 2 and 5 clear the filter; descending by id puts 5 first, and the limit keeps
+    // only that one.
+    expect(res.data.users).toEqual([{ id: 5, name: 'FifthUser' }]);
+  });
+
+  it('applies an offset supplied as a variable', async () => {
+    const res = await ctx.gql.queryGql(
+      /* GraphQL */ `
+				query Page($limit: Int, $offset: Int) {
+					users(orderBy: { id: { priority: 1, direction: asc } }, limit: $limit, offset: $offset) {
+						id
+					}
+				}
+			`,
+      { limit: 2, offset: 1 },
+    );
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data.users).toEqual([{ id: 2 }, { id: 5 }]);
+  });
+
+  it('accepts variables for arguments on a relation field', async () => {
+    const res = await ctx.gql.queryGql(
+      /* GraphQL */ `
+				query AuthorWithPosts($id: Int!, $postLimit: Int) {
+					users(where: { id: { eq: $id } }) {
+						id
+						posts(limit: $postLimit, orderBy: { id: { priority: 1, direction: asc } }) {
+							id
+						}
+					}
+				}
+			`,
+      { id: 1, postLimit: 2 },
+    );
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data.users).toEqual([{ id: 1, posts: [{ id: 1 }, { id: 2 }] }]);
+  });
+
+  it('reports a variable of the wrong type as a request error rather than coercing it', async () => {
+    const res = await ctx.gql.queryGql(
+      /* GraphQL */ `
+				query Bad($limit: Int) {
+					users(limit: $limit) {
+						id
+					}
+				}
+			`,
+      { limit: 'not-a-number' },
+    );
+
+    expect(res.errors).toBeDefined();
+    expect(res.errors[0].message).toMatch(/limit/i);
+  });
+});
+
+describe.sequential('@skip and @include', () => {
+  const DOCUMENT = /* GraphQL */ `
+		query Conditional($withPosts: Boolean!, $hideEmail: Boolean!) {
+			users(where: { id: { eq: 1 } }) {
+				id
+				name
+				email @skip(if: $hideEmail)
+				posts(orderBy: { id: { priority: 1, direction: asc } }) @include(if: $withPosts) {
+					id
+				}
+			}
+		}
+	`;
+
+  it('includes a relation when the directive resolves to true', async () => {
+    const res = await ctx.gql.queryGql(DOCUMENT, { withPosts: true, hideEmail: false });
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data.users).toEqual([
+      {
+        id: 1,
+        name: 'FirstUser',
+        email: 'userOne@notmail.com',
+        posts: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 6 }],
+      },
+    ]);
+  });
+
+  it('omits the relation and the skipped scalar when the directives invert', async () => {
+    const res = await ctx.gql.queryGql(DOCUMENT, { withPosts: false, hideEmail: true });
+
+    expect(res.errors).toBeUndefined();
+    // Excluded fields have to be absent rather than present-and-null: the relation is
+    // never requested from the database, so `posts` has no key in the response at all.
+    expect(res.data.users).toEqual([{ id: 1, name: 'FirstUser' }]);
+    expect(res.data.users[0]).not.toHaveProperty('posts');
+    expect(res.data.users[0]).not.toHaveProperty('email');
+  });
+
+  it('honours a directive placed on a fragment spread', async () => {
+    const res = await ctx.gql.queryGql(
+      /* GraphQL */ `
+				query SpreadDirective($withDetail: Boolean!) {
+					users(where: { id: { eq: 2 } }) {
+						id
+						...Detail @include(if: $withDetail)
+					}
+				}
+
+				fragment Detail on User {
+					name
+					profession
+				}
+			`,
+      { withDetail: false },
+    );
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data.users).toEqual([{ id: 2 }]);
+  });
+
+  it('includes the same fragment spread when the directive flips', async () => {
+    const res = await ctx.gql.queryGql(
+      /* GraphQL */ `
+				query SpreadDirective($withDetail: Boolean!) {
+					users(where: { id: { eq: 1 } }) {
+						id
+						...Detail @include(if: $withDetail)
+					}
+				}
+
+				fragment Detail on User {
+					name
+					profession
+				}
+			`,
+      { withDetail: true },
+    );
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data.users).toEqual([{ id: 1, name: 'FirstUser', profession: 'FirstUserProf' }]);
+  });
+});
+
+describe.sequential('aliases', () => {
+  it('resolves the same root field several times under different aliases and arguments', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				first: users(where: { id: { eq: 1 } }) {
+					id
+					name
+				}
+				rest: users(where: { id: { gt: 1 } }, orderBy: { id: { priority: 1, direction: asc } }) {
+					id
+				}
+				everyone: users {
+					id
+				}
+			}
+		`);
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data.first).toEqual([{ id: 1, name: 'FirstUser' }]);
+    expect(res.data.rest).toEqual([{ id: 2 }, { id: 5 }]);
+    expect(res.data.everyone).toHaveLength(3);
+  });
+
+  it('aliases a relation field twice with different arguments under one parent', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				users(where: { id: { eq: 1 } }) {
+					id
+					firstPost: posts(limit: 1, orderBy: { id: { priority: 1, direction: asc } }) {
+						id
+					}
+					lastPost: posts(limit: 1, orderBy: { id: { priority: 1, direction: desc } }) {
+						id
+					}
+				}
+			}
+		`);
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data.users).toEqual([{ id: 1, firstPost: [{ id: 1 }], lastPost: [{ id: 6 }] }]);
+  });
+});
+
+describe.sequential('fragment composition, as generated clients emit it', () => {
+  it('resolves named fragments spread across a relation boundary', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				users(where: { id: { eq: 5 } }) {
+					...UserFields
+				}
+			}
+
+			fragment UserFields on User {
+				id
+				name
+				posts(orderBy: { id: { priority: 1, direction: asc } }) {
+					...PostFields
+				}
+			}
+
+			fragment PostFields on Post {
+				id
+				content
+			}
+		`);
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data.users).toEqual([
+      {
+        id: 5,
+        name: 'FifthUser',
+        posts: [
+          { id: 4, content: '1MESSAGE' },
+          { id: 5, content: '2MESSAGE' },
+        ],
+      },
+    ]);
+  });
+
+  it('merges a fragment with sibling fields selected directly', async () => {
+    // Codegen output routinely selects a field both inline and through a fragment; the two
+    // selections have to merge rather than one shadowing the other.
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				users(where: { id: { eq: 1 } }) {
+					id
+					...Contact
+					profession
+				}
+			}
+
+			fragment Contact on User {
+				id
+				email
+			}
+		`);
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data.users).toEqual([{ id: 1, email: 'userOne@notmail.com', profession: 'FirstUserProf' }]);
+  });
+
+  it('resolves fragments nested inside other fragments', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				users(where: { id: { eq: 1 } }) {
+					...Outer
+				}
+			}
+
+			fragment Outer on User {
+				id
+				...Inner
+			}
+
+			fragment Inner on User {
+				name
+			}
+		`);
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data.users).toEqual([{ id: 1, name: 'FirstUser' }]);
+  });
+
+  it('resolves an inline fragment on the enclosing type', async () => {
+    const res = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				users(where: { id: { eq: 1 } }) {
+					id
+					... on User {
+						name
+						posts(limit: 1, orderBy: { id: { priority: 1, direction: asc } }) {
+							id
+						}
+					}
+				}
+			}
+		`);
+
+    expect(res.errors).toBeUndefined();
+    expect(res.data.users).toEqual([{ id: 1, name: 'FirstUser', posts: [{ id: 1 }] }]);
+  });
+});
+
+describe.sequential('concurrent requests', () => {
+  it('keeps results separate across many in-flight requests', async () => {
+    // Relation resolvers dedupe sibling loads keyed on the GraphQL context. Requests in
+    // flight at the same time carry distinct contexts, so a key that is not genuinely
+    // per-request would show up here as one request's rows landing in another's response.
+    const wanted = [1, 2, 5, 1, 2, 5, 1, 2, 5, 1, 2, 5];
+    const results = await Promise.all(
+      wanted.map((id) =>
+        ctx.gql.queryGql(
+          /* GraphQL */ `
+						query One($id: Int!) {
+							users(where: { id: { eq: $id } }) {
+								id
+								name
+								posts(orderBy: { id: { priority: 1, direction: asc } }) {
+									id
+								}
+							}
+						}
+					`,
+          { id },
+        ),
+      ),
+    );
+
+    const expected: Record<number, unknown> = {
+      1: {
+        id: 1,
+        name: 'FirstUser',
+        posts: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 6 }],
+      },
+      2: { id: 2, name: 'SecondUser', posts: [] },
+      5: { id: 5, name: 'FifthUser', posts: [{ id: 4 }, { id: 5 }] },
+    };
+
+    results.forEach((res, i) => {
+      const label = `request ${i} (user ${wanted[i]})`;
+      expect(res.errors, label).toBeUndefined();
+      expect(res.data.users, label).toEqual([expected[wanted[i]!]]);
+    });
+  });
+
+  it('keeps concurrent writes consistent', async () => {
+    const ids = [10, 11, 12, 13];
+    const results = await Promise.all(
+      ids.map((id) =>
+        ctx.gql.queryGql(
+          /* GraphQL */ `
+						mutation Add($values: CreateUserInput!) {
+							createUser(values: $values) {
+								id
+								name
+							}
+						}
+					`,
+          { values: { id, name: `User${id}` } },
+        ),
+      ),
+    );
+
+    for (const res of results) {
+      expect(res.errors).toBeUndefined();
+    }
+    expect(results.map((r) => r.data.createUser.id).sort((a: number, b: number) => a - b)).toEqual(ids);
+
+    const after = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				users {
+					id
+				}
+			}
+		`);
+    // The three fixture rows plus the four just written, with nothing lost to a race.
+    expect(after.data.users).toHaveLength(7);
+  });
+});
+
+describe.sequential('a full create/read/update/delete cycle', () => {
+  it('carries a row through every generated mutation using variables throughout', async () => {
+    const created = await ctx.gql.queryGql(
+      /* GraphQL */ `
+				mutation Create($values: CreateUserInput!) {
+					createUser(values: $values) {
+						id
+						name
+						email
+					}
+				}
+			`,
+      { values: { id: 100, name: 'Dana', email: 'dana@example.com' } },
+    );
+    expect(created.errors).toBeUndefined();
+    expect(created.data.createUser).toEqual({
+      id: 100,
+      name: 'Dana',
+      email: 'dana@example.com',
+    });
+
+    const read = await ctx.gql.queryGql(
+      /* GraphQL */ `
+				query Read($id: Int!) {
+					user(where: { id: { eq: $id } }) {
+						id
+						name
+						email
+					}
+				}
+			`,
+      { id: 100 },
+    );
+    expect(read.data.user).toEqual({ id: 100, name: 'Dana', email: 'dana@example.com' });
+
+    const updated = await ctx.gql.queryGql(
+      /* GraphQL */ `
+				mutation Update($id: Int!, $set: UpdateUserInput!) {
+					updateUserSingle(where: { id: { eq: $id } }, set: $set) {
+						id
+						name
+						email
+					}
+				}
+			`,
+      { id: 100, set: { name: 'Dana Renamed', email: null } },
+    );
+    expect(updated.errors).toBeUndefined();
+    // `email` is nullable, so an explicit null here is a real update rather than an
+    // omission to be dropped from the statement.
+    expect(updated.data.updateUserSingle).toEqual({
+      id: 100,
+      name: 'Dana Renamed',
+      email: null,
+    });
+
+    const deleted = await ctx.gql.queryGql(
+      /* GraphQL */ `
+				mutation Delete($id: Int!) {
+					deleteUser(where: { id: { eq: $id } }) {
+						id
+					}
+				}
+			`,
+      { id: 100 },
+    );
+    expect(deleted.errors).toBeUndefined();
+    expect(deleted.data.deleteUser).toEqual([{ id: 100 }]);
+
+    const gone = await ctx.gql.queryGql(
+      /* GraphQL */ `
+				query Read($id: Int!) {
+					user(where: { id: { eq: $id } }) {
+						id
+					}
+				}
+			`,
+      { id: 100 },
+    );
+    expect(gone.data.user).toBeNull();
+  });
+
+  it('surfaces a write rejection as a GraphQL error carrying a machine-readable code', async () => {
+    // `name` is NOT NULL; setting it to null on update has to be refused rather than
+    // silently dropped from the statement and reported as a success.
+    const res = await ctx.gql.queryGql(
+      /* GraphQL */ `
+				mutation Break($id: Int!) {
+					updateUserSingle(where: { id: { eq: $id } }, set: { name: null }) {
+						id
+					}
+				}
+			`,
+      { id: 1 },
+    );
+
+    expect(res.errors).toBeDefined();
+    expect(res.errors[0].extensions?.code).toBe('DRIZZLE_NOT_NULL');
+
+    // The rejected write must not have partially applied.
+    const unchanged = await ctx.gql.queryGql(/* GraphQL */ `
+			{
+				user(where: { id: { eq: 1 } }) {
+					name
+				}
+			}
+		`);
+    expect(unchanged.data.user).toEqual({ name: 'FirstUser' });
+  });
+});

--- a/tests/util/query/index.ts
+++ b/tests/util/query/index.ts
@@ -3,13 +3,20 @@ import axios, { type AxiosError } from 'axios';
 export class GraphQLClient {
   constructor(private url: string) {}
 
-  public queryGql = async (query: string) => {
+  /**
+   * `variables` and `operationName` are parts of the GraphQL-over-HTTP request body, not
+   * decoration: a real client sends its arguments as variables rather than interpolating
+   * them into the document text, and names an operation whenever the document holds more
+   * than one. Both default to the single-anonymous-operation shape existing callers use.
+   */
+  public queryGql = async (query: string, variables: Record<string, unknown> = {}, operationName?: string) => {
     try {
       const res = await axios.post(
         this.url,
         JSON.stringify({
           query: query,
-          variables: {},
+          variables: variables,
+          ...(operationName === undefined ? {} : { operationName }),
         }),
         {
           headers: {


### PR DESCRIPTION
Two integration suites covering how the library is actually used, plus a README bug the second suite uncovered.

## 1. Client-shaped requests — `tests/pglite/integration.test.ts` (24 tests)

The existing pglite suites cover each generated feature directly, by hand-written documents that reach a field the shortest way. Real consumers reach the same fields through Apollo, Relay, urql and graphql-codegen, which lean on parts of GraphQL those tests never exercise, and they issue requests concurrently. A grep confirmed the gap: `getIntrospectionQuery`, `operationName`, `@skip`, `@include` and `Promise.all` had **zero** occurrences anywhere in `tests/`.

That is a genuinely different code path. `parseResolveInfo` is vendored in this repo and is what turns a selection set into the Drizzle `with:` tree, so a document that arrives at the same field by a different syntactic route exercises different logic.

| Area | Covers |
| --- | --- |
| Introspection | full introspection query → `buildClientSchema` → `printSchema`; the rebuilt schema keeps the generated inputs, enums and object types |
| Multi-operation documents | `operationName` selection; a sibling mutation in the same document stays unexecuted; an unnamed request against a multi-operation document is refused |
| Variables | filters, ordering, `limit`/`offset` and relation arguments driven entirely from variables; a wrong-typed variable surfaces as a request error rather than being coerced |
| `@skip` / `@include` | on scalars, on relations, and on a fragment spread — excluded fields are **absent**, not present-and-null |
| Aliases | one root field resolved three times with different arguments; a relation field aliased twice under one parent |
| Fragments | named, nested and inline; a fragment merged with sibling selections |
| Concurrency | twelve in-flight requests — what would expose a relation-batching cache key that is not genuinely per-request |
| CRUD | full create → read → update → delete with variables throughout; a rejected NOT NULL write surfacing as `DRIZZLE_NOT_NULL` with no partial application |

**Enabling change:** `GraphQLClient.queryGql` hardcoded `variables: {}` and sent no `operationName`, which is why none of this was reachable. Both are now optional parameters defaulting to the single-anonymous-operation shape existing callers already use — no call site changes.

## 2. Schema composition — `tests/pglite/integration-composition.test.ts` (10 tests)

`buildSchema(db).schema` handed straight to a server is the getting-started path. Anything past a prototype instead takes `entities` and composes — the README's second example, and the shape most real deployments end up with.

`pg-custom.test.ts` covers *renaming* generated fields, but it needs Docker and never covers the other half: a hand-written field with its own resolver reusing `entities.types.*` and `entities.inputs.*`. That half reaches the library through a different door — the generated root resolvers pre-fetch relations with Drizzle `with:`, while a custom resolver returning bare `db.select()` rows does not, so the generated object type has to resolve its own relation fields or composing silently loses relations.

Built with the **default** naming (no `typeNameMapper`), because that is what a consumer following the README gets:

- the documented entity keys exist, so a rename shows up here rather than as a silent `undefined` in someone's composed schema
- only the declared fields are served; omitted generated queries do not leak in through the `types:` array
- a cherry-picked generated query still resolves relations under a new field name
- a hand-written field resolves scalars **and** relations off rows never pre-fetched, and agrees field-for-field with the generated query beside it in the same document
- `UsersFilters` works as an argument type outside the field it was generated for, including as a variable
- `entities.mutations` spread wholesale round-trips a row, and a NOT NULL rejection still arrives as `DRIZZLE_NOT_NULL` inside a composed schema

## 3. README fix (found by the above)

The composition example reaches for `entities.types.UsersItem`, but the generated key is `Users` — `UsersItem` is `undefined`, so anyone copying the snippet gets a schema that fails to construct. It also imports `createServer` and then calls `server.listen` without ever creating the server. Both fixed, plus an explicit note on the default key naming and that `typeNameMapper` changes these keys too. The corrected names are now asserted by suite 2.

## Verification

- `npx vitest run` → **88 files, 1407 tests, all passing**
- `npx biome check` clean on all touched files
- `tsc --noEmit -p tests/tsconfig.json` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbQroMwKrEdCsANtuCn4Gv
