### PR TITLE
fix: pick a usable fallback column when a selection names none

### DIFF
--- a/src/util/builders/common/selected-columns.ts
+++ b/src/util/builders/common/selected-columns.ts
@@ -82,40 +82,63 @@ const relationJoinColumns = (
   return needed;
 };
 
+/**
+ * The column the extractors fall back to when a selection names none of its own — a query that
+ * asked only for `__typename`, or only for relation fields. The relational query builder still
+ * needs at least one column, and some SQLite column types crash it when they are the only one
+ * selected, so a column of any other type is preferred and the first column is the last resort.
+ */
+const fallbackColumnName = (tableColumns: Record<string, Column>): string => {
+  const columnKeys = Object.entries(tableColumns);
+  return columnKeys.find(([, column]) => !rqbCrashTypes.includes(column.columnType))?.[0] ?? columnKeys[0]![0];
+};
+
+/**
+ * Property names of the columns a selection reads: the ones it names itself, plus the join
+ * columns its relation fields correlate on, plus the fallback when that leaves nothing.
+ */
+const selectedColumnNames = (
+  tree: Record<string, ResolveTree>,
+  table: Table,
+  selectionCtx: SelectionCtx | undefined,
+): string[] => {
+  const tableColumns = getColumns(table);
+  const names: string[] = [];
+
+  for (const fieldData of Object.values(tree)) {
+    if (!tableColumns[fieldData.name]) {
+      continue;
+    }
+
+    names.push(fieldData.name);
+  }
+
+  names.push(...relationJoinColumns(tree, table, selectionCtx));
+
+  if (!names.length) {
+    names.push(fallbackColumnName(tableColumns));
+  }
+
+  return names;
+};
+
+/** The requested columns as the relational query builder's `columns` map. */
 export const extractSelectedColumnsFromTree = (
   tree: Record<string, ResolveTree>,
   table: Table,
   selectionCtx?: SelectionCtx,
 ): Record<string, true> => {
-  const tableColumns = getColumns(table);
-
-  const treeEntries = Object.entries(tree);
-  const selectedColumns: SelectedColumnsRaw = [];
-
-  for (const [_fieldName, fieldData] of treeEntries) {
-    if (!tableColumns[fieldData.name]) {
-      continue;
-    }
-
-    selectedColumns.push([fieldData.name, true]);
-  }
-
-  for (const columnName of relationJoinColumns(tree, table, selectionCtx)) {
-    selectedColumns.push([columnName, true]);
-  }
-
-  if (!selectedColumns.length) {
-    const columnKeys = Object.entries(tableColumns);
-    const columnName =
-      columnKeys.find((e) => rqbCrashTypes.find((haram) => e[1].columnType !== haram))?.[0] ?? columnKeys[0]![0];
-
-    selectedColumns.push([columnName, true]);
-  }
+  const selectedColumns: SelectedColumnsRaw = selectedColumnNames(tree, table, selectionCtx).map((columnName) => [
+    columnName,
+    true,
+  ]);
 
   return Object.fromEntries(selectedColumns);
 };
 
 /**
+ * The same columns as a SQL select list.
+ *
  * Can't automatically determine column type on type level
  * Since drizzle table types extend eachother
  */
@@ -125,29 +148,10 @@ export const extractSelectedColumnsFromTreeSQLFormat = <TColType extends Column 
   selectionCtx?: SelectionCtx,
 ): Record<string, TColType> => {
   const tableColumns = getColumns(table);
-
-  const treeEntries = Object.entries(tree);
-  const selectedColumns: SelectedSQLColumns = [];
-
-  for (const [_fieldName, fieldData] of treeEntries) {
-    if (!tableColumns[fieldData.name]) {
-      continue;
-    }
-
-    selectedColumns.push([fieldData.name, tableColumns[fieldData.name]!]);
-  }
-
-  for (const columnName of relationJoinColumns(tree, table, selectionCtx)) {
-    selectedColumns.push([columnName, tableColumns[columnName]!]);
-  }
-
-  if (!selectedColumns.length) {
-    const columnKeys = Object.entries(tableColumns);
-    const columnName =
-      columnKeys.find((e) => rqbCrashTypes.find((haram) => e[1].columnType !== haram))?.[0] ?? columnKeys[0]![0];
-
-    selectedColumns.push([columnName, tableColumns[columnName]!]);
-  }
+  const selectedColumns: SelectedSQLColumns = selectedColumnNames(tree, table, selectionCtx).map((columnName) => [
+    columnName,
+    tableColumns[columnName]!,
+  ]);
 
   return Object.fromEntries(selectedColumns) as Record<string, TColType>;
 };

