### PR TITLE
refactor: fold the repeated mutation prologue and scoped-where into helpers

### DIFF
--- a/src/util/builders/common.ts
+++ b/src/util/builders/common.ts
@@ -91,8 +91,11 @@ export {
   generateUpdateManyInput,
   generateWriteCount,
   hardDeleteArg,
+  mutationSelection,
   prepareMutationRelationColumns,
   rowsAffected,
+  scopedWhere,
+  withEagerRelations,
 } from './common/mutation-helpers.ts';
 export type { TypeNameMapper } from './common/naming.ts';
 export { applyObjectTypeName, resolveObjectTypeName, resolveTypeName } from './common/naming.ts';

--- a/src/util/builders/common/mutation-helpers.ts
+++ b/src/util/builders/common/mutation-helpers.ts
@@ -7,6 +7,7 @@ import type { GraphQLFieldConfigArgumentMap } from 'graphql';
 import { GraphQLBoolean, GraphQLInputObjectType, GraphQLNonNull } from 'graphql';
 import { capitalize } from '../../case-ops/index.ts';
 import type { ResolveTree } from '../../parse-resolve-info.ts';
+import { parseResolveInfo } from '../../parse-resolve-info.ts';
 import { remapUpdateInput } from '../field-updates.ts';
 // Type-only: the nested-write module imports this one at runtime, so the dependency has to
 // stay one-directional. The implementation is injected by the dialect builder.
@@ -17,10 +18,12 @@ import { withPrimaryKeyColumns } from './keys.ts';
 import type { DefaultOrderByFor, LimitPolicyFor } from './limits.ts';
 import type { TypeNameMapper } from './naming.ts';
 import { resolveObjectTypeName } from './naming.ts';
-import type { ScopeResolver } from './policies.ts';
+import type { DeletedMode, ScopeResolver } from './policies.ts';
+import { withScope } from './policies.ts';
 import type { RelationFilterBase, RelationFilterContext } from './relation-filters.ts';
 import { extractFilters, relationFilterCtx } from './relation-filters.ts';
 import { extractRelationsParams } from './relation-params.ts';
+import { eagerLoadMutationRelations } from './select-runtime.ts';
 import { extractSelectedColumnsFromTreeSQLFormat } from './selected-columns.ts';
 import type { MutationTxCtx } from './transactions.ts';
 import { runMutation } from './transactions.ts';
