### PR TITLE
perf: hoist per-request invariants out of hot paths

### DIFF
--- a/src/util/builders/aggregates.ts
+++ b/src/util/builders/aggregates.ts
@@ -97,7 +97,37 @@ interface AggregateColumnSets {
  * arrays (including array-typed number columns), JSON, buffers, and object-shaped columns
  * (e.g. geometry) are excluded entirely.
  */
+/**
+ * Cache for {@link classifyAggregateColumns}. Keyed on the table object, then on the name it
+ * was classified under — the name only reaches `drizzleColumnToGraphQLType` for enum naming,
+ * but a table registered under two names would name its enums differently, so it is part of
+ * the key rather than assumed irrelevant.
+ *
+ * The entries hold this build's GraphQL types and this build's column exclusions, so the
+ * cache lives exactly as long as a build: {@link resetAggregateColumnCache} runs at the start
+ * of every one, alongside the other per-build registries. Kept across builds it would hand a
+ * second build the first build's enum instances, which is a schema with two types of one name.
+ */
+let aggregateColumnSetsCache = new WeakMap<Table, Map<string, AggregateColumnSets>>();
+
+/** Drops the classifications cached for the previous build. Called once per `generateSchemaData`. */
+export const resetAggregateColumnCache = (): void => {
+  aggregateColumnSetsCache = new WeakMap();
+};
+
 const classifyAggregateColumns = (table: Table, tableName: string): AggregateColumnSets => {
+  // Called from every aggregate/group-by generator for the same table — five times per table
+  // at build time, plus twice per to-many relation — and each call re-converts every column.
+  let byName = aggregateColumnSetsCache.get(table);
+  if (!byName) {
+    byName = new Map();
+    aggregateColumnSetsCache.set(table, byName);
+  }
+  const cached = byName.get(tableName);
+  if (cached) {
+    return cached;
+  }
+
   const numeric: AggregateColumnSets['numeric'] = {};
   const orderable: AggregateColumnSets['orderable'] = {};
   const all: AggregateColumnSets['all'] = {};
@@ -130,7 +160,10 @@ const classifyAggregateColumns = (table: Table, tableName: string): AggregateCol
     }
   }
 
-  return { numeric, orderable, all };
+  const sets = { numeric, orderable, all };
+  byName.set(tableName, sets);
+
+  return sets;
 };
 
 /**

--- a/src/util/builders/build-context.ts
+++ b/src/util/builders/build-context.ts
@@ -59,6 +59,7 @@ import {
   generateGroupByEnum,
   generateGroupByType,
   generateHavingInput,
+  resetAggregateColumnCache,
 } from './aggregates.ts';
 import {
   buildNestedWritePlans,
@@ -193,6 +194,9 @@ export const createSchemaBuilder = <WithReturning extends boolean>(adapter: Sche
     // And the same for column exclusions: a per-build registry read by every site that decides
     // what the schema contains, reset here so a rebuild never inherits the previous build's.
     registerColumnExclusions(tables, options.exclude);
+    // Column classifications for the aggregates are cached across the tables of one build, and
+    // hold that build's types and exclusions — so they are dropped here for the same reason.
+    resetAggregateColumnCache();
 
     // Flatten drizzle-orm v1 TablesRelationalConfig into the canonical shape
     // used throughout common.ts: Record<tableName, Record<relName, TableNamedRelations>>

--- a/src/util/builders/common/cursor.ts
+++ b/src/util/builders/common/cursor.ts
@@ -126,12 +126,25 @@ const decodeCursorValue = (value: any): any => {
  * payload holding the ordering spec (`o`) and the row's values for it (`v`). The spec rides
  * along so a later request can verify the cursor was issued for the same ordering it is using.
  */
