### PR TITLE
refactor: consolidate duplicated column helpers

### DIFF
--- a/src/util/builders/common/column-filters.ts
+++ b/src/util/builders/common/column-filters.ts
@@ -43,6 +43,25 @@ export const columnDialect = (column: Column): 'pg' | 'mysql' | 'sqlite' | undef
   return undefined;
 };
 
+/**
+ * Whether the column stores JSON.
+ *
+ * Decided on drizzle's `dataType`, its semantic marker, rather than on `columnType`, which
+ * names the implementing class. drizzle-orm v1 uses compound dataType strings (`"object
+ * json"` for every json/jsonb column across the three dialects), hence the inclusion test.
+ *
+ * `PgGeometryObject` is excluded explicitly. That is currently redundant — it reports
+ * `"object geometry"` — but it is stored as json, has its own object type in the generated
+ * schema, and must not be reclassified if drizzle ever spells its dataType differently.
+ *
+ * One predicate for two callers that must agree: the filter builder, whose `path` and
+ * `contains` operators mean structural JSON containment rather than the string operators,
+ * and the data mappers, which transport a JSON value as-is instead of remapping it. They
+ * previously had a copy each, asking different questions of the column.
+ */
+export const isJsonColumn = (column: Column): boolean =>
+  ((column as any).dataType ?? '').includes('json') && (column as any).columnType !== 'PgGeometryObject';
+
 /** How a column's generic filter input should be shaped, alongside the cache key to store it under. */
 interface GenericFilterDescriptor {
   name: string;

--- a/src/util/builders/common/filters.ts
+++ b/src/util/builders/common/filters.ts
@@ -27,7 +27,7 @@ import {
 } from 'drizzle-orm';
 import { remapFromGraphQLCore } from '../../data-mappers/index.ts';
 import type { FilterColumnOperators, FilterColumnOperatorsCore } from '../types.ts';
-import { columnDialect } from './column-filters.ts';
+import { columnDialect, isJsonColumn } from './column-filters.ts';
 import { drizzleError } from './errors.ts';
 
 /**
@@ -110,12 +110,6 @@ const lowerMembership = (column: Column, values: unknown[], negated: boolean): S
   );
   return negated ? sql`lower(${column}) not in (${lowered})` : sql`lower(${column}) in (${lowered})`;
 };
-
-/**
- * Whether the column stores JSON — its `contains` operator is structural containment,
- * not the safe substring operator string columns get.
- */
-const isJsonColumn = (column: Column): boolean => (((column as any).columnType ?? '') as string).includes('Json');
 
 /**
  * Structural JSON containment for the `contains` operator on json/jsonb columns.

--- a/src/util/builders/common/mutation-helpers.ts
+++ b/src/util/builders/common/mutation-helpers.ts
@@ -67,19 +67,13 @@ export const prepareMutationRelationColumns = (params: {
   const { relationMap, tables, tableName, typeNameMapper, table, pkNames, parsedInfo, resolveName } = params;
   const typeName = resolveObjectTypeName(tableName, typeNameMapper, resolveName);
   const withParams = relationMap[tableName]
-    ? extractRelationsParams(
-        relationMap,
-        tables,
-        tableName,
-        parsedInfo,
-        typeName,
+    ? extractRelationsParams(relationMap, tables, tableName, parsedInfo, typeName, {
         typeNameMapper,
-        undefined,
-        params.limits,
-        params.scope,
-        params.defaultOrderBy,
+        limits: params.limits,
+        scope: params.scope,
+        defaultOrderBy: params.defaultOrderBy,
         resolveName,
-      )
+      })
     : undefined;
   const hasRelations = !!(withParams && Object.keys(withParams).length);
   const baseColumns = extractSelectedColumnsFromTreeSQLFormat(parsedInfo.fieldsByTypeName[typeName]!, table, {

--- a/src/util/builders/common/relation-params.ts
+++ b/src/util/builders/common/relation-params.ts
@@ -19,26 +19,40 @@ import { extractFilters, relationFilterCtx } from './relation-filters.ts';
 import { extractSelectedColumnsFromTree } from './selected-columns.ts';
 import type { TypeNameResolver } from './type-names.ts';
 
-export const extractRelationsParamsInner = (
+/**
+ * The build-wide policy the walk carries down unchanged. Grouped rather than passed
+ * positionally because the recursion below re-passes every one of them as it descends, and
+ * five of the six are object-or-undefined — a positional list of those is a silent hazard
+ * (a caller that means "no limits, no scope" writes three bare `undefined`s in a row).
+ */
+export interface RelationParamsOptions {
+  typeNameMapper?: TypeNameMapper;
+  filterCtx?: RelationFilterBase;
+  limits?: LimitPolicyFor;
+  scope?: ScopeResolver;
+  defaultOrderBy?: DefaultOrderByFor;
+  resolveName?: TypeNameResolver;
+}
+
+export const extractRelationsParams = (
   relationMap: Record<string, Record<string, TableNamedRelations>>,
   tables: Record<string, Table>,
   tableName: string,
+  info: ResolveTree | undefined,
   typeName: string,
-  originField: ResolveTree,
-  typeNameMapper?: TypeNameMapper,
-  _isInitial: boolean = false,
-  filterCtx?: RelationFilterBase,
-  limits?: LimitPolicyFor,
-  scope?: ScopeResolver,
-  defaultOrderBy?: DefaultOrderByFor,
-  resolveName?: TypeNameResolver,
-) => {
+  options: RelationParamsOptions = {},
+): Record<string, Partial<ProcessedTableSelectArgs>> | undefined => {
+  const { typeNameMapper, filterCtx, limits, scope, defaultOrderBy, resolveName } = options;
+  if (!info) {
+    return undefined;
+  }
+
   const relationsForTable = relationMap[tableName];
   if (!relationsForTable) {
     return undefined;
   }
 
-  const baseField = Object.entries(originField.fieldsByTypeName).find(([key, _value]) => key === typeName)?.[1];
+  const baseField = Object.entries(info.fieldsByTypeName).find(([key, _value]) => key === typeName)?.[1];
   if (!baseField) {
     return undefined;
   }
@@ -174,61 +188,13 @@ export const extractRelationsParamsInner = (
     thisRecord.offset = offset;
     thisRecord.limit = limit;
 
-    const relWith = relationField
-      ? extractRelationsParamsInner(
-          relationMap,
-          tables,
-          targetTableName,
-          relTypeName,
-          relationField,
-          typeNameMapper,
-          false,
-          filterCtx,
-          limits,
-          scope,
-          defaultOrderBy,
-          resolveName,
-        )
-      : undefined;
+    const relWith = extractRelationsParams(relationMap, tables, targetTableName, relationField, relTypeName, options);
     thisRecord.with = relWith;
 
     args[relName] = thisRecord;
   }
 
   return args;
-};
-
-export const extractRelationsParams = (
-  relationMap: Record<string, Record<string, TableNamedRelations>>,
-  tables: Record<string, Table>,
-  tableName: string,
-  info: ResolveTree | undefined,
-  typeName: string,
-  typeNameMapper?: TypeNameMapper,
-  filterCtx?: RelationFilterBase,
-  limits?: LimitPolicyFor,
-  scope?: ScopeResolver,
-  defaultOrderBy?: DefaultOrderByFor,
-  resolveName?: TypeNameResolver,
-): Record<string, Partial<ProcessedTableSelectArgs>> | undefined => {
-  if (!info) {
-    return undefined;
-  }
-
-  return extractRelationsParamsInner(
-    relationMap,
-    tables,
-    tableName,
-    typeName,
-    info,
-    typeNameMapper,
-    true,
-    filterCtx,
-    limits,
-    scope,
-    defaultOrderBy,
-    resolveName,
-  );
 };
 
 /**

--- a/src/util/builders/common/select-runtime.ts
+++ b/src/util/builders/common/select-runtime.ts
@@ -117,7 +117,7 @@ export const runRelationalSelect = async (opts: {
   // Taking a slice of an unordered result lets the database return any rows it likes, so
   // `limit`/`offset` pages can overlap or skip rows between requests, and a single query
   // can return a different row each time. Default to the primary key whenever the query is
-  // narrowed to a subset, mirroring the relation-level default in extractRelationsParamsInner.
+  // narrowed to a subset, mirroring the relation-level default in extractRelationsParams.
   const needsDefaultOrder = single || offset != null || opts.limit != null;
 
   // `distinct` runs as its own pass — the relational query builder cannot express it — and
@@ -201,19 +201,14 @@ export const runRelationalSelect = async (opts: {
           }
         : undefined,
     with: relationMap[tableName]
-      ? extractRelationsParams(
-          relationMap,
-          tables,
-          tableName,
-          parsedInfo,
-          typeName,
+      ? extractRelationsParams(relationMap, tables, tableName, parsedInfo, typeName, {
           typeNameMapper,
           filterCtx,
-          opts.limits,
+          limits: opts.limits,
           scope,
-          opts.defaultOrderBy,
-          opts.resolveName,
-        )
+          defaultOrderBy: opts.defaultOrderBy,
+          resolveName: opts.resolveName,
+        })
       : undefined,
   };
 

--- a/src/util/builders/common/table-types.ts
+++ b/src/util/builders/common/table-types.ts
@@ -237,7 +237,7 @@ const generateSelectFields = <TWithOrder extends boolean>(
       // pagination surface a root list of that table does. `after` and `distinct` are the
       // two drizzle's `with:` clause cannot express, so a request that passes either drops
       // the relation out of the eager fetch and resolves it through the batch loader, which
-      // implements both — see extractRelationsParamsInner.
+      // implements both — see extractRelationsParams.
       const targetDistinctEnum = cacheCtx.featureOf(targetTableName).distinct
         ? generateDistinctEnum(
             tables[targetTableName]!,

--- a/src/util/data-mappers/index.ts
+++ b/src/util/data-mappers/index.ts
@@ -1,12 +1,8 @@
-import { type Column, getTableColumns, is, One, type Table } from 'drizzle-orm';
+import { type Column, getColumns, is, One, type Table } from 'drizzle-orm';
+import { isJsonColumn } from '../builders/common/column-filters.ts';
 import { drizzleError } from '../builders/common/errors.ts';
 import type { TableNamedRelations } from '../builders/index.ts';
 import { getColumnScalarOverride } from '../type-converter/index.ts';
-
-// drizzle-orm v1 uses compound dataType strings (e.g. "object json"), so inclusion rather
-// than equality. PgGeometryObject is stored as json but has its own object type.
-const isJsonColumn = (column: Column): boolean =>
-  ((column as any).dataType ?? '').includes('json') && (column as any).columnType !== 'PgGeometryObject';
 
 export const remapToGraphQLCore = (
   key: string,
@@ -101,7 +97,7 @@ export const remapToGraphQLSingleOutput = (
   table: Table,
   relationMap?: Record<string, Record<string, TableNamedRelations>>,
 ) => {
-  const columns = getTableColumns(table);
+  const columns = getColumns(table);
 
   for (const [key, value] of Object.entries(queryOutput)) {
     if (value === undefined || value === null) {
@@ -297,11 +293,13 @@ export const remapFromGraphQLSingleInput = (
   table: Table,
   operation: RemapInputOperation = 'insert',
 ) => {
+  const columns = getColumns(table);
+
   for (const [key, value] of Object.entries(queryInput)) {
     if (value === undefined) {
       delete queryInput[key];
     } else {
-      const column = getTableColumns(table)[key];
+      const column = columns[key];
       if (!column) {
         throw drizzleError(`Unknown column: ${key}`, { code: 'DRIZZLE_UNKNOWN_COLUMN' });
       }

--- a/src/util/selection.ts
+++ b/src/util/selection.ts
@@ -191,12 +191,7 @@ export const selectionToWith = (
     table,
     parsed,
     resolveObjectTypeName(table, typeNameMapper, resolveName),
-    typeNameMapper,
-    filterCtx,
-    undefined,
-    undefined,
-    undefined,
-    resolveName,
+    { typeNameMapper, filterCtx, resolveName },
   );
   // A selection with no relations in it gets no `with` clause at all, rather than an empty
   // object the query builder would have to be asked to ignore.

--- a/src/util/type-converter/index.ts
+++ b/src/util/type-converter/index.ts
@@ -1,5 +1,5 @@
 import type { Column, Table } from 'drizzle-orm';
-import { extractExtendedColumnType, getTableColumns, is } from 'drizzle-orm';
+import { extractExtendedColumnType, getColumns, is } from 'drizzle-orm';
 import { MySqlInt, MySqlSerial } from 'drizzle-orm/mysql-core';
 import { PgDate, PgDateString, PgInteger, PgSerial, PgTimestamp, PgTimestampString, PgUUID } from 'drizzle-orm/pg-core';
 import { SQLiteInteger } from 'drizzle-orm/sqlite-core';
@@ -331,7 +331,7 @@ export const registerScalarOverrides = (
   config: { scalars?: ScalarOverridesConfig; mapColumnType?: ColumnTypeMapper },
 ): void => {
   for (const [tableName, table] of Object.entries(tables)) {
-    for (const [columnName, column] of Object.entries(getTableColumns(table))) {
+    for (const [columnName, column] of Object.entries(getColumns(table))) {
       const declared = config.scalars?.[tableName]?.[columnName];
 
       let resolved: { output?: GraphQLScalarType; input?: GraphQLScalarType } | undefined;


### PR DESCRIPTION
Three internal cleanups. No behaviour change; full suite green (88 files, 1344 tests).

### `isJsonColumn` — one rule instead of two (#139)

The predicate existed twice with two different definitions: `data-mappers/index.ts` asked drizzle's `dataType`, `common/filters.ts` asked its `columnType`.

The issue claimed they diverge on `customType` columns. **They don't** — I probed it, and posted the correction on #139. `Column#dataType` for a `PgCustomColumn` is the literal `'custom'`; the `dataType()` you write in `customType({...})` is the *SQL* type string and surfaces as `getSQLType()`. The two predicates agree on every column type drizzle ships.

So this is consolidation, not a fix. What it does buy: the `PgGeometryObject` exclusion becomes a decision rather than an accident. The `columnType` copy only excluded geometry because `'PgGeometryObject'.includes('Json')` is false on a capital J. The kept version excludes it explicitly and says why, and notes that it is currently redundant (`dataType` is `'object geometry'`) but guards a column that genuinely is stored as json and has its own object type in the schema.

Lives in `common/column-filters.ts` next to `columnDialect`, the other "what kind of column is this" helper. No import cycle: nothing `column-filters.ts` reaches imports `data-mappers`.

### `getTableColumns` → `getColumns` (#133)

drizzle-orm v1 marks `getTableColumns` `@deprecated`. The rest of the codebase already uses `getColumns` (67 references), so two spellings for one lookup were waiting for the deprecated one to be dropped in a drizzle minor. Four call sites switched; `getColumns` is a superset, so no behaviour change.

Also hoisted the lookup out of the per-key loop in `remapFromGraphQLSingleInput`. It is a symbol property read, so this is tidiness rather than a win.

### `extractRelationsParams` — drop the dead parameter (#142)

`extractRelationsParamsInner` took 12 positional parameters, the seventh being `_isInitial`, never read — the underscore was the only thing keeping Biome quiet about it. The exported wrapper existed to guard `!info` and to pass `true` for it, so a 12-argument call was written out twice to thread a value nothing consumes.

The parameter is gone, the guard is folded in, and the recursion is a direct self-call. The six values the walk carries down unchanged move into a `RelationParamsOptions` object — five are object-or-undefined, and `selection.ts` was passing three bare `undefined`s in a row to skip `limits`, `scope` and `defaultOrderBy`:

```diff
-    typeNameMapper,
-    filterCtx,
-    undefined,
-    undefined,
-    undefined,
-    resolveName,
+    { typeNameMapper, filterCtx, resolveName },
```

`extractRelationsParams` is internal — not re-exported from `src/index.ts`, and the package exports only `.` — so the signature change reaches no consumer.

Closes #133, closes #139, closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DBnK2Q3YdAY2D3gxPCg5oM