@@ -45,7 +48,7 @@ export const hardDeleteArg = {
  * then forces the primary key into the column set (so the post-mutation eager-load can
  * re-key rows). Returns everything the resolver needs to decide whether to eager-load.
  */
-export const prepareMutationRelationColumns = (params: {
+export interface PrepareMutationRelationColumnsParams {
   relationMap: Record<string, Record<string, TableNamedRelations>>;
   tables: Record<string, Table>;
   tableName: string;
@@ -59,7 +62,11 @@ export const prepareMutationRelationColumns = (params: {
   defaultOrderBy?: DefaultOrderByFor;
   /** The build's type-naming rule — the selection tree is keyed by the name it produced. */
   resolveName?: TypeNameResolver;
-}): {
+}
+
+export const prepareMutationRelationColumns = (
+  params: PrepareMutationRelationColumnsParams,
+): {
   columns: Record<string, Column>;
   hasRelations: boolean;
   withParams: Record<string, Partial<ProcessedTableSelectArgs>> | undefined;
@@ -84,6 +91,70 @@ export const prepareMutationRelationColumns = (params: {
   const columns = hasRelations ? withPrimaryKeyColumns(baseColumns, table, pkNames) : baseColumns;
   return { columns, hasRelations, withParams };
 };
+
+/**
+ * The prologue every write resolver runs: parse the resolve info, then work out the columns
+ * to return and the relations to eager-load from it. `parsedInfo` comes back too — the delete
+ * resolver reads its own columns off the tree rather than taking the prepared set.
+ */
+export const mutationSelection = (
+  info: any,
+  params: Omit<PrepareMutationRelationColumnsParams, 'parsedInfo'>,
+): {
+  parsedInfo: ResolveTree;
+  columns: Record<string, Column>;
+  hasRelations: boolean;
+  withParams: Record<string, Partial<ProcessedTableSelectArgs>> | undefined;
+} => {
+  const parsedInfo = parseResolveInfo(info, { deep: true }) as ResolveTree;
+  return { parsedInfo, ...prepareMutationRelationColumns({ ...params, parsedInfo }) };
+};
+
+/**
+ * The `where` a write runs under: the caller's filters — required when the mutation refuses to
+ * run unbounded — with the row scope ANDed on last, so a supplied filter can only narrow the
+ * scope and never widen it. An out-of-scope row is simply not matched.
+ *
+ * `deleted` states which soft-delete mode the match reads at, for the writes that need one:
+ * `restore` sees only marked rows, a hard delete has to see them too.
+ */
+export const scopedWhere = <TTable extends Table>(params: {
+  scope: ScopeResolver | undefined;
+  tableName: string;
+  table: TTable;
+  where: Filters<TTable> | undefined;
+  relationCtx?: RelationFilterContext;
+  /** The single-row writes always require a `where`; the plural ones do under `requireWhere`. */
+  required?: boolean;
+  deleted?: DeletedMode;
+}): SQL | undefined => {
+  const { scope, tableName, table, where, relationCtx, required, deleted } = params;
+  return withScope(
+    scope,
+    tableName,
+    table,
+    required
+      ? extractRequiredFilters(table, tableName, where, relationCtx)
+      : where
+        ? extractFilters(table, tableName, where, relationCtx)
+        : undefined,
+    deleted,
+  );
+};
+
+/**
+ * The epilogue: the written rows with their selected relations attached, or the rows as they
+ * came back when the selection asked for no relation at all.
+ */
+export const withEagerRelations = (
+  executor: any,
+  tableName: string,
+  rows: any[],
+  pkNames: readonly string[],
+  withParams: Record<string, Partial<ProcessedTableSelectArgs>> | undefined,
+  hasRelations: boolean,
+): Promise<any[]> | any[] =>
+  hasRelations ? eagerLoadMutationRelations(executor, tableName, rows, pkNames, withParams) : rows;
 
 /**
  * The per-entry input of `update<Table>Many`: `{ where, set }`, reusing the table's
@@ -242,12 +313,15 @@ export const generateWriteCount = ({
         return await runMutation(db, context, info, txCtx, async (executor) => {
           const { where, set } = args;
 
-          const relationCtx = relationFilterCtx(filterCtx, tableName);
-          const filters = requireWhere
-            ? extractRequiredFilters(table, tableName, where, relationCtx)
-            : where
-              ? extractFilters(table, tableName, where, relationCtx)
-              : undefined;
+          // No scope here: this mutation is only generated for tables without one.
+          const filters = scopedWhere({
+            scope: undefined,
+            tableName,
+            table,
+            where,
+            relationCtx: relationFilterCtx(filterCtx, tableName),
+            required: requireWhere,
+          });
 
           let query: any;
           if (kind === 'delete') {

--- a/src/util/builders/mysql.ts
+++ b/src/util/builders/mysql.ts
@@ -17,7 +17,6 @@ import {
   defineRootField,
   drizzleError,
   extractFilters,
-  extractRequiredFilters,
   generateOnConflictInput,
   generateUpdateManyInput,
   generateWriteCount,
@@ -31,6 +30,7 @@ import {
   type ResolverPolicies,
   relationFilterCtx,
   resolveConflictPlan,
+  scopedWhere,
   stripContextValues,
   type TablesRelationalConfig,
   type WriteOperation,
@@ -235,16 +235,14 @@ const generateUpdate = (
 
       const relationCtx = relationFilterCtx(filterCtx, tableName);
       // The scope is ANDed on last, so a caller-supplied `where` can only narrow it.
-      const filters = withScope(
+      const filters = scopedWhere({
         scope,
         tableName,
         table,
-        single || requireWhere
-          ? extractRequiredFilters(table, tableName, where, relationCtx)
-          : where
-            ? extractFilters(table, tableName, where, relationCtx)
-            : undefined,
-      );
+        where,
+        relationCtx,
+        required: single || requireWhere,
+      });
 
       if (single) {
         await assertSingleMatch(executor, table, filters!);
@@ -393,19 +391,17 @@ const generateDelete = (
       // rows inside it — an out-of-scope row is not matched rather than being refused.
       // A soft-deleting table adds the marker predicate the same way: `delete` only sees
       // rows that are not already marked, `restore` only sees the ones that are.
-      const filters = withScope(
+      const filters = scopedWhere({
         scope,
         tableName,
         table,
-        single || requireWhere
-          ? extractRequiredFilters(table, tableName, where, relationCtx)
-          : where
-            ? extractFilters(table, tableName, where, relationCtx)
-            : undefined,
+        where,
+        relationCtx,
+        required: single || requireWhere,
         // A hard delete reads at INCLUDE: the rows it mostly exists to remove are the
         // ones already marked, which the default EXCLUDE could not reach at all.
-        restore ? 'ONLY' : hard ? 'INCLUDE' : undefined,
-      );
+        deleted: restore ? 'ONLY' : hard ? 'INCLUDE' : undefined,
+      });
 
       if (single) {
         await assertSingleMatch(executor, table, filters!);

--- a/src/util/builders/update-many.ts
+++ b/src/util/builders/update-many.ts
@@ -14,23 +14,21 @@ import type { GraphQLFieldConfigArgumentMap, GraphQLInputObjectType } from 'grap
 import { GraphQLList, GraphQLNonNull } from 'graphql';
 import {
   drizzleError,
-  eagerLoadMutationRelations,
   extractFilters,
   type LimitPolicyFor,
   type MutationTxCtx,
-  prepareMutationRelationColumns,
+  mutationSelection,
   type RelationFilterBase,
   type ResolverPolicies,
   relationFilterCtx,
   stripContextValues,
   type TypeNameMapper,
   type TypeNameResolver,
+  withEagerRelations,
   withScope,
   writeResolver,
 } from '../builders/common.ts';
 import { remapToGraphQLSingleOutput } from '../data-mappers/index.ts';
-import type { ResolveTree } from '../parse-resolve-info.ts';
-import { parseResolveInfo } from '../parse-resolve-info.ts';
 import { remapUpdateInput } from './field-updates.ts';
 import { mergedOps, type NestedWriteRuntime } from './nested-writes.ts';
 import type { UpdateManyGenerator } from './schema-data.ts';
@@ -165,11 +163,7 @@ export const createUpdateManyGenerator = (
         const scope = policies?.scope?.(context);
         const contextColumns = policies?.contextValues?.(tableName);
 
-        const parsedInfo = parseResolveInfo(info, {
-          deep: true,
-        }) as ResolveTree;
-
-        const { columns, hasRelations, withParams } = prepareMutationRelationColumns({
+        const { columns, hasRelations, withParams } = mutationSelection(info, {
           relationMap,
           tables,
           tableName,
@@ -178,7 +172,6 @@ export const createUpdateManyGenerator = (
           resolveName,
           table,
           pkNames,
-          parsedInfo,
           limits,
           scope,
           defaultOrderBy: policies?.defaultOrderBy,
@@ -233,9 +226,7 @@ export const createUpdateManyGenerator = (
         const flatRows = perEntry.flat();
         await after(flatRows);
 
-        const enriched = hasRelations
-          ? await eagerLoadMutationRelations(executor, tableName, flatRows, pkNames, withParams)
-          : flatRows;
+        const enriched = await withEagerRelations(executor, tableName, flatRows, pkNames, withParams, hasRelations);
 
         // Rebuild the per-entry slots: a no-match entry contributes `null`, a multi-match
         // entry contributes each of its rows.

--- a/src/util/builders/write-resolvers.ts
+++ b/src/util/builders/write-resolvers.ts
@@ -28,25 +28,25 @@ import {
   applyObjectTypeName,
   assertSingleMatch,
   drizzleError,
-  eagerLoadMutationRelations,
   excludedColumnRef,
   extractFilters,
-  extractRequiredFilters,
   extractSelectedColumnsFromTreeSQLFormat,
   hardDeleteArg,
   type LimitPolicyFor,
   type MutationTxCtx,
+  mutationSelection,
   type OnConflictArg,
-  prepareMutationRelationColumns,
   type RelationFilterBase,
   type ResolverPolicies,
   relationFilterCtx,
   resolveConflictPlan,
   type SelectionCtx,
+  scopedWhere,
   stripContextValues,
   type TypeNameMapper,
   type TypeNameResolver,
   type WriteOperation,
+  withEagerRelations,
   withScope,
   writeResolver,
 } from './common.ts';
@@ -128,11 +128,7 @@ export const buildWriteResolvers = (primaryKeyPropNames: PrimaryKeyPropNames) =>
               context,
             );
 
-        const parsedInfo = parseResolveInfo(info, {
-          deep: true,
-        }) as ResolveTree;
-
-        const { columns, hasRelations, withParams } = prepareMutationRelationColumns({
+        const { columns, hasRelations, withParams } = mutationSelection(info, {
           relationMap,
           tables,
           tableName,
@@ -141,7 +137,6 @@ export const buildWriteResolvers = (primaryKeyPropNames: PrimaryKeyPropNames) =>
           resolveName,
           table,
           pkNames,
-          parsedInfo,
           limits,
           scope,
           defaultOrderBy: policies?.defaultOrderBy,
@@ -174,9 +169,7 @@ export const buildWriteResolvers = (primaryKeyPropNames: PrimaryKeyPropNames) =>
 
         await after(result);
 
-        const enriched = hasRelations
-          ? await eagerLoadMutationRelations(executor, tableName, result, pkNames, withParams)
-          : result;
+        const enriched = await withEagerRelations(executor, tableName, result, pkNames, withParams, hasRelations);
 
         return remapToGraphQLArrayOutput(enriched, tableName, table, relationMap);
       },
@@ -233,11 +226,7 @@ export const buildWriteResolvers = (primaryKeyPropNames: PrimaryKeyPropNames) =>
               context,
             );
 
-        const parsedInfo = parseResolveInfo(info, {
-          deep: true,
-        }) as ResolveTree;
-
-        const { columns, hasRelations, withParams } = prepareMutationRelationColumns({
+        const { columns, hasRelations, withParams } = mutationSelection(info, {
           relationMap,
           tables,
           tableName,
@@ -246,7 +235,6 @@ export const buildWriteResolvers = (primaryKeyPropNames: PrimaryKeyPropNames) =>
           resolveName,
           table,
           pkNames,
-          parsedInfo,
           limits,
           scope,
           defaultOrderBy: policies?.defaultOrderBy,
@@ -288,9 +276,7 @@ export const buildWriteResolvers = (primaryKeyPropNames: PrimaryKeyPropNames) =>
           return undefined;
         }
 
-        const enriched = hasRelations
-          ? await eagerLoadMutationRelations(executor, tableName, result, pkNames, withParams)
-          : result;
+        const enriched = await withEagerRelations(executor, tableName, result, pkNames, withParams, hasRelations);
 
         return remapToGraphQLSingleOutput(enriched[0], tableName, table, relationMap);
       },
@@ -366,9 +352,7 @@ export const buildWriteResolvers = (primaryKeyPropNames: PrimaryKeyPropNames) =>
               context,
             );
 
-        const parsedInfo = parseResolveInfo(info, { deep: true }) as ResolveTree;
-
-        const { columns, hasRelations, withParams } = prepareMutationRelationColumns({
+        const { columns, hasRelations, withParams } = mutationSelection(info, {
           relationMap,
           tables,
           tableName,
@@ -377,7 +361,6 @@ export const buildWriteResolvers = (primaryKeyPropNames: PrimaryKeyPropNames) =>
           resolveName,
           table,
           pkNames,
-          parsedInfo,
           limits,
           scope,
           defaultOrderBy: policies?.defaultOrderBy,
@@ -434,9 +417,7 @@ export const buildWriteResolvers = (primaryKeyPropNames: PrimaryKeyPropNames) =>
           return undefined;
         }
 
-        const enriched = hasRelations
-          ? await eagerLoadMutationRelations(executor, tableName, result, pkNames, withParams)
-          : result;
+        const enriched = await withEagerRelations(executor, tableName, result, pkNames, withParams, hasRelations);
 
         return single
           ? remapToGraphQLSingleOutput(enriched[0], tableName, table, relationMap)
@@ -492,11 +473,7 @@ export const buildWriteResolvers = (primaryKeyPropNames: PrimaryKeyPropNames) =>
         const scope = policies?.scope?.(context);
         await before();
 
-        const parsedInfo = parseResolveInfo(info, {
-          deep: true,
-        }) as ResolveTree;
-
-        const { columns, hasRelations, withParams } = prepareMutationRelationColumns({
+        const { columns, hasRelations, withParams } = mutationSelection(info, {
           relationMap,
           tables,
           tableName,
@@ -505,7 +482,6 @@ export const buildWriteResolvers = (primaryKeyPropNames: PrimaryKeyPropNames) =>
           resolveName,
           table,
           pkNames,
-          parsedInfo,
           limits,
           scope,
           defaultOrderBy: policies?.defaultOrderBy,
@@ -527,16 +503,14 @@ export const buildWriteResolvers = (primaryKeyPropNames: PrimaryKeyPropNames) =>
 
         const relationCtx = relationFilterCtx(filterCtx, tableName);
         // The scope is ANDed on last, so a caller-supplied `where` can only narrow it.
-        const filters = withScope(
+        const filters = scopedWhere({
           scope,
           tableName,
           table,
-          single || requireWhere
-            ? extractRequiredFilters(table, tableName, where, relationCtx)
-            : where
-              ? extractFilters(table, tableName, where, relationCtx)
-              : undefined,
-        );
+          where,
+          relationCtx,
+          required: single || requireWhere,
+        });
 
         if (single) {
           await assertSingleMatch(executor, table, filters!);
@@ -579,9 +553,7 @@ export const buildWriteResolvers = (primaryKeyPropNames: PrimaryKeyPropNames) =>
           return undefined;
         }
 
-        const enriched = hasRelations
-          ? await eagerLoadMutationRelations(executor, tableName, result, pkNames, withParams)
-          : result;
+        const enriched = await withEagerRelations(executor, tableName, result, pkNames, withParams, hasRelations);
 
         return single
           ? remapToGraphQLSingleOutput(enriched[0], tableName, table, relationMap)
@@ -663,19 +635,17 @@ export const buildWriteResolvers = (primaryKeyPropNames: PrimaryKeyPropNames) =>
         // rows inside it — an out-of-scope row is not matched rather than being refused.
         // A soft-deleting table adds the marker predicate the same way: `delete` only sees
         // rows that are not already marked, `restore` only sees the ones that are.
-        const filters = withScope(
+        const filters = scopedWhere({
           scope,
           tableName,
           table,
-          single || requireWhere
-            ? extractRequiredFilters(table, tableName, where, relationCtx)
-            : where
-              ? extractFilters(table, tableName, where, relationCtx)
-              : undefined,
+          where,
+          relationCtx,
+          required: single || requireWhere,
           // A hard delete reads at INCLUDE: the rows it mostly exists to remove are the
           // ones already marked, which the default EXCLUDE could not reach at all.
-          restore ? 'ONLY' : hard ? 'INCLUDE' : undefined,
-        );
+          deleted: restore ? 'ONLY' : hard ? 'INCLUDE' : undefined,
+        });
 
         if (single) {
           await assertSingleMatch(executor, table, filters!);


### PR DESCRIPTION
Closes #146.

The five write resolvers (`insert`, `insert…Single`, `update`, `update…Many`, `delete`) each opened with the same two copied blocks:

- parse the resolve info, then pass the tree plus a 13-key parameter literal to `prepareMutationRelationColumns`;
- build the row filter as a three-way nested ternary (required filters / optional filters / none) wrapped in `withScope`.

They also closed with the same `hasRelations ? await eagerLoadMutationRelations(…) : rows` epilogue. Each was copied verbatim, so a change had to be made five times and stayed correct only by inspection.

Three helpers in `common/mutation-helpers.ts` now own those shapes:

- `mutationSelection(info, params)` — parses the tree and projects the relation columns, returning `parsedInfo` alongside the existing result.
- `scopedWhere({ scope, tableName, table, where, relationCtx, required, deleted })` — the filter choice with the scope ANDed on last.
- `withEagerRelations(executor, tableName, rows, pkNames, withParams, hasRelations)` — the enrichment epilogue.

`prepareMutationRelationColumns`'s inline parameter type is now the exported `PrepareMutationRelationColumnsParams`, so `mutationSelection` can take it minus the tree it parses itself.

Behaviour is unchanged. The one non-obvious call site is the count-returning mutation inside `mutation-helpers.ts`, which had no `withScope` wrapper: it moves to `scopedWhere` with `scope: undefined`, which `withScope` passes through unchanged — that mutation is only generated for tables without a scope, and a comment says so.

Lint, both typecheck passes and the PGlite + SQLite suites (1107 tests) are green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8CNohGit8bcDzuTau1G2W