### PR TITLE
test: stop the gql test client racing the server's keep-alive timeout

### DIFF
--- a/tests/util/query/index.ts
+++ b/tests/util/query/index.ts
@@ -1,4 +1,14 @@
+import { Agent } from 'node:http';
 import axios, { type AxiosError } from 'axios';
+
+/**
+ * Node's global agent keeps sockets alive between requests, and a Node HTTP server closes an
+ * idle one after five seconds. A suite that pauses longer than that between requests — a slow
+ * neighbouring test, a loaded CI runner — can hand axios a socket the server is closing at that
+ * moment, which surfaces as a response-less ECONNRESET and a test asserting on `undefined`.
+ * A fresh connection per request costs nothing here and takes the race away.
+ */
+const agent = new Agent({ keepAlive: false });
 
 export class GraphQLClient {
   constructor(private url: string) {}
@@ -23,6 +33,7 @@ export class GraphQLClient {
             accept: 'application/graphql-response+json, application/json',
             'content-type': 'application/json',
           },
+          httpAgent: agent,
         },
       );
 
@@ -30,8 +41,14 @@ export class GraphQLClient {
     } catch (e) {
       const err = e as AxiosError<any>;
 
-      console.warn(err.status, err.response?.data.errors);
-      return err.response?.data;
+      if (!err.response) {
+        // No response at all — a transport failure, not a GraphQL error. Say so, rather than
+        // returning `undefined` and letting the assertion report a mysterious missing body.
+        throw new Error(`Drizzle-GraphQL test client: request to ${this.url} failed with ${err.code ?? err.message}`);
+      }
+
+      console.warn(err.status, err.response.data?.errors);
+      return err.response.data;
     }
   };
 }


### PR DESCRIPTION
`tests/sqlite.test.ts > __typename only tests > Select single` has now failed twice in CI on unrelated PRs, both times with `AssertionError: expected undefined to strictly equal { data: … }`.

`queryGql` returns `undefined` when axios throws with no `response` — a transport failure. Node's global HTTP agent keeps sockets alive between requests (default since Node 19) and a Node HTTP server closes an idle keep-alive socket after five seconds, so a pause longer than that between two requests — a slow neighbouring test on a loaded runner — can have the client write to a socket the server is closing at that instant. That surfaces as a response-less `ECONNRESET`.

- The client now uses its own `http.Agent({ keepAlive: false })`: a fresh connection per request, which costs nothing at test volumes and removes the race.
- A response-less failure now throws an error naming the URL and the transport fault, instead of returning `undefined` for an assertion several lines later to trip over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8CNohGit8bcDzuTau1G2W