### PR TITLE
perf: cache the dialect getTableConfig per table

### DIFF
--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -67,6 +67,7 @@ export {
   getPrimaryKeyPropNames,
   getPrimaryKeyPropNamesFromConfig,
   getUniqueColumnSets,
+  memoizeTableConfig,
   primaryKeyOrderExprs,
   withPrimaryKeyColumns,
 } from './common/keys.ts';

--- a/src/util/builders/common/keys.ts
+++ b/src/util/builders/common/keys.ts
@@ -62,6 +62,34 @@ export const withPrimaryKeyColumns = <T extends Record<string, any>>(
 };
 
 /**
+ * Wraps a dialect's `getTableConfig` in a per-table cache.
+ *
+ * The dialect implementations are not lookups: each call re-runs the table's
+ * `extraConfigBuilder` and rebuilds every index, check, unique constraint, primary key and
+ * foreign key it declares. Nothing about a table changes after it is defined, so the result
+ * is the same every time — but a build asks for it many times per table (primary-key names,
+ * unique column sets, conflict targets, one per relation that keys off the target's PK), and
+ * an overriding resolver asks again at request time.
+ *
+ * The cache is a `WeakMap` on the table object, so it costs nothing once the table is gone.
+ * Bind it once per dialect module, at module scope, so the cache outlives a single
+ * `buildSchema` call.
+ */
+export const memoizeTableConfig = <TTable extends Table, TConfig>(
+  getTableConfig: (table: TTable) => TConfig,
+): ((table: TTable) => TConfig) => {
+  const cache = new WeakMap<TTable, TConfig>();
+  return (table: TTable): TConfig => {
+    let config = cache.get(table);
+    if (config === undefined) {
+      config = getTableConfig(table);
+      cache.set(table, config);
+    }
+    return config;
+  };
+};
+
+/**
  * Resolves a table's primary-key property names using a dialect's `getTableConfig` to
  * surface table-level composite keys (whose member columns aren't flagged `.primary`).
  * Each dialect builder binds this with its own getTableConfig and reuses the binding for

--- a/src/util/builders/mysql.ts
+++ b/src/util/builders/mysql.ts
@@ -1,5 +1,5 @@
 import type { Table } from 'drizzle-orm';
-import { getTableConfig, type MySqlAsyncDatabase, MySqlTable } from 'drizzle-orm/mysql-core';
+import { type MySqlAsyncDatabase, MySqlTable, getTableConfig as mysqlTableConfig } from 'drizzle-orm/mysql-core';
 import {
   GraphQLBoolean,
   type GraphQLInputObjectType,
@@ -23,6 +23,7 @@ import {
   getPrimaryKeyPropNamesFromConfig,
   hardDeleteArg,
   type MutationTxCtx,
+  memoizeTableConfig,
   mysqlValuesColumnRef,
   type OnConflictArg,
   type RelationFilterBase,
@@ -426,6 +427,9 @@ const generateDelete = (
     },
   });
 };
+
+/** The dialect's table config, cached per table — see {@link memoizeTableConfig}. */
+const getTableConfig = memoizeTableConfig(mysqlTableConfig);
 
 /** Primary-key property names for a MySQL table, including table-level composite keys. */
 const mysqlPrimaryKeyPropNames = (table: MySqlTable): string[] =>

--- a/src/util/builders/pg.ts
+++ b/src/util/builders/pg.ts
@@ -1,10 +1,17 @@
 import type { Table } from 'drizzle-orm';
-import { getTableConfig, type PgAsyncDatabase, PgTable } from 'drizzle-orm/pg-core';
+import { type PgAsyncDatabase, PgTable, getTableConfig as pgTableConfig } from 'drizzle-orm/pg-core';
 import type { GeneratedEntities } from '../../types.ts';
-import { getPrimaryKeyPropNamesFromConfig, type TablesRelationalConfig } from '../builders/common.ts';
+import {
+  getPrimaryKeyPropNamesFromConfig,
+  memoizeTableConfig,
+  type TablesRelationalConfig,
+} from '../builders/common.ts';
 import { createSchemaDataGenerator } from './schema-data.ts';
 import type { SchemaGeneratorOptions } from './types.ts';
 import { createUpdateManyGenerator } from './update-many.ts';
+
+/** The dialect's table config, cached per table — see {@link memoizeTableConfig}. */
+const getTableConfig = memoizeTableConfig(pgTableConfig);
 
 /** Primary-key property names for a PG table, including table-level composite keys. */
 const pgPrimaryKeyPropNames = (table: PgTable): string[] => getPrimaryKeyPropNamesFromConfig(table, getTableConfig);

--- a/src/util/builders/sqlite.ts
+++ b/src/util/builders/sqlite.ts
@@ -1,11 +1,18 @@
 import type { Table } from 'drizzle-orm';
-import { getTableConfig, type SQLiteAsyncDatabase, SQLiteTable } from 'drizzle-orm/sqlite-core';
+import { type SQLiteAsyncDatabase, SQLiteTable, getTableConfig as sqliteTableConfig } from 'drizzle-orm/sqlite-core';
 
 import type { GeneratedEntities } from '../../types.ts';
