### PR TITLE
perf: read only the columns a lazy relation selection needs

### DIFF
--- a/src/util/builders/common/relation-resolvers.ts
+++ b/src/util/builders/common/relation-resolvers.ts
@@ -7,6 +7,8 @@ import { and, getColumns, gt, inArray, lte, type SQL, sql } from 'drizzle-orm';
 import { getOrCreateLoader, getOrCreateRequestValue } from '../../batch-loader/index.ts';
 import { remapToGraphQLArrayOutput } from '../../data-mappers/index.ts';
 import { relationFieldExtension } from '../../extensions.ts';
+import type { ResolveTree } from '../../parse-resolve-info.ts';
+import { parseResolveInfo } from '../../parse-resolve-info.ts';
 import type { TableNamedRelations } from '../types.ts';
 import type { CursorOrderEntry, NullOrdering } from './cursor.ts';
 import {
@@ -31,6 +33,7 @@ import type { RelationFilterBase, RelationFilterContext } from './relation-filte
 import { extractFilters, relationFilterCtx } from './relation-filters.ts';
 import type { RelationResolverFactory } from './relations.ts';
 import { extractRelationJoinColumns } from './relations.ts';
+import { extractSelectedColumnsFromTreeSQLFormat } from './selected-columns.ts';
 
 /**
  * Fetches a to-many relation with per-parent limit/offset for ALL parents in a
@@ -52,10 +55,11 @@ const batchedPaginatedRelationQuery = async (
   limit: number | null,
   offset: number | null,
   pkNames: readonly string[],
+  columns: Record<string, Column> | undefined,
   orderCtx?: RelationFilterContext,
   whereArgs?: Record<string, any>,
 ): Promise<any[]> => {
-  const cols = getColumns(targetTable);
+  const cols = columns ?? getColumns(targetTable);
 
   // Always tiebreak the window by the target's primary key so per-parent limit/offset
   // slices are deterministic even when the client supplies no (or a non-unique) orderBy.
@@ -148,6 +152,42 @@ export const createRelationResolverFactory =
     const targetPkNames = relEntry.targetPkNames ?? [];
     const errorCtx: DrizzleErrorContext = { table: targetTableName, operation: 'relation', relation: relationName };
 
+    /**
+     * The columns one batch reads: the ones the selection names, plus the ones the batch needs
+     * whatever the client asked for — the key it groups the rows by, and the ordering columns a
+     * row cursor is encoded from. Nested relation fields contribute their own join column
+     * through the selection context, the same way the root select path narrows.
+     *
+     * `undefined` means "every column", which is what a resolver with no readable resolve info
+     * has to fall back to.
+     */
+    const selectedColumns = (info: any, cursorEntries: CursorOrderEntry[] | undefined) => {
+      const parsed = info ? (parseResolveInfo(info) as ResolveTree | undefined) : undefined;
+      if (!parsed) {
+        return undefined;
+      }
+      // A relation field returns one object type, but merging every entry costs nothing and
+      // keeps this honest if the target is ever reached through an abstract type.
+      const tree: Record<string, ResolveTree> = Object.assign({}, ...Object.values(parsed.fieldsByTypeName));
+
+      const columns = extractSelectedColumnsFromTreeSQLFormat(tree, targetTable, {
+        tableName: targetTableName,
+        relationMap: filterCtx?.relationMap ?? {},
+        tables,
+        allRelations: filterCtx?.relationMap,
+      });
+
+      const targetColumns = getColumns(targetTable);
+      columns[foreignColPropName] = foreignCol;
+      for (const [columnName] of cursorEntries ?? []) {
+        const column = targetColumns[columnName];
+        if (column) {
+          columns[columnName] = column;
+        }
+      }
+      return columns;
+    };
+
     const resolve = async (parent: any, args: any, context: any, info: any) => {
       // Eager path: the parent resolver pre-fetched this relation via Drizzle's `with`.
       if (parent[relationName] !== undefined) {
@@ -165,7 +205,7 @@ export const createRelationResolverFactory =
       // identical for every parent row the batch fetches. Resolvers run once per parent row, so it
       // is computed once per field per request and reused, rather than re-reading the selection and
       // re-stringifying the loader key N times.
-      const { orderByArg, limit, distinct, cursorEntries, cursorValues, loaderKey } = getOrCreateRequestValue(
+      const { orderByArg, limit, distinct, cursorEntries, cursorValues, columns, loaderKey } = getOrCreateRequestValue(
         context,
         info?.fieldNodes?.[0],
         `relation:${tableName}::${relationName}`,
@@ -211,11 +251,15 @@ export const createRelationResolverFactory =
           }
           const cursorValues = after != null && cursorEntries ? decodeCursor(after, cursorEntries) : undefined;
 
+          const columns = selectedColumns(info, cursorEntries);
+
           // Batch path: collect all sibling calls in this tick and execute one query.
           // Pagination args are part of the loader key so siblings sharing identical
           // args batch together; per-parent limit/offset is applied inside the batch
           // via a window function rather than bailing to a per-parent query (N+1).
           // `cursorEntries` joins the key because it changes the ordering, not just the filter.
+          // The column list joins it too: one batch runs one SELECT, so two aliases of the same
+          // relation asking for different columns need a batch each.
           const argsKey = JSON.stringify({
             where: whereArg ?? null,
             orderBy: orderByArg ?? null,
@@ -225,6 +269,7 @@ export const createRelationResolverFactory =
             after: after ?? null,
             distinct: distinct ?? null,
             cursor: cursorEntries ? 1 : 0,
+            columns: columns ? Object.keys(columns).sort() : null,
           });
 
           return {
@@ -233,6 +278,7 @@ export const createRelationResolverFactory =
             distinct,
             cursorEntries,
             cursorValues,
+            columns,
             loaderKey: `${tableName}::${relationName}::${argsKey}`,
           };
         },
@@ -295,13 +341,16 @@ export const createRelationResolverFactory =
             limit ?? null,
             offset ?? null,
             targetPkNames,
+            columns,
             relationFilterCtx(filterCtx, targetTableName),
             whereArg,
           );
         } else {
           // Use plain db.select() so column refs are never aliased — avoids drizzle-orm v1
           // RQB aliasing requirements that would require referencing via aliasedTable proxy.
-          let q = executor.select().from(targetTable).where(whereCondition) as any;
+          let q = (columns ? executor.select(columns) : executor.select())
+            .from(targetTable)
+            .where(whereCondition) as any;
           const orderExprs = cursorEntries
             ? cursorOrderExprs(targetTable, cursorEntries)
             : orderByArg

--- a/tests/pglite/eager-load-opt-out.test.ts
+++ b/tests/pglite/eager-load-opt-out.test.ts
@@ -124,4 +124,60 @@ describe.sequential('eagerLoadRelations opt-out', () => {
     // The forced join column must not leak into the response.
     expect(users[0]).not.toHaveProperty('id');
   });
+
+  // The lazy path narrows its SELECT the same way the root path does: the columns the
+  // selection names, plus the key the batch groups on. `posts.content` is never asked for
+  // here, so it is never read.
+  describe('the lazy batch reads only the columns the selection needs', () => {
+    const postsBatch = (sqls: string[]) => sqls.filter(isPostsBatch);
+    const paginatedPostsBatch = (sqls: string[]) =>
+      sqls.filter((q) => /row_number\(\) over/i.test(q) && q.includes('"posts"'));
+
+    it('narrows the batched IN query', async () => {
+      const gqlSchema = buildWith(false);
+      const { result, sqls } = await runCapturing(gqlSchema, `{ users { id posts { id } } }`);
+
+      expect(result.errors).toBeUndefined();
+      const [batch] = postsBatch(sqls);
+      expect(batch).toBeDefined();
+      expect(batch).toContain('"author_id"');
+      expect(batch).not.toContain('"content"');
+    });
+
+    it('narrows the paginated batch, keeping the row-number window', async () => {
+      const gqlSchema = buildWith(false);
+      const { result, sqls } = await runCapturing(gqlSchema, `{ users { id posts(limit: 1) { id } } }`);
+
+      expect(result.errors).toBeUndefined();
+      expect((result.data as any)?.users?.find((u: any) => u.id === 1)?.posts).toHaveLength(1);
+      const [batch] = paginatedPostsBatch(sqls);
+      expect(batch).toBeDefined();
+      expect(batch).toContain('__drizzle_graphql_rn');
+      expect(batch).not.toContain('"content"');
+    });
+
+    it('reads a column the selection does name', async () => {
+      const gqlSchema = buildWith(false);
+      const { result, sqls } = await runCapturing(gqlSchema, `{ users { id posts { content } } }`);
+
+      expect(result.errors).toBeUndefined();
+      expect((result.data as any)?.users?.find((u: any) => u.id === 1)?.posts?.[0]).toEqual({
+        content: '1MESSAGE',
+      });
+      expect(postsBatch(sqls)[0]).toContain('"content"');
+    });
+
+    it('keeps the join column a relation under the lazy relation resolves from', async () => {
+      const gqlSchema = buildWith(false);
+      const { result, sqls } = await runCapturing(gqlSchema, `{ users { id posts { id author { name } } } }`);
+
+      expect(result.errors).toBeUndefined();
+      const posts = (result.data as any)?.users?.find((u: any) => u.id === 1)?.posts ?? [];
+      expect(posts[0]?.author).toEqual({ name: 'FirstUser' });
+      // `author_id` is the key both the batch and the nested `author` field correlate on, and
+      // it stays out of the response either way.
+      expect(posts[0]).not.toHaveProperty('authorId');
+      expect(postsBatch(sqls)[0]).not.toContain('"content"');
+    });
+  });
 });


