### PR TITLE
perf: compute a relation field's loader key once per request

### DIFF
--- a/src/util/batch-loader/index.ts
+++ b/src/util/batch-loader/index.ts
@@ -1,4 +1,5 @@
 const DRIZZLE_LOADERS_KEY = Symbol('drizzle-graphql-loaders');
+const DRIZZLE_REQUEST_CACHE_KEY = Symbol('drizzle-graphql-request-cache');
 
 type BatchFn<K, V> = (keys: readonly K[]) => Promise<readonly V[]>;
 
@@ -51,4 +52,42 @@ export const getOrCreateLoader = <K, V>(context: any, key: string, batchFn: Batc
     loaders.set(key, new BatchLoader<K, V>(batchFn));
   }
   return loaders.get(key) as BatchLoader<K, V>;
+};
+
+/**
+ * Memoizes a value that a resolver derives from its own field — its args and its selection —
+ * for the length of one request. Resolvers run once per parent row, so anything derived only
+ * from the field is otherwise recomputed for every row of a batch.
+ *
+ * The cache lives on the context (weakly keyed by the AST node the value is derived from, so a
+ * document cached across requests never carries values between them) and `key` separates fields
+ * that share a node: one fragment selection can resolve for more than one parent type. Without a
+ * context object there is nowhere request-scoped to cache, so the value is simply computed.
+ *
+ * `compute` must not read the parent row.
+ */
+export const getOrCreateRequestValue = <T>(
+  context: any,
+  node: object | undefined,
+  key: string,
+  compute: () => T,
+): T => {
+  if (!context || typeof context !== 'object' || !node || typeof node !== 'object') {
+    return compute();
+  }
+  if (!context[DRIZZLE_REQUEST_CACHE_KEY]) {
+    context[DRIZZLE_REQUEST_CACHE_KEY] = new WeakMap<object, Map<string, unknown>>();
+  }
+  const cache = context[DRIZZLE_REQUEST_CACHE_KEY] as WeakMap<object, Map<string, unknown>>;
+  let entries = cache.get(node);
+  if (!entries) {
+    entries = new Map<string, unknown>();
+    cache.set(node, entries);
+  }
+  if (entries.has(key)) {
+    return entries.get(key) as T;
+  }
+  const value = compute();
+  entries.set(key, value);
+  return value;
 };

--- a/src/util/builders/common/relation-resolvers.ts
+++ b/src/util/builders/common/relation-resolvers.ts
@@ -4,7 +4,7 @@
 
 import type { Column, Table } from 'drizzle-orm';
 import { and, getColumns, gt, inArray, lte, type SQL, sql } from 'drizzle-orm';
-import { getOrCreateLoader } from '../../batch-loader/index.ts';
+import { getOrCreateLoader, getOrCreateRequestValue } from '../../batch-loader/index.ts';
 import { remapToGraphQLArrayOutput } from '../../data-mappers/index.ts';
 import { relationFieldExtension } from '../../extensions.ts';
 import type { TableNamedRelations } from '../types.ts';
@@ -160,63 +160,83 @@ export const createRelationResolverFactory =
       }
 
       const { where: whereArg, limit: requestedLimit, offset, after, deleted } = (args ?? {}) as any;
-      // A relation field falls back to the *target* table's default ordering, since that is
-      // the table it reads. A to-one relation is a single row and takes no ordering at all.
-      const orderByArg = isOne
-        ? (args as any)?.orderBy
-        : withDefaultOrderBy(args ?? {}, targetTableName, policies?.defaultOrderBy).orderBy;
-      const limit = applyLimitPolicy(requestedLimit, limitPolicy, errorCtx);
-      const distinct = ((args ?? {}) as any).distinct?.length ? ((args ?? {}) as any).distinct : undefined;
 
