### PR TITLE
perf: hand out the narrowed relation filter context instead of rebuilding it

### DIFF
--- a/src/util/builders/common/relation-filters.ts
+++ b/src/util/builders/common/relation-filters.ts
@@ -54,11 +54,50 @@ export interface RelationFilterContext {
  */
 export type RelationFilterBase = Pick<RelationFilterContext, 'tables' | 'relationMap' | 'uniqueKeys'>;
 
-/** Narrows the build-scoped relation filter context to the table a resolver is filtering. */
+/**
+ * The narrowed contexts already handed out, keyed by the build-scoped base and then by
+ * table. The base is created once per `buildSchema` and the result depends on nothing else,
+ * so every call for one table produces the same value — a `WeakMap` on the base keeps them
+ * for exactly as long as that build is reachable.
+ */
+const narrowedCtxCache = new WeakMap<RelationFilterBase, Map<string, RelationFilterContext>>();
+
+/**
+ * Narrows the build-scoped relation filter context to the table a resolver is filtering.
+ *
+ * Cached rather than rebuilt: the base carries the build's whole `tables` and `relationMap`,
+ * and the spread copied both on every call — three per parent row in the lazy relation
+ * resolver, one per parent row in the relation aggregate, and up to four per select, several
+ * of them inside callbacks drizzle invokes lazily.
+ *
+ * The one field written after the fact is `aliases`, the counter that keeps subquery aliases
+ * apart ({@link extractRelationFilter}). Sharing it is what makes the caching safe rather
+ * than a hazard: the counter now spans the process instead of restarting per extraction, and
+ * aliases only ever have to be unique *within* one statement, which a number that never
+ * repeats gives more surely than one that restarts.
+ */
 export const relationFilterCtx = (
   base: RelationFilterBase | undefined,
   tableKey: string,
-): RelationFilterContext | undefined => (base ? { ...base, tableKey } : undefined);
+): RelationFilterContext | undefined => {
+  if (!base) {
+    return undefined;
+  }
+
+  let byTable = narrowedCtxCache.get(base);
+  if (!byTable) {
+    byTable = new Map();
+    narrowedCtxCache.set(base, byTable);
+  }
+
+  let ctx = byTable.get(tableKey);
+  if (!ctx) {
+    ctx = { ...base, tableKey };
+    byTable.set(tableKey, ctx);
+  }
+
+  return ctx;
+};
 
 /** The three ways a to-many relation can be required to match, plus the to-one shorthand. */
 type RelationMatchMode = 'some' | 'none' | 'every';

--- a/tests/relation-filter-ctx.test.ts
+++ b/tests/relation-filter-ctx.test.ts
@@ -1,0 +1,36 @@
+// `relationFilterCtx` is called several times per parent row on the lazy relation path, and
+// the object it returns carries the build's whole table and relation maps. These pin that it
+// is handed out rather than rebuilt, and that two builds never share one.
+
+import { integer, pgTable, text } from 'drizzle-orm/pg-core';
+import { describe, expect, it } from 'vitest';
+import { type RelationFilterBase, relationFilterCtx } from '@/util/builders/common';
+
+const Users = pgTable('users', { id: integer('id').primaryKey(), name: text('name') });
+
+const baseFor = (): RelationFilterBase => ({ tables: { Users }, relationMap: {}, uniqueKeys: {} });
+
+describe('relationFilterCtx', () => {
+  it('returns the same context for the same base and table', () => {
+    const base = baseFor();
+
+    expect(relationFilterCtx(base, 'Users')).toBe(relationFilterCtx(base, 'Users'));
+  });
+
+  it('narrows to the table it was asked for', () => {
+    const base = baseFor();
+    const users = relationFilterCtx(base, 'Users');
+
+    expect(users?.tableKey).toBe('Users');
+    expect(users?.tables).toBe(base.tables);
+    expect(relationFilterCtx(base, 'Posts')).not.toBe(users);
+  });
+
+  it('keeps separate builds apart', () => {
+    expect(relationFilterCtx(baseFor(), 'Users')).not.toBe(relationFilterCtx(baseFor(), 'Users'));
+  });
+
+  it('has nothing to narrow without a base', () => {
+    expect(relationFilterCtx(undefined, 'Users')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #148.

`relationFilterCtx` spread the build-scoped base on every call, and that base carries the build's whole `tables`, `relationMap` and `uniqueKeys`. Of the 22 call sites, nearly all are on the request path — three per parent row in the lazy relation resolver, one per parent row in the relation aggregate, two per relation inside the `where`/`orderBy` callbacks drizzle invokes lazily, and up to four per select. Every one produced an identical object.

It now memoizes on the base (a `WeakMap`, so a build's contexts are collected with the build) and then on the table key, as the issue sketched.

## The two things the issue asked to confirm

- **Nothing mutates the returned context** except `ctx.aliases ??= { n: 0 }` in `extractRelationFilter` and `orderBy`'s relation path. Sharing that counter is what makes the caching safe rather than a hazard: aliases only have to be unique *within* one statement, and a counter that never repeats gives that more surely than one restarting at zero per extraction. No test or code path reads the alias numbering.
- **`base` is per-build** — `filterCtx` is assembled once in `prepareBuild` and handed to every resolver.

## Testing

`tests/relation-filter-ctx.test.ts` pins identity across calls, separation between tables and between builds, and the `undefined` base. PGlite + SQLite suites pass locally (1090 tests).