--- a/tests/selected-columns.test.ts
+++ b/tests/selected-columns.test.ts
@@ -1,0 +1,64 @@
+// Unit tests for the column extractors. A selection that names no column of its own — a
+// `__typename`-only query, or one that asks for relation fields only — still has to produce a
+// column for the statement to select, and which one it picks matters: a handful of SQLite
+// column types crash the relational query builder when they are the only column selected.
+
+import { blob, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { describe, expect, it } from 'vitest';
+import { extractSelectedColumnsFromTree, extractSelectedColumnsFromTreeSQLFormat } from '@/util/builders/common';
+import type { ResolveTree } from '@/util/parse-resolve-info';
+
+/** A table whose first column is one the relational query builder cannot stand alone. */
+const CrashFirst = sqliteTable('crash_first', {
+  blobBigInt: blob('blob_bigint', { mode: 'bigint' }),
+  id: integer('id').primaryKey(),
+  name: text('name'),
+});
+
+/** A table with nothing but crash-prone columns — the fallback has no safe choice to make. */
+const AllCrash = sqliteTable('all_crash', {
+  blobBigInt: blob('blob_bigint', { mode: 'bigint' }),
+  blobJson: blob('blob_json', { mode: 'json' }),
+});
+
+const Plain = sqliteTable('plain', {
+  id: integer('id').primaryKey(),
+  name: text('name'),
+});
+
+const field = (name: string): ResolveTree => ({ name, alias: name, args: {}, fieldsByTypeName: {} });
+
+describe('extractSelectedColumnsFromTree', () => {
+  it('returns the columns the selection names', () => {
+    expect(extractSelectedColumnsFromTree({ name: field('name') }, Plain)).toStrictEqual({ name: true });
+  });
+
+  it('ignores fields that are not columns', () => {
+    expect(extractSelectedColumnsFromTree({ posts: field('posts') }, Plain)).toStrictEqual({ id: true });
+  });
+
+  it('skips a crash-prone column when falling back', () => {
+    // The empty selection is what a `__typename`-only query produces.
+    expect(extractSelectedColumnsFromTree({}, CrashFirst)).toStrictEqual({ id: true });
+  });
+
+  it('falls back to the first column when every column is crash-prone', () => {
+    expect(extractSelectedColumnsFromTree({}, AllCrash)).toStrictEqual({ blobBigInt: true });
+  });
+});
+
+describe('extractSelectedColumnsFromTreeSQLFormat', () => {
+  it('returns the same columns as the map form, as column objects', () => {
+    const selected = extractSelectedColumnsFromTreeSQLFormat({ name: field('name') }, Plain);
+
+    expect(Object.keys(selected)).toStrictEqual(['name']);
+    expect(selected['name']).toBe(Plain.name);
+  });
+
+  it('skips a crash-prone column when falling back', () => {
+    const selected = extractSelectedColumnsFromTreeSQLFormat({}, CrashFirst);
+
+    expect(Object.keys(selected)).toStrictEqual(['id']);
+    expect(selected['id']).toBe(CrashFirst.id);
+  });
+});


### PR DESCRIPTION
Closes #130. Closes #131.

## The bug

`extractSelectedColumnsFromTree` falls back to one column when a selection names none of its own — a `__typename`-only query, or one that asks for relation fields only. It is supposed to avoid three SQLite column types that crash the relational query builder when they are the only column selected. The guard never did that:

```ts
columnKeys.find((e) => rqbCrashTypes.find((haram) => e[1].columnType !== haram))?.[0] ?? columnKeys[0]![0]
```

The inner `find` asks whether *some* crash type differs from this column's type — true for every column, including the crash types themselves (`'SQLiteBigInt' !== 'SQLiteBlobJson'`). So the outer `find` matched the first entry unconditionally and the fallback was always `columnKeys[0]`. A table whose first column is a `blob(… mode: 'bigint')` or `blob(… mode: 'json')` picked exactly the column the guard existed to avoid.

The fix is the membership test it meant to be:

```ts
columnKeys.find(([, column]) => !rqbCrashTypes.includes(column.columnType))?.[0] ?? columnKeys[0]![0]
```

The `?? columnKeys[0]` last resort stays — a table of nothing but crash-prone columns still has to select something.

## The duplication

`extractSelectedColumnsFromTree` and `extractSelectedColumnsFromTreeSQLFormat` were the same function twice, differing only in whether the map's value is `true` or the column object — including two copies of the broken guard, which is how one fix would have missed the other. Both now share `selectedColumnNames`, and each maps the names into its own shape.

## Tests

New `tests/selected-columns.test.ts` unit-tests both extractors directly, including a table whose first column is a `blob(bigint)` and one where every column is crash-prone. Both fallback cases fail on `main` and pass here.

`npx vitest run tests/pglite/ tests/sqlite.test.ts` — 1096 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DBnK2Q3YdAY2D3gxPCg5oM