### PR TITLE
perf: parse a relation aggregate's selection once per request

### DIFF
--- a/src/util/builders/aggregates.ts
+++ b/src/util/builders/aggregates.ts
@@ -27,7 +27,7 @@ import {
   GraphQLNonNull,
   GraphQLObjectType,
 } from 'graphql';
-import { getOrCreateLoader } from '../batch-loader/index.ts';
+import { getOrCreateLoader, getOrCreateRequestValue } from '../batch-loader/index.ts';
 import { capitalize } from '../case-ops/index.ts';
 import { remapToGraphQLCore } from '../data-mappers/index.ts';
 import type { ResolveTree } from '../parse-resolve-info.ts';
@@ -531,7 +531,24 @@ export const createRelationAggregateFactory = (
       info: any,
     ) => {
       try {
-        const request = parseAggregateRequest(info, target);
+        // This resolver runs once per parent row, and the resolve-info walk and the loader key
+        // depend on the field alone, not on the row — so they are derived once per field per
+        // request and reused by every sibling the batch serves.
+        const { request, loaderKey } = getOrCreateRequestValue(
+          context,
+          info?.fieldNodes?.[0],
+          `aggregate:${tableName}::${relationName}`,
+          () => {
+            const request = parseAggregateRequest(info, target);
+            // Siblings only share a batch when they'd run the same query: same filters, same aggregates.
+            const argsKey = JSON.stringify({
+              where: args?.where ?? null,
+              deleted: args?.deleted ?? defaultDeleted ?? null,
+              selection: Object.keys(request.selection).sort(),
+            });
+            return { request, loaderKey: `${tableName}::${relationName}::aggregate::${argsKey}` };
+          },
+        );
         if (!Object.keys(request.selection).length) {
           return {};
         }
@@ -544,13 +561,6 @@ export const createRelationAggregateFactory = (
 
         const whereArg = args?.where;
         const deleted = args?.deleted;
-        // Siblings only share a batch when they'd run the same query: same filters, same aggregates.
-        const argsKey = JSON.stringify({
-          where: whereArg ?? null,
-          deleted: deleted ?? defaultDeleted ?? null,
-          selection: Object.keys(request.selection).sort(),
-        });
-        const loaderKey = `${tableName}::${relationName}::aggregate::${argsKey}`;
 
         const loader = getOrCreateLoader(context, loaderKey, async (parentIds: readonly any[]) => {
           // Loaders are cached per context, so the whole batch shares this request's executor.

--- a/tests/pglite/relation-aggregate.test.ts
+++ b/tests/pglite/relation-aggregate.test.ts
@@ -199,6 +199,38 @@ describe.sequential('relation aggregates', () => {
     expect(result.data?.deleteUser).toEqual([{ id: 5, postsAggregate: { count: 2 } }]);
   });
 
+  // The parsed selection and the batch key are derived once per field per request, so two
+  // aliases of the same relation aggregate must stay apart: they are separate fields, with
+  // separate args and separate selections, even though they name one relation.
+  it('keeps aliases of the same aggregate apart when their filters differ', async () => {
+    const result = await ctx.gql.queryGql(`{
+      users(orderBy: { id: { direction: asc, priority: 1 } }) {
+        id
+        all: postsAggregate { count }
+        early: postsAggregate(where: { id: { lt: 4 } }) { count }
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([
+      { id: 1, all: { count: 4 }, early: { count: 3 } },
+      { id: 2, all: { count: 0 }, early: { count: 0 } },
+      { id: 5, all: { count: 2 }, early: { count: 0 } },
+    ]);
+  });
+
+  it('keeps aliases of the same aggregate apart when their selections differ', async () => {
+    const result = await ctx.gql.queryGql(`{
+      users(where: { id: { eq: 1 } }) {
+        counted: postsAggregate { count }
+        summed: postsAggregate { sum { id } }
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.users).toEqual([{ counted: { count: 4 }, summed: { sum: { id: 12 } } }]);
+  });
+
   describe('schema shape', () => {
     const type = (name: string) => (ctx.entities.types as unknown as Record<string, GraphQLObjectType>)[name]!;
 


### PR DESCRIPTION
Closes #144.

`createRelationAggregateFactory`'s resolver runs once per parent row, so a list of N parents did N `parseResolveInfo({ deep: true })` walks, N `Object.keys(...).sort()` allocations and N `JSON.stringify` calls, all producing the same string — the batch key exists precisely because those inputs are identical across siblings.

Both are now derived inside `getOrCreateRequestValue` (the per-field, per-request memo added for #132 in #160), keyed by the field's AST node and `aggregate:${tableName}::${relationName}`. The parsed `request` is cached alongside the key, so the `if (!Object.keys(request.selection).length) return {}` early return still runs per call, and `request` is never mutated after `parseAggregateRequest` returns it.

Two tests in `tests/pglite/relation-aggregate.test.ts` pin that aliases of one relation aggregate stay apart — separate AST nodes, so separate memo entries — when their filters differ and when their selections differ.

Lint, both typechecks and the PGlite + SQLite suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8CNohGit8bcDzuTau1G2W