-import { getPrimaryKeyPropNamesFromConfig, type TablesRelationalConfig } from '../builders/common.ts';
+import {
+  getPrimaryKeyPropNamesFromConfig,
+  memoizeTableConfig,
+  type TablesRelationalConfig,
+} from '../builders/common.ts';
 import { createSchemaDataGenerator } from './schema-data.ts';
 import type { SchemaGeneratorOptions } from './types.ts';
 import { createUpdateManyGenerator, type UpdateManyBatchRunner, type UpdateManyEntry } from './update-many.ts';
+
+/** The dialect's table config, cached per table — see {@link memoizeTableConfig}. */
+const getTableConfig = memoizeTableConfig(sqliteTableConfig);
 
 /** Primary-key property names for a SQLite table, including table-level composite keys. */
 const sqlitePrimaryKeyPropNames = (table: SQLiteTable): string[] =>

--- a/src/util/selection.ts
+++ b/src/util/selection.ts
@@ -1,7 +1,7 @@
 import { is, Table } from 'drizzle-orm';
-import { getTableConfig as getMySqlTableConfig, MySqlAsyncDatabase } from 'drizzle-orm/mysql-core';
-import { getTableConfig as getPgTableConfig, PgAsyncDatabase } from 'drizzle-orm/pg-core';
-import { getTableConfig as getSQLiteTableConfig, SQLiteAsyncDatabase } from 'drizzle-orm/sqlite-core';
+import { MySqlAsyncDatabase, getTableConfig as mysqlTableConfig } from 'drizzle-orm/mysql-core';
+import { PgAsyncDatabase, getTableConfig as pgTableConfig } from 'drizzle-orm/pg-core';
+import { SQLiteAsyncDatabase, getTableConfig as sqliteTableConfig } from 'drizzle-orm/sqlite-core';
 import type { GraphQLResolveInfo } from 'graphql';
 import type { AnyDrizzleDB } from '../types.ts';
 import {
@@ -10,6 +10,7 @@ import {
   type DerivedTypeNameMapper,
   extractRelationsParams,
   getPrimaryKeyPropNamesFromConfig,
+  memoizeTableConfig,
   type RelationFilterBase,
   resolveGeneratedTypeNames,
   resolveObjectTypeName,
@@ -36,16 +37,24 @@ type SelectionContext = {
 
 const contextCache = new WeakMap<object, SelectionContext>();
 
+type TableConfigLookup = (table: Table) => { primaryKeys: { columns: { name: string }[] }[] };
+
+// Cached per table, and bound at module scope so the cache is shared with every selection
+// this process translates — the same memoization each dialect builder applies.
+const getMySqlTableConfig = memoizeTableConfig(mysqlTableConfig as unknown as TableConfigLookup);
+const getPgTableConfig = memoizeTableConfig(pgTableConfig as unknown as TableConfigLookup);
+const getSQLiteTableConfig = memoizeTableConfig(sqliteTableConfig as unknown as TableConfigLookup);
+
 /** The dialect's `getTableConfig`, which is the only place a composite primary key shows up. */
-const tableConfigFor = (db: AnyDrizzleDB<any>) => {
+const tableConfigFor = (db: AnyDrizzleDB<any>): TableConfigLookup => {
   if (is(db, MySqlAsyncDatabase)) {
-    return getMySqlTableConfig as (table: Table) => { primaryKeys: { columns: { name: string }[] }[] };
+    return getMySqlTableConfig;
   }
   if (is(db, PgAsyncDatabase)) {
-    return getPgTableConfig as unknown as (table: Table) => { primaryKeys: { columns: { name: string }[] }[] };
+    return getPgTableConfig;
   }
   if (is(db, SQLiteAsyncDatabase)) {
-    return getSQLiteTableConfig as unknown as (table: Table) => { primaryKeys: { columns: { name: string }[] }[] };
+    return getSQLiteTableConfig;
   }
   throw new Error('Drizzle-GraphQL Error: unsupported database instance — expected a PostgreSQL, MySQL or SQLite one.');
 };


### PR DESCRIPTION
Closes #134.

`getTableConfig` reads as a lookup but isn't one. Each dialect's implementation re-runs the table's `extraConfigBuilder` and rebuilds every index, check, unique constraint, primary key and foreign key the table declares — `node_modules/drizzle-orm/pg-core/utils.js:16-50`. Nothing about a table changes after it is defined, so every call after the first recomputes a value that is already known.

A build asks for it repeatedly per table: `getPrimaryKeyPropNamesFromConfig`, `getUniqueColumnSets`, the conflict-target resolution, and once per relation that keys off its target's primary key. `selectionToWith` / `resolveSelection` ask again at request time.

## Measured

Instrumented on the pg test schema (5 tables, 4 with relations):

```
BUILD1  calls=39  misses=4
BUILD2  calls=78  misses=4
```

39 calls per `buildSchema`, 4 of which do real work. A second build over the same table objects adds no work at all.

## The change

New `memoizeTableConfig` in `common/keys.ts` wraps a dialect's function in a `WeakMap<Table, Config>`. Each dialect module (`pg.ts`, `sqlite.ts`, `mysql.ts`) and `selection.ts` binds its own at module scope, so the cache outlives a single `buildSchema` call and every consumer inside the module — the primary-key helper and the schema adapter alike — reads through it with no further edits. Keying on the table object means the entry is released when the table is.

`npx vitest run tests/pglite/ tests/sqlite*.test.ts` — 1103 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DBnK2Q3YdAY2D3gxPCg5oM