-      // ── keyset (cursor) pagination ──
-      // The same rules the root list follows, over the related rows of one parent: the cursor
-      // is defined over the request's orderBy plus the target's primary-key tiebreak, and the
-      // keyset predicate is a plain condition on the target's own columns — so it filters each
-      // parent's rows independently even though the batch fetches them all at once.
-      const cursorSelected = !isOne && !!info && selectsCursorField(info, targetTable);
-      let cursorEntries: CursorOrderEntry[] | undefined;
-      if (!isOne && (after != null || cursorSelected)) {
-        if (after != null && distinct) {
-          throw drizzleError("'after' cannot be combined with 'distinct'.", { code: 'DRIZZLE_INVALID_CURSOR' });
-        }
-        if (orderByHasRelationEntry(orderByArg)) {
-          if (after != null) {
-            throw drizzleError(
-              "'after' cannot be combined with an orderBy that orders through a relation — a related row's value cannot be encoded into a cursor.",
-              { code: 'DRIZZLE_INVALID_CURSOR' },
-            );
-          }
-          // `cursor` was selected under a relation ordering — the field resolves to null.
-        } else if (!targetPkNames.length) {
-          if (after != null) {
-            throw drizzleError(
-              `Table ${targetTableName} has no primary key, so cursor pagination cannot be used on it.`,
-              { code: 'DRIZZLE_INVALID_CURSOR' },
-            );
-          }
-          // `cursor` was selected but no total order exists — the field resolves to null.
-        } else {
-          cursorEntries = cursorOrderingEntries(orderByArg, targetPkNames);
-        }
-      }
-      const cursorValues = after != null && cursorEntries ? decodeCursor(after, cursorEntries) : undefined;
+      // Everything below is derived from this field alone — its args and its selection — so it is
+      // identical for every parent row the batch fetches. Resolvers run once per parent row, so it
+      // is computed once per field per request and reused, rather than re-reading the selection and
+      // re-stringifying the loader key N times.
+      const { orderByArg, limit, distinct, cursorEntries, cursorValues, loaderKey } = getOrCreateRequestValue(
+        context,
+        info?.fieldNodes?.[0],
+        `relation:${tableName}::${relationName}`,
+        () => {
+          // A relation field falls back to the *target* table's default ordering, since that is
+          // the table it reads. A to-one relation is a single row and takes no ordering at all.
+          const orderByArg = isOne
+            ? (args as any)?.orderBy
+            : withDefaultOrderBy(args ?? {}, targetTableName, policies?.defaultOrderBy).orderBy;
+          const limit = applyLimitPolicy(requestedLimit, limitPolicy, errorCtx);
+          const distinct = ((args ?? {}) as any).distinct?.length ? ((args ?? {}) as any).distinct : undefined;
 
-      // Batch path: collect all sibling calls in this tick and execute one query.
-      // Pagination args are part of the loader key so siblings sharing identical
-      // args batch together; per-parent limit/offset is applied inside the batch
-      // via a window function rather than bailing to a per-parent query (N+1).
-      // `cursorEntries` joins the key because it changes the ordering, not just the filter.
-      const argsKey = JSON.stringify({
-        where: whereArg ?? null,
-        orderBy: orderByArg ?? null,
-        limit: limit ?? null,
-        offset: offset ?? null,
-        deleted: deleted ?? defaultDeleted ?? null,
-        after: after ?? null,
-        distinct: distinct ?? null,
-        cursor: cursorEntries ? 1 : 0,
-      });
-      const loaderKey = `${tableName}::${relationName}::${argsKey}`;
+          // ── keyset (cursor) pagination ──
+          // The same rules the root list follows, over the related rows of one parent: the cursor
+          // is defined over the request's orderBy plus the target's primary-key tiebreak, and the
+          // keyset predicate is a plain condition on the target's own columns — so it filters each
+          // parent's rows independently even though the batch fetches them all at once.
+          const cursorSelected = !isOne && !!info && selectsCursorField(info, targetTable);
+          let cursorEntries: CursorOrderEntry[] | undefined;
+          if (!isOne && (after != null || cursorSelected)) {
+            if (after != null && distinct) {
+              throw drizzleError("'after' cannot be combined with 'distinct'.", { code: 'DRIZZLE_INVALID_CURSOR' });
+            }
+            if (orderByHasRelationEntry(orderByArg)) {
+              if (after != null) {
+                throw drizzleError(
+                  "'after' cannot be combined with an orderBy that orders through a relation — a related row's value cannot be encoded into a cursor.",
+                  { code: 'DRIZZLE_INVALID_CURSOR' },
+                );
+              }
+              // `cursor` was selected under a relation ordering — the field resolves to null.
+            } else if (!targetPkNames.length) {
+              if (after != null) {
+                throw drizzleError(
+                  `Table ${targetTableName} has no primary key, so cursor pagination cannot be used on it.`,
+                  { code: 'DRIZZLE_INVALID_CURSOR' },
+                );
+              }
+              // `cursor` was selected but no total order exists — the field resolves to null.
+            } else {
+              cursorEntries = cursorOrderingEntries(orderByArg, targetPkNames);
+            }
+          }
+          const cursorValues = after != null && cursorEntries ? decodeCursor(after, cursorEntries) : undefined;
+
+          // Batch path: collect all sibling calls in this tick and execute one query.
+          // Pagination args are part of the loader key so siblings sharing identical
+          // args batch together; per-parent limit/offset is applied inside the batch
+          // via a window function rather than bailing to a per-parent query (N+1).
+          // `cursorEntries` joins the key because it changes the ordering, not just the filter.
+          const argsKey = JSON.stringify({
+            where: whereArg ?? null,
+            orderBy: orderByArg ?? null,
+            limit: limit ?? null,
+            offset: offset ?? null,
+            deleted: deleted ?? defaultDeleted ?? null,
+            after: after ?? null,
+            distinct: distinct ?? null,
+            cursor: cursorEntries ? 1 : 0,
+          });
+
+          return {
+            orderByArg,
+            limit,
+            distinct,
+            cursorEntries,
+            cursorValues,
+            loaderKey: `${tableName}::${relationName}::${argsKey}`,
+          };
+        },
+      );
 
       const loader = getOrCreateLoader(context, loaderKey, async (parentIds: readonly any[]) => {
         // Loaders are cached per context, so every call batched here shares this request's

--- a/tests/request-value-cache.test.ts
+++ b/tests/request-value-cache.test.ts
@@ -1,0 +1,96 @@
+// A relation resolver runs once per parent row, so the plan it derives from its own field — the
+// loader key included — would otherwise be rebuilt for every row of a batch. These pin that the
+// cache hands the first value back, that it separates fields, nodes and requests, and that it
+// stays correct when there is no context to cache on.
+
+import { describe, expect, it } from 'vitest';
+import { getOrCreateRequestValue } from '@/util/batch-loader/index.ts';
+
+const node = () => ({ kind: 'Field' as const });
+
+describe('getOrCreateRequestValue', () => {
+  it('computes once per node and key', () => {
+    const context: any = {};
+    const field = node();
+    let calls = 0;
+    const compute = () => {
+      calls += 1;
+      return { calls };
+    };
+
+    const first = getOrCreateRequestValue(context, field, 'relation:Users::posts', compute);
+
+    expect(getOrCreateRequestValue(context, field, 'relation:Users::posts', compute)).toBe(first);
+    expect(calls).toBe(1);
+  });
+
+  it('caches a falsy value rather than recomputing it', () => {
+    const context: any = {};
+    const field = node();
+    let calls = 0;
+    const compute = () => {
+      calls += 1;
+      return undefined;
+    };
+
+    getOrCreateRequestValue(context, field, 'k', compute);
+    getOrCreateRequestValue(context, field, 'k', compute);
+
+    expect(calls).toBe(1);
+  });
+
+  it('keeps separate keys on one node apart', () => {
+    const context: any = {};
+    const field = node();
+
+    const posts = getOrCreateRequestValue(context, field, 'relation:Users::posts', () => ({ of: 'posts' }));
+    const comments = getOrCreateRequestValue(context, field, 'relation:Users::comments', () => ({ of: 'comments' }));
+
+    expect(comments).not.toBe(posts);
+    expect(comments.of).toBe('comments');
+  });
+
+  it('keeps separate nodes apart', () => {
+    const context: any = {};
+
+    const first = getOrCreateRequestValue(context, node(), 'k', () => ({}));
+    const second = getOrCreateRequestValue(context, node(), 'k', () => ({}));
+
+    expect(second).not.toBe(first);
+  });
+
+  it('never carries a value between requests sharing a parsed document', () => {
+    const field = node();
+
+    const first = getOrCreateRequestValue({} as any, field, 'k', () => ({}));
+    const second = getOrCreateRequestValue({} as any, field, 'k', () => ({}));
+
+    expect(second).not.toBe(first);
+  });
+
+  it('computes every time when there is nothing request-scoped to cache on', () => {
+    const field = node();
+    let calls = 0;
+    const compute = () => {
+      calls += 1;
+      return calls;
+    };
+
+    expect(getOrCreateRequestValue(undefined, field, 'k', compute)).toBe(1);
+    expect(getOrCreateRequestValue({} as any, undefined, 'k', compute)).toBe(2);
+  });
+
+  it('does not cache a throw', () => {
+    const context: any = {};
+    const field = node();
+    let calls = 0;
+    const compute = () => {
+      calls += 1;
+      throw new Error('nope');
+    };
+
+    expect(() => getOrCreateRequestValue(context, field, 'k', compute)).toThrow('nope');
+    expect(() => getOrCreateRequestValue(context, field, 'k', compute)).toThrow('nope');
+    expect(calls).toBe(2);
+  });
+});


### PR DESCRIPTION
Closes #132.

A relation resolver runs once per parent row. Everything it derived from its own field — the `withDefaultOrderBy` fallback, the limit policy, the cursor entries and the `JSON.stringify`'d loader key — was rebuilt on every one of those calls, even though a field's args and selection are the same for every row of a batch.

- `getOrCreateRequestValue` (new, next to `getOrCreateLoader` in `src/util/batch-loader/index.ts`) memoizes a per-field value on the GraphQL context, weakly keyed by the AST node it is derived from and separated by a caller-supplied key, so a document cached across requests never carries a value between them and one fragment node can serve more than one parent type. No context object means nothing request-scoped to cache on, so the value is simply computed — the previous behaviour.
- `createRelationResolverFactory` now derives its plan (`orderByArg`, `limit`, `distinct`, `cursorEntries`, `cursorValues`, `loaderKey`) inside that memo. The cursor validation errors and the `deleted ?? defaultDeleted` term stay inside it, and a throw is not cached.

`tests/request-value-cache.test.ts` covers reuse per node+key, falsy values, separation across keys/nodes/requests, the no-context fallback, and that throws are not cached. Lint, both typechecks and the PGlite + SQLite suites (1108 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8CNohGit8bcDzuTau1G2W