-export const encodeCursor = (entries: CursorOrderEntry[], row: Record<string, any>): string => {
-  const payload = {
-    o: entries,
-    v: entries.map(([column]) => encodeCursorValue(row[column] ?? null)),
+export const encodeCursor = (entries: CursorOrderEntry[], row: Record<string, any>): string =>
+  cursorEncoder(entries)(row);
+
+/**
+ * `encodeCursor` bound to one ordering, for encoding a whole page.
+ *
+ * The ordering spec is the same for every row of a page, so it is serialized once here and
+ * spliced into each row's payload rather than re-serialized per row. The bytes are identical
+ * to what building the payload object and stringifying it produces — same keys, same order —
+ * so cursors stay interchangeable with ones issued before this was split out.
+ */
+const cursorEncoder = (entries: CursorOrderEntry[]): ((row: Record<string, any>) => string) => {
+  const spec = JSON.stringify(entries);
+  const columns = entries.map(([column]) => column);
+
+  return (row) => {
+    const values = JSON.stringify(columns.map((column) => encodeCursorValue(row[column] ?? null)));
+    return Buffer.from(`{"o":${spec},"v":${values}}`, 'utf8').toString('base64url');
   };
-  return Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
 };
 
 /**
@@ -294,8 +307,9 @@ export const selectsCursorField = (info: any, table: Table): boolean => {
  * dates and bigints into their transport forms.
  */
 export const attachRowCursors = (rows: Record<string, any>[], entries: CursorOrderEntry[]): void => {
+  const encode = cursorEncoder(entries);
   for (const row of rows) {
-    row[ROW_CURSOR_PROP] = encodeCursor(entries, row);
+    row[ROW_CURSOR_PROP] = encode(row);
   }
 };
 

--- a/src/util/builders/common/filters.ts
+++ b/src/util/builders/common/filters.ts
@@ -310,6 +310,19 @@ const jsonPathCondition = (column: Column, columnName: string, filter: Record<st
   return variants.length ? (variants.length > 1 ? and(...variants) : variants[0]) : undefined;
 };
 
+// The operator dispatch tables. Constant, and hoisted out of `extractFiltersColumn` — which
+// recurses once per AND/OR/NOT branch of every filter of every request — so they are built
+// once per process rather than five objects per call.
+const singleValueOps: Record<string, (...args: any[]) => SQL> = { eq, ne, gt, gte, lt, lte };
+const stringValueOps: Record<string, (...args: any[]) => SQL> = { like, notLike, ilike, notIlike };
+const arrayValueOps: Record<string, (...args: any[]) => SQL> = { inArray, notInArray };
+/** Membership operators for array columns: element list → SQL. Empty lists are rejected below. */
+const arrayMembershipOps: Record<string, (...args: any[]) => SQL> = {
+  hasSome: arrayOverlaps,
+  hasEvery: arrayContains,
+};
+const nullableOps: Record<string, (...args: any[]) => SQL> = { isNull, isNotNull };
+
 export const extractFiltersColumn = <TColumn extends Column>(
   column: TColumn,
   columnName: string,
@@ -325,16 +338,6 @@ export const extractFiltersColumn = <TColumn extends Column>(
   const foldCase = insensitive === true;
 
   const entries = Object.entries(restOperators as FilterColumnOperatorsCore<TColumn>);
-
-  const singleValueOps: Record<string, (...args: any[]) => SQL> = { eq, ne, gt, gte, lt, lte };
-  const stringValueOps: Record<string, (...args: any[]) => SQL> = { like, notLike, ilike, notIlike };
-  const arrayValueOps: Record<string, (...args: any[]) => SQL> = { inArray, notInArray };
-  // Membership operators for array columns: element list → SQL. Empty lists are rejected below.
-  const arrayMembershipOps: Record<string, (...args: any[]) => SQL> = {
-    hasSome: arrayOverlaps,
-    hasEvery: arrayContains,
-  };
-  const nullableOps: Record<string, (...args: any[]) => SQL> = { isNull, isNotNull };
 
   const variants = [] as SQL[];
   for (const [operatorName, operatorValue] of entries) {

--- a/src/util/builders/common/order-by.ts
+++ b/src/util/builders/common/order-by.ts
@@ -37,8 +37,11 @@ export const orderByEntries = (
   orderArgs: Record<string, any>,
 ): [string, 'asc' | 'desc', OrderNullsOption | undefined][] =>
   Object.entries(orderArgs)
-    .sort((a, b) => (b[1]?.priority ?? 0) - (a[1]?.priority ?? 0))
+    // Filtered before the sort: an unset key contributes no entry, so sorting it is work
+    // thrown away — and `sort` is stable, so dropping first leaves the same relative order
+    // among equal priorities.
     .filter(([, config]) => config)
+    .sort((a, b) => (b[1]?.priority ?? 0) - (a[1]?.priority ?? 0))
     .map(([column, config]) => {
       if (typeof config === 'object' && config.direction === undefined) {
         throw drizzleError(`ORDER BY ${column}: ordering through a relation is not supported in this query`, {

--- a/src/util/parse-resolve-info.ts
+++ b/src/util/parse-resolve-info.ts
@@ -186,6 +186,9 @@ const collectSelections = (
     fields = {};
     tree[parentTypeName] = fields;
   }
+  // Loop-invariant: the parent type is the same for every selection in this set, and this
+  // walk runs on every resolve of every request.
+  const parentFields = fieldsOf(parentType);
 
   for (const selection of selections) {
     if (isExcluded(info, selection)) {
@@ -198,7 +201,7 @@ const collectSelections = (
         continue;
       }
 
-      const fieldDef = fieldsOf(parentType)?.[name];
+      const fieldDef = parentFields?.[name];
       // A field the parent type does not declare: either a union's own selection set, which
       // carries nothing but meta-fields, or a document that never passed validation.
       if (!fieldDef) {
@@ -294,7 +297,13 @@ const collectSelections = (
   return tree;
 };
 
-const firstKey = (object: Record<string, unknown>): string | undefined => Object.keys(object)[0];
+/** The first key of an object, without materializing the whole key array to discard it. */
+const firstKey = (object: Record<string, unknown>): string | undefined => {
+  for (const key in object) {
+    return key;
+  }
+  return undefined;
+};
 
 /**
  * Reads the selection under a resolver's own field out of its `info`, as a tree of

--- a/tests/cursor-encoding.test.ts
+++ b/tests/cursor-encoding.test.ts
@@ -1,0 +1,42 @@
+// The cursor payload is a wire format: a client pages by handing back a string an earlier
+// response gave it, so its bytes have to stay stable across releases. These pin the exact
+// encoding rather than only the round trip, which would keep passing if both halves changed
+// together and would silently invalidate every cursor already in flight.
+
+import { describe, expect, it } from 'vitest';
+import type { CursorOrderEntry } from '@/util/builders/common';
+import { decodeCursor, encodeCursor } from '@/util/builders/common';
+
+const entries: CursorOrderEntry[] = [
+  ['createdAt', 'desc', 'last'],
+  ['id', 'asc'],
+];
+
+describe('cursor encoding', () => {
+  it('encodes a row to a stable string', () => {
+    const cursor = encodeCursor(entries, { createdAt: new Date('2024-04-02T06:44:41.785Z'), id: 7 });
+
+    expect(cursor).toBe(
+      Buffer.from(
+        '{"o":[["createdAt","desc","last"],["id","asc"]],"v":[{"$type":"date","value":"2024-04-02T06:44:41.785Z"},7]}',
+        'utf8',
+      ).toString('base64url'),
+    );
+  });
+
+  it('round-trips the ordering values', () => {
+    const row = { createdAt: new Date('2024-04-02T06:44:41.785Z'), id: 7n };
+
+    expect(decodeCursor(encodeCursor(entries, row), entries)).toStrictEqual([row.createdAt, 7n]);
+  });
+
+  it('encodes a missing value as null', () => {
+    expect(decodeCursor(encodeCursor(entries, { id: 7 }), entries)).toStrictEqual([null, 7]);
+  });
+
+  it('rejects a cursor issued for a different ordering', () => {
+    const cursor = encodeCursor(entries, { createdAt: new Date(0), id: 1 });
+
+    expect(() => decodeCursor(cursor, [['id', 'asc']])).toThrow(/different ordering/);
+  });
+});


### PR DESCRIPTION
Five places rebuilt the same value on every call. None of them change what is produced — only how often.

### Request path
- **`filters.ts` (#138)** — the five operator dispatch tables were object literals allocated *inside* `extractFiltersColumn`, which recurses once per `AND`/`OR`/`NOT` branch of every filter on every request. Moved to module scope.
- **`order-by.ts` (#149)** — `orderByEntries` sorted every entry and then skipped the unset ones. Now filters first, then sorts; `Array#sort` is stable, so the relative order of the kept entries is unchanged.
- **`parse-resolve-info.ts` (#150)** — `fieldsOf(parentType)` is loop-invariant, hoisted above the selection loop. `firstKey` built a whole `Object.keys()` array to read index 0; a `for…in` that returns on the first key does the same thing without the allocation.
- **`cursor.ts` (#140)** — encoding a page re-stringified the ordering spec and re-derived the column list for every row. `cursorEncoder` now does that once per result set and returns a closure; `encodeCursor` (single row) keeps its signature.

### Build path
- **`aggregates.ts` (#143)** — `classifyAggregateColumns` converts every column of a table to its GraphQL type, and ran five times per table at build time plus twice per to-many relation. Now cached per table.

  The cached entries hold *this build's* `GraphQLEnumType` instances and *this build's* column exclusions, so the cache is per-build, not per-process: `resetAggregateColumnCache()` runs in `prepareBuild` alongside `registerScalarOverrides` / `registerEnumConfig` / `registerColumnExclusions`. Kept across builds it hands the second build the first build's enum objects, which is a schema with two distinct types named `RoleEnum` — the existing `buildSchema` idempotency test catches exactly that.

### Tests
`tests/cursor-encoding.test.ts` (4 tests) pins the exact base64url bytes for a fixed row and ordering, plus `Date`/`bigint` round-tripping, missing values encoding as null, and rejection of a cursor from a different ordering. Without it the encoder refactor would only have been checked against itself.

Full suite green: 74 files, 1120 passed, 0 failed.

Closes #138, closes #140, closes #143, closes #149, closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DBnK2Q3YdAY2D3gxPCg5oM