### PR DESCRIPTION
Closes #129.

The root select path narrows to the requested columns via `extractSelectedColumnsFromTree` and the eager `with:` path inherits that, but the lazy relation path selected the target's whole column list. `{ users { posts { id } } }` on a non-eager relation read every column of `posts` — wide `text`/`json`/`blob` columns included — and graphql-js then discarded them.

- A new `selectedColumns` helper parses the field's resolve info once and runs `extractSelectedColumnsFromTreeSQLFormat` against the target table, with the build's relation map as the selection context — so a relation field nested under the lazy relation still gets the join column it correlates on.
- Unioned in regardless of the selection: the foreign key the batch groups by, and the cursor's ordering columns (`attachRowCursors` encodes them off the row).
- Both batch paths use it: the plain `select()` and the window-function subquery, which keeps its `__drizzle_graphql_rn` alias.
- It is computed inside the per-field, per-request memo from #132, so it costs one parse per field per request, not one per parent row.
- The column list is part of the loader key: a batch runs a single SELECT, so two aliases of one relation with different column sets need a batch each. Without this, whichever alias resolved first would decide the projection for both — `tests/pglite/relation-alias.test.ts` catches exactly that.

Four tests in `tests/pglite/eager-load-opt-out.test.ts` pin the narrowing on the plain batch, on the paginated batch (row-number window kept), that a named column is still read, and that a nested relation under the lazy relation still resolves. Three of them fail on `main`.

Lint, both typechecks and the PGlite + SQLite suites (1129 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8CNohGit8bcDzuTau1G2W