### PR TITLE
feat!: give each column type the filter operators it can actually use

### DIFF
--- a/README.md
+++ b/README.md
@@ -850,7 +850,51 @@ by hand. Under `insensitive` the operand stays a literal and stays a bound param
         the left side is a plain `lower(column)`, a `lower(column)` expression index can serve the
         lookup — which `ilike '%…%'` never can
 -   The flag appears only on filters whose column can take string operators, so it is absent
-        from the numeric, uuid and boolean filters
+        from the numeric, uuid, boolean, timestamp and enum filters (see
+        [Which operators a column gets](#which-operators-a-column-gets))
+
+## Which operators a column gets
+
+A filter input carries the operators that can express a question about that column type, and
+no others. The set follows the column's data type, never its name:
+
+| column type | `eq` `ne` `inArray` `notInArray` `isNull` `isNotNull` | `lt` `lte` `gt` `gte` | pattern operators + `insensitive` |
+| --- | --- | --- | --- |
+| text / varchar | yes | yes | yes |
+| timestamp, date | yes | yes | — |
+| int, float, bigint, decimal | yes | yes | — |
+| uuid | yes | yes | — |
+| boolean | yes | — | — |
+| enum | yes | — | — |
+
+The pattern operators are `like` / `notLike` / `ilike` / `notIlike`, the safe
+`startsWith` / `endsWith` / `contains` and their `i`-prefixed forms, plus the `insensitive`
+flag that modifies them.
+
+The omissions are the cases where the operator cannot ask anything a caller means:
+
+-   **Pattern matching a timestamp, a boolean or an enum member** compares whatever the value
+        is rendered as rather than anything in the row, and the answer depends on session
+        formatting. On a numeric column it is invalid SQL outright.
+-   **Ordering two booleans** is equality spelled as a puzzle — `gt: false` is `eq: true`.
+-   **Ordering enum members** compares their declaration order, which is an artefact of how the
+        column was written rather than a fact about the domain. `inArray` says the same thing
+        exactly.
+
+Timestamps keep the ordering operators — ranges are the point of having them — and `json` /
+`jsonb` and array columns have their own sets entirely (structural containment and membership;
+see [Filtering inside JSON documents](#filtering-inside-json-documents)).
+
+A column given a custom scalar through `scalarOverrides` keeps the pattern operators only when
+a `LIKE` against the underlying database column would be valid — string-typed and not
+numeric — and keeps the ordering operators either way, since a custom scalar says nothing about
+whether its column is orderable.
+
+> **Upgrading:** `BooleanFilter` and the generated `*EnumFilter`s used to carry the full
+> 24-operator string set, and `DateTimeFilter` the pattern half of it. Queries that sent one of
+> the removed operators are now validation errors; `eq` / `ne` / `inArray` / `notInArray` /
+> `isNull` / `isNotNull` and the boolean branches `AND` / `OR` / `NOT` are unchanged, as is
+> ordering on timestamps.
 
 ## Matching lists of values
 

--- a/src/util/builders/common/column-filters.ts
+++ b/src/util/builders/common/column-filters.ts
@@ -66,6 +66,13 @@ export const isJsonColumn = (column: Column): boolean =>
 interface GenericFilterDescriptor {
   name: string;
   kind: 'scalar' | 'json' | 'array';
+  /**
+   * True for an enum column. Enum filter types are named after the enum, so they cannot be
+   * recognised by name the way the built-in filters below are — but they want the same lean
+   * operator set as `Boolean`: a closed set of members has nothing to pattern-match and no
+   * order beyond the accident of how the column was declared.
+   */
+  isEnum?: boolean;
 }
 
 /**
@@ -79,11 +86,12 @@ interface GenericFilterDescriptor {
  *                       StringArray, …) so arrays with different element types never share
  *                       one filter input; membership operators instead of scalar comparisons
  * - "Id"          → uuid-typed columns (no string pattern operators)
- * - "Boolean"     → boolean columns
+ * - "Boolean"     → boolean columns (equality and membership only — no ordering, no patterns)
  * - "BigInt"      → bigint columns (BigInt-scalar-typed operators, no string pattern operators)
  * - "Decimal"     → numeric/decimal columns (Decimal-scalar-typed operators, no string pattern operators)
- * - the enum GraphQL type name → enum columns (still unique per enum)
- * - "DateTime"    → timestamp and date columns
+ * - the enum GraphQL type name → enum columns (still unique per enum; equality and
+ *                       membership only, like Boolean)
+ * - "DateTime"    → timestamp and date columns (ordering kept, no string pattern operators)
  * - "Int"         → integer/serial columns (no string pattern operators)
  * - "Float"       → real/double columns (no string pattern operators)
  * - "String"      → all other text/varchar columns
@@ -115,7 +123,7 @@ const resolveGenericFilterDescriptor = (
   }
   // Enum type — keep unique per enum since values differ
   if (columnGraphQLType.type instanceof GraphQLEnumType) {
-    return { name: columnGraphQLType.type.name, kind: 'scalar' };
+    return { name: columnGraphQLType.type.name, kind: 'scalar', isEnum: true };
   }
   // Named numeric-string scalars — give them their own filters so the operators
   // are typed with the scalar (and validated by it) instead of a shared StringFilter.
@@ -287,11 +295,23 @@ const arrayFilterFields = (colType: GraphQLList<any>, colArr: GraphQLList<any>) 
 
 /**
  * Filters whose fields omit the string pattern operators (like/notLike/ilike/notIlike/
- * startsWith/contains/…): they are nonsensical on opaque uuids and invalid SQL on numeric
- * columns. Keyed on the generic filter name (i.e. on column type) — a string-typed column
- * keeps the string operators whatever it is called.
+ * startsWith/contains/… and the `insensitive` flag that modifies them): they are nonsensical
+ * on opaque uuids, booleans and enum members, invalid SQL on numeric columns, and on a
+ * timestamp they match whatever the session happens to render the value as rather than
+ * anything in the query. Keyed on the generic filter name (i.e. on column type) — a
+ * string-typed column keeps the string operators whatever it is called. Enum filters are
+ * named after their enum and are recognised by `isEnum` instead.
  */
-const FILTERS_WITHOUT_STRING_OPS = new Set(['Id', 'Int', 'Float', 'BigInt', 'Decimal']);
+const FILTERS_WITHOUT_STRING_OPS = new Set(['Id', 'Int', 'Float', 'BigInt', 'Decimal', 'Boolean', 'Date', 'DateTime']);
+
+/**
+ * Filters that additionally omit the ordering operators (lt/lte/gt/gte). Ordering two
+ * booleans is `eq` spelled as a puzzle (`gt: false` is `eq: true`), and ordering enum members
+ * compares their declaration order — an artefact of how the column was written rather than a
+ * fact about the domain. Timestamps and the numerics keep them: ranges are the point of
+ * having them. Enum filters are recognised by `isEnum`, as above.
+ */
+const FILTERS_WITHOUT_ORDERING_OPS = new Set(['Boolean']);
 
 /**
  * Scalars the built-in detection itself can produce. A scalar override to one of these
@@ -346,7 +366,11 @@ export const generateColumnFilterValues = (
   // same scalar share one filter type.
   const inputOverride = getColumnScalarOverride(column, true);
 
-  const { name: genericName, kind } = inputOverride
+  const {
+    name: genericName,
+    kind,
+    isEnum,
+  } = inputOverride
     ? resolveOverrideFilterDescriptor(inputOverride)
     : resolveGenericFilterDescriptor(column, columnGraphQLType);
   const cached = cacheCtx.genericFilterCache.get(genericName);
@@ -359,18 +383,20 @@ export const generateColumnFilterValues = (
   const colType = columnGraphQLType.type as NullableConvertedColumnType<true>;
   const colArr = new GraphQLList(new GraphQLNonNull(colType));
 
-  // Uuid and numeric filters omit the string pattern operators
-  // (like/ilike/startsWith/contains/…) — decided by column type, never by column name.
-  // A filter shared with the built-ins keeps that name-keyed rule even for an overridden
-  // column, so the shared type's shape never depends on which column built it first. A
-  // custom override scalar's own filter carries the pattern operators only when a pattern
-  // match is valid SQL on the underlying database column: string-typed, and not
-  // numeric/decimal (those transport as strings but reject LIKE).
+  // Which operators a column type gets is decided by the column type, never by the column
+  // name. A filter shared with the built-ins keeps that name-keyed rule even for an
+  // overridden column, so the shared type's shape never depends on which column built it
+  // first. A custom override scalar's own filter carries the pattern operators only when a
+  // pattern match is valid SQL on the underlying database column: string-typed, and not
+  // numeric/decimal (those transport as strings but reject LIKE). Ordering operators are
+  // dropped only for the built-in shapes where they are meaningless — a custom scalar says
+  // nothing about whether its column is orderable, so it keeps them.
   const customOverrideFilter = inputOverride !== undefined && !BUILTIN_FILTER_SCALARS.has(inputOverride);
   const underlying = extractExtendedColumnType(column);
   const omitStringOps = customOverrideFilter
     ? underlying.type !== 'string' || underlying.constraint === 'numeric'
-    : FILTERS_WITHOUT_STRING_OPS.has(genericName);
+    : isEnum || FILTERS_WITHOUT_STRING_OPS.has(genericName);
+  const omitOrderingOps = !customOverrideFilter && (isEnum || FILTERS_WITHOUT_ORDERING_OPS.has(genericName));
 
   const baseFields =
     kind === 'json'
@@ -380,10 +406,14 @@ export const generateColumnFilterValues = (
         : {
             eq: { type: colType, description: 'Equal to' },
             ne: { type: colType, description: 'Not equal to' },
-            lt: { type: colType, description: 'Less than' },
-            lte: { type: colType, description: 'Less than or equal to' },
-            gt: { type: colType, description: 'Greater than' },
-            gte: { type: colType, description: 'Greater than or equal to' },
+            ...(omitOrderingOps
+              ? {}
+              : {
+                  lt: { type: colType, description: 'Less than' },
+                  lte: { type: colType, description: 'Less than or equal to' },
+                  gt: { type: colType, description: 'Greater than' },
+                  gte: { type: colType, description: 'Greater than or equal to' },
+                }),
             ...(omitStringOps
               ? {}
               : {

--- a/tests/pglite/filter-operator-sets.test.ts
+++ b/tests/pglite/filter-operator-sets.test.ts
@@ -1,0 +1,196 @@
+import { PGlite } from '@electric-sql/pglite';
+import { buildRelations, sql } from 'drizzle-orm';
+import { boolean, date, pgEnum, pgTable, serial, text, timestamp } from 'drizzle-orm/pg-core';
+import { drizzle } from 'drizzle-orm/pglite';
+import { type GraphQLInputObjectType, type GraphQLSchema, graphql } from 'graphql';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildSchema } from '@/index';
+import { unknownInputField } from '../util/validation-messages';
+
+// ── Which operators a column type is worth offering ───────────────────────────
+// A pattern match against a boolean, a timestamp or an enum member asks a question
+// nobody means: it compares whatever the session renders the value as, not anything
+// in the row. Ordering is the same for booleans (`gt: false` is `eq: true` spelled as
+// a puzzle) and for enums, where the order is the accident of how the column was
+// declared. Timestamps keep ordering — ranges are the point of having one.
+const kindEnum = pgEnum('kind', ['cron', 'event']);
+
+const Triggers = pgTable('triggers', {
+  id: serial('id').primaryKey(),
+  name: text('name'),
+  kind: kindEnum('kind'),
+  enabled: boolean('enabled'),
+  firedAt: timestamp('fired_at'),
+  onDay: date('on_day', { mode: 'date' }),
+});
+const relations = buildRelations({ Triggers }, {});
+const schema = { Triggers, relations };
+
+let pglite: PGlite;
+let db: any;
+let gqlSchema: GraphQLSchema;
+
+const filterFieldsFor = (columnName: string) => {
+  const tableFilters = gqlSchema.getType('TriggersFilters') as GraphQLInputObjectType;
+  const columnFilter = tableFilters.getFields()[columnName]!.type as GraphQLInputObjectType;
+  return { name: columnFilter.name, fields: Object.keys(columnFilter.getFields()) };
+};
+
+const PATTERN_OPS = [
+  'like',
+  'notLike',
+  'ilike',
+  'notIlike',
+  'startsWith',
+  'endsWith',
+  'contains',
+  'iStartsWith',
+  'iEndsWith',
+  'iContains',
+  'insensitive',
+];
+const ORDERING_OPS = ['lt', 'lte', 'gt', 'gte'];
+
+beforeAll(async () => {
+  pglite = new PGlite();
+  await pglite.waitReady;
+  db = (drizzle as any)({ client: pglite, schema, relations, logger: !!process.env['LOG_SQL'] });
+
+  await db.execute(sql`CREATE TYPE "kind" AS ENUM ('cron', 'event');`);
+  await db.execute(sql`CREATE TABLE "triggers" (
+    "id" serial PRIMARY KEY NOT NULL,
+    "name" text,
+    "kind" "kind",
+    "enabled" boolean,
+    "fired_at" timestamp,
+    "on_day" date
+  );`);
+
+  await db.insert(Triggers).values([
+    { id: 1, name: 'nightly', kind: 'cron', enabled: true, firedAt: new Date('2024-01-01T00:00:00Z') },
+    { id: 2, name: 'signup', kind: 'event', enabled: false, firedAt: new Date('2024-06-01T00:00:00Z') },
+    { id: 3, name: 'weekly', kind: 'cron', enabled: true, firedAt: new Date('2024-12-01T00:00:00Z') },
+  ]);
+
+  gqlSchema = buildSchema(db).schema;
+});
+
+afterAll(async () => {
+  await pglite?.close().catch(() => {});
+});
+
+describe.sequential('operator sets follow the column type', () => {
+  it('leaves a boolean column equality and membership only', () => {
+    const { name, fields } = filterFieldsFor('enabled');
+    expect(name).toBe('BooleanFilter');
+    for (const op of [...PATTERN_OPS, ...ORDERING_OPS]) {
+      expect(fields).not.toContain(op);
+    }
+    expect(fields).toEqual(
+      expect.arrayContaining(['eq', 'ne', 'inArray', 'notInArray', 'isNull', 'isNotNull', 'OR', 'AND', 'NOT']),
+    );
+  });
+
+  it('leaves an enum column equality and membership only', () => {
+    const { name, fields } = filterFieldsFor('kind');
+    expect(name).toBe('KindEnumFilter');
+    for (const op of [...PATTERN_OPS, ...ORDERING_OPS]) {
+      expect(fields).not.toContain(op);
+    }
+    expect(fields).toEqual(expect.arrayContaining(['eq', 'ne', 'inArray', 'notInArray', 'isNull', 'isNotNull']));
+  });
+
+  it('keeps ordering on a timestamp column but drops the pattern operators', () => {
+    const { name, fields } = filterFieldsFor('firedAt');
+    expect(name).toBe('DateTimeFilter');
+    for (const op of PATTERN_OPS) {
+      expect(fields).not.toContain(op);
+    }
+    expect(fields).toEqual(expect.arrayContaining(['eq', 'ne', ...ORDERING_OPS, 'inArray', 'isNull', 'isNotNull']));
+  });
+
+  it('treats a date column the same as a timestamp', () => {
+    const { name, fields } = filterFieldsFor('onDay');
+    expect(name).toBe('DateTimeFilter');
+    for (const op of PATTERN_OPS) {
+      expect(fields).not.toContain(op);
+    }
+    expect(fields).toEqual(expect.arrayContaining(ORDERING_OPS));
+  });
+
+  it('leaves a text column the full set', () => {
+    const { name, fields } = filterFieldsFor('name');
+    expect(name).toBe('StringFilter');
+    expect(fields).toEqual(expect.arrayContaining([...PATTERN_OPS, ...ORDERING_OPS]));
+  });
+});
+
+describe.sequential('the operators that stay still run', () => {
+  const run = (source: string) => graphql({ schema: gqlSchema, source, contextValue: {} });
+
+  it('filters a boolean column by equality', async () => {
+    const result = await run(
+      `{ triggers(where: { enabled: { eq: true } }, orderBy: { id: { direction: asc, priority: 1 } }) { id } }`,
+    );
+
+    expect(result.errors).toBeUndefined();
+    expect((result.data as any).triggers).toEqual([{ id: 1 }, { id: 3 }]);
+  });
+
+  it('filters an enum column by membership', async () => {
+    const result = await run(
+      `{ triggers(where: { kind: { inArray: [event] } }, orderBy: { id: { direction: asc, priority: 1 } }) { id } }`,
+    );
+
+    expect(result.errors).toBeUndefined();
+    expect((result.data as any).triggers).toEqual([{ id: 2 }]);
+  });
+
+  it('filters a timestamp column by range', async () => {
+    const result = await run(
+      `{ triggers(where: { firedAt: { gte: "2024-06-01T00:00:00.000Z" } }, orderBy: { id: { direction: asc, priority: 1 } }) { id } }`,
+    );
+
+    expect(result.errors).toBeUndefined();
+    expect((result.data as any).triggers).toEqual([{ id: 2 }, { id: 3 }]);
+  });
+});
+
+describe.sequential('the operators that went away are validation errors', () => {
+  const run = (source: string) => graphql({ schema: gqlSchema, source, contextValue: {} });
+
+  it('rejects gt on a boolean column', async () => {
+    const result = await run(`{ triggers(where: { enabled: { gt: false } }) { id } }`);
+
+    expect(result.errors).toBeDefined();
+    expect(result.errors![0]!.message).toMatch(unknownInputField('gt'));
+  });
+
+  it('rejects contains on a boolean column', async () => {
+    const result = await run(`{ triggers(where: { enabled: { contains: "tr" } }) { id } }`);
+
+    expect(result.errors).toBeDefined();
+    expect(result.errors![0]!.message).toMatch(unknownInputField('contains'));
+  });
+
+  it('rejects lt on an enum column', async () => {
+    const result = await run(`{ triggers(where: { kind: { lt: event } }) { id } }`);
+
+    expect(result.errors).toBeDefined();
+    expect(result.errors![0]!.message).toMatch(unknownInputField('lt'));
+  });
+
+  it('rejects startsWith on a timestamp column', async () => {
+    const result = await run(`{ triggers(where: { firedAt: { startsWith: "2024" } }) { id } }`);
+
+    expect(result.errors).toBeDefined();
+    expect(result.errors![0]!.message).toMatch(unknownInputField('startsWith'));
+  });
+
+  it('rejects insensitive on a timestamp column', async () => {
+    const result = await run(`{ triggers(where: { firedAt: { insensitive: true } }) { id } }`);
+
+    expect(result.errors).toBeDefined();
+    expect(result.errors![0]!.message).toMatch(unknownInputField('insensitive'));
+  });
+});


### PR DESCRIPTION
Closes #156.

`FILTERS_WITHOUT_STRING_OPS` held only the numeric names, so `DateTimeFilter`, `BooleanFilter` and every generated `*EnumFilter` fell through to the full 24-operator `StringFilter` shape. This widens the set that already exists rather than adding an axis:

- `Boolean`, `DateTime` and `Date` join the pattern-operator exclusion set (which also carries `insensitive`, since it sits inside that block).
- Enum descriptors gain an `isEnum` flag — enum filters are named after their enum, so a name-keyed set cannot catch them — and are excluded on the same predicate.
- A second, narrower set (`FILTERS_WITHOUT_ORDERING_OPS`) drops `lt`/`lte`/`gt`/`gte` from booleans and enums. Timestamps and the numerics keep them: ranges are the point of having them.
- Custom override scalars are unchanged. Their pattern operators still follow the underlying database column (string-typed, not numeric), and they keep the ordering operators — a custom scalar says nothing about whether its column is orderable.

`eq` / `ne` / `inArray` / `notInArray` / `isNull` / `isNotNull` and the `AND`/`OR`/`NOT` branches stay everywhere.

### What this looks like on a schema

`BooleanFilter` and `*EnumFilter` go from 24 operators to 9; `DateTimeFilter` from 24 to 13 (the shape `IntFilter` already had). The issue measured −24.6% on a 17-tool MCP listing built from a 5-table schema, with the enum filters alone accounting for a third of it.

### Deliberately not in this pass

A `date()` column in its default (string) mode is a `PgDateString`, whose input scalar is `GraphQLString`, so it shares `StringFilter` and keeps the pattern operators. Splitting it out would need its own filter type — a separate change, since the name `Date` is already claimed by a `scalarOverrides` override to `GraphQLDate` whose operand type differs. `JSONPathFilter` is likewise left alone: the issue calls its `lt`/`gt` defensible, and a path names a scalar whose type is not known at build time.

### Tests

New `tests/pglite/filter-operator-sets.test.ts` — 13 tests over a schema with text, enum, boolean, timestamp and date columns: the operator set each filter type ends up with, that the surviving operators still run (boolean `eq`, enum `inArray`, timestamp range), and that each removed operator is now a validation error. All 9 shape/rejection tests fail on `main`.

Lint, both typecheck passes and the PGlite + SQLite suites (1120 tests) are green locally. README gains a "Which operators a column gets" section with the table, the reasoning and an upgrade note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8CNohGit8bcDzuTau1G2W