### PR TITLE
fix!: apply both suffixes to the mutations, and catch name collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,9 +353,23 @@ const { schema } = buildSchema(db, {
 })
 ```
 
+Both suffixes reach every operation that comes in a list/single pair, mutations included:
+the config above gives `usersAll` / `users` on the query side and `addUsersAll` / `addUsers`,
+`editUsersAll` / `editUsers`, `removeUsersAll` / `removeUsers` on the mutation side. The
+variants that carry their own disambiguator — `usersAggregate`, `usersGroupBy`,
+`updateUsersMany`, `updateUsersCount`, `deleteUsersCount` — take neither suffix.
+
 The list and single suffixes cannot be identical unless a `typeNameMapper` is also given —
 `users` and `usersSingle` would otherwise collapse onto one field name, and `buildSchema`
-throws rather than generating a schema that silently drops one of them.
+throws rather than generating a schema that silently drops one of them. With a mapper the
+plural and singular nouns keep the queries and the inserts apart, but the bulk update,
+delete and restore mutations are singular on both sides, so those three keep a `Single`
+suffix whenever the two configured suffixes are the same string.
+
+That check compares the configured suffixes, which is only part of what a name is made of.
+Every generated root field is also registered by name, and a build that puts two operations
+on one field name throws naming the field rather than dropping whichever registered first —
+whatever combination of prefixes, suffixes and mapper produced it.
 
 `typeNameMapper` renames the table itself, which is what a plural-keyed schema usually wants:
 `export const users = pgTable('users', …)` otherwise produces `type Users` and a

--- a/src/util/builders/build-context.ts
+++ b/src/util/builders/build-context.ts
@@ -28,6 +28,7 @@ import {
   buildUniqueKeyMap,
   createMutationTxCtx,
   createRelationResolverFactory,
+  defineRootField,
   extractRelationJoinColumns,
   generateTableTypes,
   getUniqueColumnSets,
@@ -455,7 +456,7 @@ export const createSchemaBuilder = <WithReturning extends boolean>(adapter: Sche
           )
         : undefined;
 
-    ctx.queries[selectArrGenerated.name] = {
+    defineRootField(ctx.queries, 'query', selectArrGenerated.name, {
       type: selectArrOutput,
       args: selectArrGenerated.args,
       resolve: selectArrGenerated.resolver,
@@ -463,17 +464,17 @@ export const createSchemaBuilder = <WithReturning extends boolean>(adapter: Sche
         drizzle: drizzleMeta({ kind: 'query', operation: 'select', single: false, targetArg: 'where' }),
         ...(complexity ? { complexity: listFieldComplexity(complexity, limits?.(tableName)) } : {}),
       },
-    };
-    ctx.queries[selectSingleGenerated.name] = {
+    });
+    defineRootField(ctx.queries, 'query', selectSingleGenerated.name, {
       type: selectSingleOutput,
       args: selectSingleGenerated.args,
       resolve: selectSingleGenerated.resolver,
       extensions: {
         drizzle: drizzleMeta({ kind: 'query', operation: 'select', single: true, targetArg: 'where' }),
       },
-    };
+    });
     if (aggregateGenerated && aggregateType) {
-      ctx.queries[aggregateGenerated.name] = {
+      defineRootField(ctx.queries, 'query', aggregateGenerated.name, {
         type: new GraphQLNonNull(aggregateType),
         args: aggregateGenerated.args,
         resolve: aggregateGenerated.resolver,
@@ -481,10 +482,10 @@ export const createSchemaBuilder = <WithReturning extends boolean>(adapter: Sche
           drizzle: drizzleMeta({ kind: 'aggregate', operation: 'aggregate', single: true, targetArg: 'where' }),
           ...(complexity ? { complexity: aggregateFieldComplexity(complexity) } : {}),
         },
-      };
+      });
     }
     if (groupByGenerated && groupByType) {
-      ctx.queries[groupByGenerated.name] = {
+      defineRootField(ctx.queries, 'query', groupByGenerated.name, {
         type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(groupByType))),
         args: groupByGenerated.args,
         resolve: groupByGenerated.resolver,
@@ -492,7 +493,7 @@ export const createSchemaBuilder = <WithReturning extends boolean>(adapter: Sche
           drizzle: drizzleMeta({ kind: 'aggregate', operation: 'groupBy', single: false, targetArg: 'where' }),
           ...(complexity ? { complexity: aggregateFieldComplexity(complexity) } : {}),
         },
-      };
+      });
     }
 
     return { aggregateType, groupByType, havingInput };

--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -128,6 +128,7 @@ export { createRelationResolverFactory } from './common/relation-resolvers.ts';
 export type { RelationAggregateFactory, RelationResolverFactory, TablesRelationalConfig } from './common/relations.ts';
 export { attachTargetPrimaryKeys, buildNamedRelations, extractRelationJoinColumns } from './common/relations.ts';
 export { computeResolverFieldNames, type ResolverFieldNames } from './common/resolver-names.ts';
+export { defineRootField } from './common/root-fields.ts';
 export { eagerLoadMutationRelations, runRelationalSelect } from './common/select-runtime.ts';
 export type { SelectionCtx } from './common/selected-columns.ts';
 export { extractSelectedColumnsFromTree, extractSelectedColumnsFromTreeSQLFormat } from './common/selected-columns.ts';

--- a/src/util/builders/common/resolver-names.ts
+++ b/src/util/builders/common/resolver-names.ts
@@ -42,34 +42,50 @@ export const computeResolverFieldNames = (
   const singleFieldName = mapped?.singular ?? uncapitalize(tableName) + suffixes.single;
   const aggregateFieldName = `${mapped?.plural ?? uncapitalize(tableName)}Aggregate`;
   const groupByFieldName = `${mapped?.plural ?? uncapitalize(tableName)}GroupBy`;
-  const createArrayFieldName = `${prefixes.insert}${mapped ? capitalize(mapped.plural) : capitalize(tableName)}`;
+  const pluralNoun = mapped ? capitalize(mapped.plural) : capitalize(tableName);
+  const singularNoun = mapped ? capitalize(mapped.singular) : capitalize(tableName);
+  // The write mutations take the same two suffixes the queries do, and in the same places:
+  // `list` on the form that operates on a set of rows, `single` on the one that operates on
+  // one. They used to take only `single`, so a build that renamed the list side got
+  // `usersAll` on the query and a bare `createUsers` next to it — and, worse, a
+  // `{ list: 'All', single: '' }` build silently lost the array insert, because both insert
+  // mutations resolved to `createUsers` and the second registration overwrote the first.
+  const createArrayFieldName = `${prefixes.insert}${pluralNoun}${suffixes.list}`;
   const createSingleFieldName = mapped
     ? `${prefixes.insert}${capitalize(mapped.singular)}`
     : `${prefixes.insert}${capitalize(tableName)}${suffixes.single}`;
   const upsertPrefix = prefixes.upsert ?? 'upsert';
-  const upsertArrayFieldName = `${upsertPrefix}${mapped ? capitalize(mapped.plural) : capitalize(tableName)}`;
+  const upsertArrayFieldName = `${upsertPrefix}${pluralNoun}${suffixes.list}`;
   const upsertSingleFieldName = mapped
     ? `${upsertPrefix}${capitalize(mapped.singular)}`
     : `${upsertPrefix}${capitalize(tableName)}${suffixes.single}`;
-  const updateFieldName = `${prefixes.update}${mapped ? capitalize(mapped.singular) : capitalize(tableName)}`;
+  // The plural update/delete/restore mutations take the singular noun — they filter rather
+  // than enumerate — so, unlike create, they cannot rely on singular vs plural to stay
+  // distinct from their Single variants. The suffixes are what separates them.
+  const updateBase = `${prefixes.update}${singularNoun}`;
+  const deleteBase = `${prefixes.delete}${singularNoun}`;
+  // The soft-delete counterpart, named the same way so `deleteUser` / `restoreUser` read as a
+  // pair however the delete prefix and the suffixes are configured.
+  const restoreBase = `${prefixes.restore ?? 'restore'}${singularNoun}`;
+  const updateFieldName = `${updateBase}${suffixes.list}`;
   // The batch variant is plural like the array insert/upsert, with an explicit `Many`
   // suffix so it never collides with the single-set update.
-  const updateManyFieldName = `${prefixes.update}${mapped ? capitalize(mapped.plural) : capitalize(tableName)}Many`;
-  const deleteFieldName = `${prefixes.delete}${mapped ? capitalize(mapped.singular) : capitalize(tableName)}`;
-  // The soft-delete counterpart, named the same way so `deleteUser` / `restoreUser` read as a
-  // pair however the delete prefix and the single suffix are configured.
-  const restoreFieldName = `${prefixes.restore ?? 'restore'}${mapped ? capitalize(mapped.singular) : capitalize(tableName)}`;
-  // The plural update/delete mutations already use the singular noun when a mapper is
-  // present, so — unlike create — the Single variants can't rely on singular vs plural to
-  // stay distinct. They always carry a suffix, falling back to 'Single' when the configured
-  // suffix is empty (a mapper config may set it to '' for the query side).
-  const writeSingleSuffix = suffixes.single === '' ? 'Single' : suffixes.single;
-  const updateSingleFieldName = `${updateFieldName}${writeSingleSuffix}`;
-  const deleteSingleFieldName = `${deleteFieldName}${writeSingleSuffix}`;
-  const restoreSingleFieldName = `${restoreFieldName}${writeSingleSuffix}`;
+  const updateManyFieldName = `${prefixes.update}${pluralNoun}Many`;
+  const deleteFieldName = `${deleteBase}${suffixes.list}`;
+  const restoreFieldName = `${restoreBase}${suffixes.list}`;
+  // An empty `single` suffix means "no suffix", the same as it does on the query side —
+  // except when it would name the Single variant exactly what the list variant above is
+  // called. That happens only when both suffixes are the same string, which `buildSchema`
+  // already rejects unless a `typeNameMapper` is present; the mapper's singular/plural pair
+  // rescues the queries but not these three, which are singular on both sides. There, and
+  // only there, the Single variants keep the 'Single' they have always had.
+  const writeSingleSuffix = suffixes.single === suffixes.list ? 'Single' : suffixes.single;
+  const updateSingleFieldName = `${updateBase}${writeSingleSuffix}`;
+  const deleteSingleFieldName = `${deleteBase}${writeSingleSuffix}`;
+  const restoreSingleFieldName = `${restoreBase}${writeSingleSuffix}`;
   // The count variants are the plural write under another name, so they take the plural
-  // noun rather than the singular one the plural mutations inherited from the mapper.
-  const pluralNoun = mapped ? capitalize(mapped.plural) : capitalize(tableName);
+  // noun rather than the singular one the plural mutations inherited from the mapper. Their
+  // explicit `Count` is the disambiguator, so they take no configured suffix.
   const updateCountFieldName = `${prefixes.update}${pluralNoun}Count`;
   const deleteCountFieldName = `${prefixes.delete}${pluralNoun}Count`;
   return {

--- a/src/util/builders/common/root-fields.ts
+++ b/src/util/builders/common/root-fields.ts
@@ -1,0 +1,33 @@
+// Registration of the generated root fields, with the collision check that the naming
+// config cannot do for itself.
+
+import type { GraphQLFieldConfig } from 'graphql';
+
+/**
+ * Registers one generated root field, refusing to overwrite a name already taken.
+ *
+ * A generated name is the table name run through `typeNameMapper`, a prefix and a suffix,
+ * and the pluralization each operation applies — so whether two operations collide is a
+ * property of the finished names, not of any one piece of the config. `buildSchema` checks
+ * what it can up front (identical list and single suffixes with no mapper), but that check
+ * compares the suffix *strings*, which cannot see a collision the rest of the naming rules
+ * produce: `{ list: 'All', single: '' }` used to give both insert mutations the name
+ * `createUsers`, and the array insert simply disappeared from the schema.
+ *
+ * Assigning into the record silently kept the last registration. Throwing here means a
+ * naming config that cannot work says so at build time, naming the field it lost.
+ */
+export const defineRootField = (
+  fields: Record<string, GraphQLFieldConfig<any, any>>,
+  kind: 'query' | 'mutation',
+  name: string,
+  config: GraphQLFieldConfig<any, any>,
+): void => {
+  if (Object.getOwnPropertyDescriptor(fields, name) !== undefined) {
+    throw new Error(
+      `Drizzle-GraphQL Error: two generated ${kind} fields are both named '${name}'. Generated names come from the table name plus config.prefixes, config.suffixes and config.typeNameMapper — some combination of those gives two operations the same name. Adjust one of them so each operation gets its own.`,
+    );
+  }
+
+  fields[name] = config;
+};

--- a/src/util/builders/mysql.ts
+++ b/src/util/builders/mysql.ts
@@ -14,6 +14,7 @@ import {
   applyContextValuesAll,
   assertSingleMatch,
   computeResolverFieldNames,
+  defineRootField,
   drizzleError,
   extractFilters,
   extractRequiredFilters,
@@ -757,33 +758,33 @@ export const generateSchemaData = <
     ];
     for (const [generated, meta] of generatedMutations) {
       if (generated) {
-        mutations[generated.name] = {
+        defineRootField(mutations, 'mutation', generated.name, {
           type: mutationReturnType,
           args: generated.args,
           resolve: generated.resolver,
           extensions: { drizzle: drizzleMeta({ kind: 'mutation', ...meta }) },
-        };
+        });
       }
     }
     // Apart from the loop above: the count mutations are the one pair whose return value is
     // not MySQL's shared `isSuccess` shape.
     if (updateCountGenerated) {
-      mutations[updateCountGenerated.name] = {
+      defineRootField(mutations, 'mutation', updateCountGenerated.name, {
         type: new GraphQLNonNull(GraphQLInt),
         args: updateCountGenerated.args,
         resolve: updateCountGenerated.resolver,
         description:
           'How many rows the update touched. The rows themselves are not read back, which is the point of this mutation.',
-      };
+      });
     }
     if (deleteCountGenerated) {
-      mutations[deleteCountGenerated.name] = {
+      defineRootField(mutations, 'mutation', deleteCountGenerated.name, {
         type: new GraphQLNonNull(GraphQLInt),
         args: deleteCountGenerated.args,
         resolve: deleteCountGenerated.resolver,
         description:
           'How many rows the delete removed. The rows themselves are not read back, which is the point of this mutation.',
-      };
+      });
     }
     // The insert/update inputs are still built (they type the mutations that survive) but
     // only reach the schema's type map when a mutation actually references them.

--- a/src/util/builders/schema-data.ts
+++ b/src/util/builders/schema-data.ts
@@ -16,6 +16,7 @@ import type { GraphQLInputObjectType } from 'graphql';
 import { GraphQLInt, GraphQLList, GraphQLNonNull } from 'graphql';
 import {
   computeResolverFieldNames,
+  defineRootField,
   generateOnConflictInput,
   generateUpdateManyInput,
   generateWriteCount,
@@ -419,17 +420,17 @@ export const createSchemaDataGenerator = (adapter: DialectSchemaAdapter) => {
             })
           : undefined;
       if (insertArrGenerated) {
-        mutations[insertArrGenerated.name] = {
+        defineRootField(mutations, 'mutation', insertArrGenerated.name, {
           type: arrTableItemOutput,
           args: insertArrGenerated.args,
           resolve: insertArrGenerated.resolver,
           extensions: {
             drizzle: drizzleMeta({ kind: 'mutation', operation: 'insert', single: false, targetArg: 'values' }),
           },
-        };
+        });
       }
       if (insertSingleGenerated) {
-        mutations[insertSingleGenerated.name] = {
+        defineRootField(mutations, 'mutation', insertSingleGenerated.name, {
           // An insert either returns the row it inserted or throws — the one path to `null` is
           // `conflictDoNothing` swallowing the insert, so the field is nullable only there.
           type: conflictDoNothing ? singleTableItemOutput : new GraphQLNonNull(singleTableItemOutput),
@@ -438,40 +439,40 @@ export const createSchemaDataGenerator = (adapter: DialectSchemaAdapter) => {
           extensions: {
             drizzle: drizzleMeta({ kind: 'mutation', operation: 'insert', single: true, targetArg: 'values' }),
           },
-        };
+        });
       }
       if (upsertArrGenerated) {
-        mutations[upsertArrGenerated.name] = {
+        defineRootField(mutations, 'mutation', upsertArrGenerated.name, {
           type: arrTableItemOutput,
           args: upsertArrGenerated.args,
           resolve: upsertArrGenerated.resolver,
           extensions: {
             drizzle: drizzleMeta({ kind: 'mutation', operation: 'upsert', single: false, targetArg: 'values' }),
           },
-        };
+        });
       }
       if (upsertSingleGenerated) {
-        mutations[upsertSingleGenerated.name] = {
+        defineRootField(mutations, 'mutation', upsertSingleGenerated.name, {
           type: singleTableItemOutput,
           args: upsertSingleGenerated.args,
           resolve: upsertSingleGenerated.resolver,
           extensions: {
             drizzle: drizzleMeta({ kind: 'mutation', operation: 'upsert', single: true, targetArg: 'values' }),
           },
-        };
+        });
       }
       if (updateGenerated) {
-        mutations[updateGenerated.name] = {
+        defineRootField(mutations, 'mutation', updateGenerated.name, {
           type: arrTableItemOutput,
           args: updateGenerated.args,
           resolve: updateGenerated.resolver,
           extensions: {
             drizzle: drizzleMeta({ kind: 'mutation', operation: 'update', single: false, targetArg: 'where' }),
           },
-        };
+        });
       }
       if (updateManyGenerated) {
-        mutations[updateManyGenerated.name] = {
+        defineRootField(mutations, 'mutation', updateManyGenerated.name, {
           type: new GraphQLNonNull(new GraphQLList(singleTableItemOutput)),
           args: updateManyGenerated.args,
           resolve: updateManyGenerated.resolver,
@@ -483,20 +484,20 @@ export const createSchemaDataGenerator = (adapter: DialectSchemaAdapter) => {
           // entry, so an entry that matched nothing has to be able to say so.
           description:
             "Each entry's updated rows, in entry order. An entry whose `where` matched no rows contributes `null` in its slot; an entry that matched several contributes each of its rows.",
-        };
+        });
       }
       if (updateSingleGenerated) {
-        mutations[updateSingleGenerated.name] = {
+        defineRootField(mutations, 'mutation', updateSingleGenerated.name, {
           type: singleTableItemOutput,
           args: updateSingleGenerated.args,
           resolve: updateSingleGenerated.resolver,
           extensions: {
             drizzle: drizzleMeta({ kind: 'mutation', operation: 'update', single: true, targetArg: 'where' }),
           },
-        };
+        });
       }
       if (deleteGenerated) {
-        mutations[deleteGenerated.name] = {
+        defineRootField(mutations, 'mutation', deleteGenerated.name, {
           type: arrTableItemOutput,
           args: deleteGenerated.args,
           resolve: deleteGenerated.resolver,
@@ -509,10 +510,10 @@ export const createSchemaDataGenerator = (adapter: DialectSchemaAdapter) => {
               ...(softDeleteInfo?.hardDelete ? { hardDelete: true } : {}),
             }),
           },
-        };
+        });
       }
       if (deleteSingleGenerated) {
-        mutations[deleteSingleGenerated.name] = {
+        defineRootField(mutations, 'mutation', deleteSingleGenerated.name, {
           type: singleTableItemOutput,
           args: deleteSingleGenerated.args,
           resolve: deleteSingleGenerated.resolver,
@@ -525,45 +526,45 @@ export const createSchemaDataGenerator = (adapter: DialectSchemaAdapter) => {
               ...(softDeleteInfo?.hardDelete ? { hardDelete: true } : {}),
             }),
           },
-        };
+        });
       }
       if (restoreGenerated) {
-        mutations[restoreGenerated.name] = {
+        defineRootField(mutations, 'mutation', restoreGenerated.name, {
           type: arrTableItemOutput,
           args: restoreGenerated.args,
           resolve: restoreGenerated.resolver,
           extensions: {
             drizzle: drizzleMeta({ kind: 'mutation', operation: 'restore', single: false, targetArg: 'where' }),
           },
-        };
+        });
       }
       if (restoreSingleGenerated) {
-        mutations[restoreSingleGenerated.name] = {
+        defineRootField(mutations, 'mutation', restoreSingleGenerated.name, {
           type: singleTableItemOutput,
           args: restoreSingleGenerated.args,
           resolve: restoreSingleGenerated.resolver,
           extensions: {
             drizzle: drizzleMeta({ kind: 'mutation', operation: 'restore', single: true, targetArg: 'where' }),
           },
-        };
+        });
       }
       if (updateCountGenerated) {
-        mutations[updateCountGenerated.name] = {
+        defineRootField(mutations, 'mutation', updateCountGenerated.name, {
           type: new GraphQLNonNull(GraphQLInt),
           args: updateCountGenerated.args,
           resolve: updateCountGenerated.resolver,
           description:
             'How many rows the update touched. The rows themselves are not read back, which is the point of this mutation.',
-        };
+        });
       }
       if (deleteCountGenerated) {
-        mutations[deleteCountGenerated.name] = {
+        defineRootField(mutations, 'mutation', deleteCountGenerated.name, {
           type: new GraphQLNonNull(GraphQLInt),
           args: deleteCountGenerated.args,
           resolve: deleteCountGenerated.resolver,
           description:
             'How many rows the delete removed. The rows themselves are not read back, which is the point of this mutation.',
-        };
+        });
       }
       // The insert/update inputs are still built (they type the mutations that survive) but
       // only reach the schema's type map when a mutation actually references them.

--- a/tests/pglite/suffixes.test.ts
+++ b/tests/pglite/suffixes.test.ts
@@ -1,0 +1,128 @@
+// `suffixes` renames the operations that come in list/single pairs. It used to reach the
+// queries only: a build that renamed the list side got `usersAll` next to a bare
+// `createUsers`, `{ single: '' }` was honoured by the queries and the insert but ignored by
+// update and delete, and the two together gave both insert mutations the name `createUsers`,
+// which silently dropped the array insert from the schema (#155).
+//
+// buildSchema only reads drizzle metadata, so these never touch the database.
+
+import { PGlite } from '@electric-sql/pglite';
+import { drizzle, type PgliteDatabase } from 'drizzle-orm/pglite';
+import type { GraphQLSchema } from 'graphql';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { type BuildSchemaConfig, buildSchema, type DrizzleFieldExtension, drizzleExtension } from '@/index';
+import * as schema from '../schema/pg';
+
+let pglite: PGlite;
+let db: PgliteDatabase<typeof schema.relations>;
+
+const build = (config: BuildSchemaConfig<any>): GraphQLSchema => buildSchema(db, config).schema;
+
+/** The generated mutations for one table, as `name → { operation, single }`. */
+const mutationsFor = (gqlSchema: GraphQLSchema, table: string): Record<string, string> => {
+  const found: Record<string, string> = {};
+  for (const [name, field] of Object.entries(gqlSchema.getMutationType()!.getFields())) {
+    const meta = drizzleExtension(field) as DrizzleFieldExtension | undefined;
+    if (meta?.table === table) {
+      found[name] = `${meta.operation}/${meta.single ? 'single' : 'list'}`;
+    }
+  }
+  return found;
+};
+
+beforeAll(async () => {
+  pglite = new PGlite();
+  await pglite.waitReady;
+  db = drizzle({ client: pglite, relations: schema.relations });
+});
+
+afterAll(async () => {
+  await pglite.close().catch(console.error);
+});
+
+describe('suffixes reach the mutations too', () => {
+  it('applies the list suffix to the list mutations and the single suffix to the single ones', () => {
+    const mutations = mutationsFor(build({ suffixes: { list: 'All', single: 'One' } }), 'Users');
+
+    expect(mutations['createUsersAll']).toBe('insert/list');
+    expect(mutations['createUsersOne']).toBe('insert/single');
+    expect(mutations['updateUsersAll']).toBe('update/list');
+    expect(mutations['updateUsersOne']).toBe('update/single');
+    expect(mutations['deleteUsersAll']).toBe('delete/list');
+    expect(mutations['deleteUsersOne']).toBe('delete/single');
+  });
+
+  it('honours an empty single suffix in update and delete, as the queries already did', () => {
+    const gqlSchema = build({ suffixes: { list: 'All', single: '' } });
+    const mutations = mutationsFor(gqlSchema, 'Users');
+
+    expect(mutations['updateUsers']).toBe('update/single');
+    expect(mutations['deleteUsers']).toBe('delete/single');
+    expect(mutations['updateUsersAll']).toBe('update/list');
+    expect(mutations['updateUsersSingle']).toBeUndefined();
+    expect(mutations['deleteUsersSingle']).toBeUndefined();
+
+    // The queries, unchanged, are what the mutations now agree with.
+    const queries = Object.keys(gqlSchema.getQueryType()!.getFields());
+    expect(queries).toContain('usersAll');
+    expect(queries).toContain('users');
+  });
+
+  it('keeps the array insert that used to be overwritten by the single one', () => {
+    const mutations = mutationsFor(build({ suffixes: { list: 'All', single: '' } }), 'Users');
+
+    expect(mutations['createUsersAll']).toBe('insert/list');
+    expect(mutations['createUsers']).toBe('insert/single');
+  });
+
+  it('leaves the default naming alone', () => {
+    const mutations = mutationsFor(build({}), 'Users');
+
+    expect(mutations['createUsers']).toBe('insert/list');
+    expect(mutations['createUsersSingle']).toBe('insert/single');
+    expect(mutations['updateUsers']).toBe('update/list');
+    expect(mutations['updateUsersSingle']).toBe('update/single');
+    expect(mutations['deleteUsers']).toBe('delete/list');
+    expect(mutations['deleteUsersSingle']).toBe('delete/single');
+  });
+
+  it('keeps the Single fallback where the suffixes cannot separate the pair', () => {
+    // A mapper's singular/plural forms separate the queries, so both suffixes may be empty
+    // there — but update/delete are singular on both sides, so they still need the fallback.
+    const mutations = mutationsFor(
+      build({
+        typeNameMapper: 'singularize',
+        suffixes: { list: '', single: '' },
+      }),
+      'Users',
+    );
+
+    expect(mutations['updateUser']).toBe('update/list');
+    expect(mutations['updateUserSingle']).toBe('update/single');
+    expect(mutations['createUsers']).toBe('insert/list');
+    expect(mutations['createUser']).toBe('insert/single');
+  });
+});
+
+describe('colliding generated names', () => {
+  it('rejects identical suffixes before it generates anything', () => {
+    expect(() => build({ suffixes: { list: 'X', single: 'X' } })).toThrow(
+      /List and single query suffixes cannot be the same/,
+    );
+  });
+
+  it('names the field when two operations collide on something the suffix check cannot see', () => {
+    // Two prefixes that agree put the bulk update and the bulk delete on one name, which no
+    // amount of comparing suffix strings can notice.
+    expect(() => build({ prefixes: { update: 'delete' } })).toThrow(
+      /two generated mutation fields are both named 'deleteUsers'/,
+    );
+  });
+
+  it('catches a mapper that gives two tables the same name', () => {
+    // Every table answers to `users`, so the first pair of list queries already collides.
+    expect(() => build({ typeNameMapper: () => ({ singular: 'user', plural: 'users' }) })).toThrow(
+      /two generated query fields are both named 'users'/,
+    );
+  });
+});

--- a/tests/pglite/suffixes.test.ts
+++ b/tests/pglite/suffixes.test.ts
@@ -16,7 +16,7 @@ import * as schema from '../schema/pg';
 let pglite: PGlite;
 let db: PgliteDatabase<typeof schema.relations>;
 
-const build = (config: BuildSchemaConfig<any>): GraphQLSchema => buildSchema(db, config).schema;
+const build = (config: BuildSchemaConfig): GraphQLSchema => buildSchema(db, config).schema;
 
 /** The generated mutations for one table, as `name → { operation, single }`. */
 const mutationsFor = (gqlSchema: GraphQLSchema, table: string): Record<string, string> => {


### PR DESCRIPTION
Closes #155.

`suffixes` renames the operations that come in list/single pairs. On the query side it did; on the mutation side it was applied inconsistently, and one combination silently dropped a mutation from the schema.

## What was wrong

1. **List mutations ignored `list`.** `{ list: 'All' }` gave `usersAll` on the query side and a bare `createUsers` next to it.
2. **`single: ''` was ignored by update/delete/restore.** They fell back to `Single`, while the queries and the insert honoured the empty string.
3. **The collision guard compares suffix *strings*.** `{ list: 'All', single: '' }` put both insert mutations on `createUsers` — `'All' !== ''`, so nothing fired, the later registration won, and the array insert left the schema with no error.

## What this changes

- Both suffixes now reach every list/single pair: insert, upsert, update, delete, restore. The variants with their own disambiguator (`Aggregate`, `GroupBy`, `Many`, `Count`) take neither.
- The `'' → Single` fallback for the bulk update/delete/restore singles survives only where the two suffixes are the same string. Without a mapper `buildSchema` already rejects that; with one, the mapper's plural/singular nouns separate the queries and the inserts but not these three, which are singular on both sides — so they keep the `Single` they have always had.
- Every generated root field is registered through `defineRootField`, which throws naming the field rather than letting one operation overwrite another. That covers collisions the suffix check cannot see, including ones produced by `prefixes` or a `typeNameMapper`.

The suffix-equality check stays where it was: it is the earlier, more specific error for the case it does catch.

## Compatibility

Default naming is unchanged (`list: ''`, `single: 'Single'`), and so is every mapper-plus-empty-suffixes build in the test suite. Builds that set a non-default `list` suffix, or `single: ''` next to a different `list`, get renamed mutations — hence `fix!` and the `BREAKING CHANGE` footer.

## Testing

`tests/pglite/suffixes.test.ts` covers each defect from the issue plus the two collision paths, identifying fields through `extensions.drizzle` rather than by name. Full PGlite + SQLite suites pass locally (1128 tests); Docker legs run in CI.