### PR TITLE
refactor: give the write generators options objects

### DIFF
--- a/src/util/builders/schema-data.ts
+++ b/src/util/builders/schema-data.ts
@@ -21,39 +21,24 @@ import {
   generateUpdateManyInput,
   generateWriteCount,
   getUniqueColumnSets,
-  type LimitPolicyFor,
-  type MutationTxCtx,
-  type RelationFilterBase,
-  type ResolverPolicies,
   type TablesRelationalConfig,
-  type TypeNameMapper,
-  type TypeNameResolver,
 } from '../builders/common.ts';
 import { tableFieldExtensions } from '../extensions.ts';
 import { createSchemaBuilder, type SchemaBuildAdapter } from './build-context.ts';
-import type { NestedWriteRuntime } from './nested-writes.ts';
-import type { CreatedResolver, SchemaGeneratorOptions, TableNamedRelations } from './types.ts';
-import { buildWriteResolvers } from './write-resolvers.ts';
+import type { CreatedResolver, SchemaGeneratorOptions } from './types.ts';
+import { buildWriteResolvers, type WriteBuildOptions } from './write-resolvers.ts';
+
+/** The per-table half of {@link UpdateManyGenerator}'s options; the rest comes from the build. */
+export interface UpdateManyOptions {
+  tableName: string;
+  table: any;
+  updateManyInput: GraphQLInputObjectType;
+  fieldName: string;
+  typeName: string;
+}
 
 /** `update<Table>Many` — batch update, whose statement loop is dialect-specific. */
-export type UpdateManyGenerator = (
-  db: any,
-  tableName: string,
-  table: any,
-  tables: Record<string, Table>,
-  relationMap: Record<string, Record<string, TableNamedRelations>>,
-  updateManyInput: GraphQLInputObjectType,
-  fieldName: string,
-  typeName: string,
-  typeNameMapper?: TypeNameMapper,
-  filterCtx?: RelationFilterBase,
-  txCtx?: MutationTxCtx,
-  nested?: NestedWriteRuntime,
-  limits?: LimitPolicyFor,
-  policies?: ResolverPolicies,
-  /** The build's type-naming rule — the resolve tree is keyed by the names it produced. */
-  resolveName?: TypeNameResolver,
-) => CreatedResolver;
+export type UpdateManyGenerator = (build: WriteBuildOptions, opts: UpdateManyOptions) => CreatedResolver;
 
 /**
  * Everything {@link createSchemaDataGenerator} cannot decide for itself: the shared build's
@@ -107,6 +92,21 @@ export const createSchemaDataGenerator = (adapter: DialectSchemaAdapter) => {
       outputs,
     } = ctx;
 
+    // Everything a write generator takes from the build rather than from the table. The same
+    // object serves every table below, so each call names only what varies per table.
+    const writeBuild: WriteBuildOptions = {
+      db,
+      tables,
+      relationMap: eagerRelations,
+      typeNameMapper,
+      filterCtx,
+      txCtx: mutationTxCtx,
+      nested: nestedRuntime,
+      limits,
+      policies,
+      resolveName: cacheCtx.typeName,
+    };
+
     for (const [tableName, tableTypes] of Object.entries(gqlSchemaTypes)) {
       // Everything this table generates, with any per-table predicate already run.
       const tableFeatures = featureOf(tableName);
@@ -144,44 +144,26 @@ export const createSchemaDataGenerator = (adapter: DialectSchemaAdapter) => {
       const { aggregateType, groupByType, havingInput } = addReadFields(ctx, tableName, names, tableTypes, drizzleMeta);
 
       const insertArrGenerated = tableFeatures.insert
-        ? generateInsert(
-            db,
+        ? generateInsert(writeBuild, {
             tableName,
-            schema[tableName] as Table,
-            tables,
-            eagerRelations,
-            insertInput,
-            createArrayFieldName,
+            table: schema[tableName] as Table,
+            baseType: insertInput,
+            fieldName: createArrayFieldName,
             typeName,
-            false,
-            typeNameMapper,
+            single: false,
             conflictDoNothing,
-            mutationTxCtx,
-            nestedRuntime,
-            limits,
-            policies,
-            cacheCtx.typeName,
-          )
+          })
         : undefined;
       const insertSingleGenerated = tableFeatures.insert
-        ? generateInsert(
-            db,
+        ? generateInsert(writeBuild, {
             tableName,
-            schema[tableName] as Table,
-            tables,
-            eagerRelations,
-            insertInput,
-            createSingleFieldName,
+            table: schema[tableName] as Table,
+            baseType: insertInput,
+            fieldName: createSingleFieldName,
             typeName,
-            true,
-            typeNameMapper,
+            single: true,
             conflictDoNothing,
-            mutationTxCtx,
-            nestedRuntime,
-            limits,
-            policies,
-            cacheCtx.typeName,
-          )
+          })
         : undefined;
       // An upsert needs something to conflict on, so a table with no primary key and no
       // unique constraint gets no upsert mutations rather than ones that always fail.
@@ -198,92 +180,52 @@ export const createSchemaDataGenerator = (adapter: DialectSchemaAdapter) => {
           })
         : undefined;
       const upsertArrGenerated = onConflictInput
-        ? generateUpsert(
-            db,
+        ? generateUpsert(writeBuild, {
             tableName,
-            schema[tableName] as Table,
-            tables,
-            eagerRelations,
-            insertInput,
-            onConflictInput,
+            table: schema[tableName] as Table,
+            baseType: insertInput,
+            onConflictType: onConflictInput,
             uniqueSets,
-            upsertArrayFieldName,
+            fieldName: upsertArrayFieldName,
             typeName,
-            false,
-            typeNameMapper,
-            filterCtx,
-            mutationTxCtx,
-            nestedRuntime,
-            limits,
-            policies,
-            cacheCtx.typeName,
-          )
+            single: false,
+          })
         : undefined;
       const upsertSingleGenerated = onConflictInput
-        ? generateUpsert(
-            db,
+        ? generateUpsert(writeBuild, {
             tableName,
-            schema[tableName] as Table,
-            tables,
-            eagerRelations,
-            insertInput,
-            onConflictInput,
+            table: schema[tableName] as Table,
+            baseType: insertInput,
+            onConflictType: onConflictInput,
             uniqueSets,
-            upsertSingleFieldName,
+            fieldName: upsertSingleFieldName,
             typeName,
-            true,
-            typeNameMapper,
-            filterCtx,
-            mutationTxCtx,
-            nestedRuntime,
-            limits,
-            policies,
-            cacheCtx.typeName,
-          )
+            single: true,
+          })
         : undefined;
       const updateGenerated = tableFeatures.update
-        ? generateUpdate(
-            db,
+        ? generateUpdate(writeBuild, {
             tableName,
-            schema[tableName] as Table,
-            tables,
-            eagerRelations,
-            updateInput,
-            tableFilters,
-            updateFieldName,
+            table: schema[tableName] as Table,
+            setArgs: updateInput,
+            filterArgs: tableFilters,
+            fieldName: updateFieldName,
             typeName,
-            false,
-            tableFeatures.requireWhere,
-            typeNameMapper,
-            filterCtx,
-            mutationTxCtx,
-            nestedRuntime,
-            limits,
-            policies,
-            cacheCtx.typeName,
-          )
+            single: false,
+            requireWhere: tableFeatures.requireWhere,
+          })
         : undefined;
       const updateSingleGenerated = tableFeatures.update
-        ? generateUpdate(
-            db,
+        ? generateUpdate(writeBuild, {
             tableName,
-            schema[tableName] as Table,
-            tables,
-            eagerRelations,
-            updateInput,
-            tableFilters,
-            updateSingleFieldName,
+            table: schema[tableName] as Table,
+            setArgs: updateInput,
+            filterArgs: tableFilters,
+            fieldName: updateSingleFieldName,
             typeName,
-            true,
-            tableFeatures.requireWhere,
-            typeNameMapper,
-            filterCtx,
-            mutationTxCtx,
-            nestedRuntime,
-            limits,
-            policies,
-            cacheCtx.typeName,
-          )
+            single: true,
+            requireWhere: tableFeatures.requireWhere,
+          })
         : undefined;
       // The batch update reuses the update `set` input, so it needs `update` on too.
       const updateManyInput =
@@ -298,95 +240,65 @@ export const createSchemaDataGenerator = (adapter: DialectSchemaAdapter) => {
             })
           : undefined;
       const updateManyGenerated = updateManyInput
-        ? adapter.generateUpdateMany(
-            db,
+        ? adapter.generateUpdateMany(writeBuild, {
             tableName,
-            schema[tableName] as Table,
-            tables,
-            eagerRelations,
+            table: schema[tableName] as Table,
             updateManyInput,
-            updateManyFieldName,
+            fieldName: updateManyFieldName,
             typeName,
-            typeNameMapper,
-            filterCtx,
-            mutationTxCtx,
-            nestedRuntime,
-            limits,
-            policies,
-            cacheCtx.typeName,
-          )
+          })
         : undefined;
       const deleteGenerated = tableFeatures.delete
-        ? generateDelete(
-            db,
+        ? generateDelete(writeBuild, {
             tableName,
-            schema[tableName] as Table,
-            tableFilters,
-            deleteFieldName,
+            table: schema[tableName] as Table,
+            filterArgs: tableFilters,
+            fieldName: deleteFieldName,
             typeName,
-            false,
-            tableFeatures.requireWhere,
-            filterCtx,
-            { tableName, relationMap: namedRelations, tables },
-            mutationTxCtx,
-            policies,
-            false,
-            cacheCtx.typeName,
-          )
+            single: false,
+            requireWhere: tableFeatures.requireWhere,
+            restore: false,
+            selectionCtx: { tableName, relationMap: namedRelations, tables },
+          })
         : undefined;
       const deleteSingleGenerated = tableFeatures.delete
-        ? generateDelete(
-            db,
+        ? generateDelete(writeBuild, {
             tableName,
-            schema[tableName] as Table,
-            tableFilters,
-            deleteSingleFieldName,
+            table: schema[tableName] as Table,
+            filterArgs: tableFilters,
+            fieldName: deleteSingleFieldName,
             typeName,
-            true,
-            tableFeatures.requireWhere,
-            filterCtx,
-            { tableName, relationMap: namedRelations, tables },
-            mutationTxCtx,
-            policies,
-            false,
-            cacheCtx.typeName,
-          )
+            single: true,
+            requireWhere: tableFeatures.requireWhere,
+            restore: false,
+            selectionCtx: { tableName, relationMap: namedRelations, tables },
+          })
         : undefined;
       const restoreGenerated = softDeleteInfo
-        ? generateDelete(
-            db,
+        ? generateDelete(writeBuild, {
             tableName,
-            schema[tableName] as Table,
-            tableFilters,
-            restoreFieldName,
+            table: schema[tableName] as Table,
+            filterArgs: tableFilters,
+            fieldName: restoreFieldName,
             typeName,
-            false,
-            tableFeatures.requireWhere,
-            filterCtx,
-            { tableName, relationMap: namedRelations, tables },
-            mutationTxCtx,
-            policies,
-            true,
-            cacheCtx.typeName,
-          )
+            single: false,
+            requireWhere: tableFeatures.requireWhere,
+            restore: true,
+            selectionCtx: { tableName, relationMap: namedRelations, tables },
+          })
         : undefined;
       const restoreSingleGenerated = softDeleteInfo
-        ? generateDelete(
-            db,
+        ? generateDelete(writeBuild, {
             tableName,
-            schema[tableName] as Table,
-            tableFilters,
-            restoreSingleFieldName,
+            table: schema[tableName] as Table,
+            filterArgs: tableFilters,
+            fieldName: restoreSingleFieldName,
             typeName,
-            true,
-            tableFeatures.requireWhere,
-            filterCtx,
-            { tableName, relationMap: namedRelations, tables },
-            mutationTxCtx,
-            policies,
-            true,
-            cacheCtx.typeName,
-          )
+            single: true,
+            requireWhere: tableFeatures.requireWhere,
+            restore: true,
+            selectionCtx: { tableName, relationMap: namedRelations, tables },
+          })
         : undefined;
       // The count variants are the plural write with its payload left off, so each follows the
       // same feature switch as the write it mirrors.

--- a/src/util/builders/update-many.ts
+++ b/src/util/builders/update-many.ts
@@ -10,20 +10,14 @@
 // =============================================================================
 
 import type { Table } from 'drizzle-orm';
-import type { GraphQLFieldConfigArgumentMap, GraphQLInputObjectType } from 'graphql';
+import type { GraphQLFieldConfigArgumentMap } from 'graphql';
 import { GraphQLList, GraphQLNonNull } from 'graphql';
 import {
   drizzleError,
   extractFilters,
-  type LimitPolicyFor,
-  type MutationTxCtx,
   mutationSelection,
-  type RelationFilterBase,
-  type ResolverPolicies,
   relationFilterCtx,
   stripContextValues,
-  type TypeNameMapper,
-  type TypeNameResolver,
   withEagerRelations,
   withScope,
   writeResolver,
@@ -31,8 +25,9 @@ import {
 import { remapToGraphQLSingleOutput } from '../data-mappers/index.ts';
 import { remapUpdateInput } from './field-updates.ts';
 import { mergedOps, type NestedWriteRuntime } from './nested-writes.ts';
-import type { UpdateManyGenerator } from './schema-data.ts';
-import type { CreatedResolver, Filters, TableNamedRelations } from './types.ts';
+import type { UpdateManyGenerator, UpdateManyOptions } from './schema-data.ts';
+import type { CreatedResolver, Filters } from './types.ts';
+import type { WriteBuildOptions } from './write-resolvers.ts';
 
 /** One entry of the `updates` argument, already remapped and validated. */
 export type UpdateManyEntry = {
@@ -118,24 +113,9 @@ export const createUpdateManyGenerator = (
   primaryKeyPropNames: (table: any) => string[],
   runBatch: UpdateManyBatchRunner = runUpdateManyBatch,
 ): UpdateManyGenerator => {
-  return (
-    db: any,
-    tableName: string,
-    table: any,
-    tables: Record<string, Table>,
-    relationMap: Record<string, Record<string, TableNamedRelations>>,
-    updateManyInput: GraphQLInputObjectType,
-    fieldName: string,
-    typeName: string,
-    typeNameMapper?: TypeNameMapper,
-    filterCtx?: RelationFilterBase,
-    txCtx?: MutationTxCtx,
-    nested?: NestedWriteRuntime,
-    limits?: LimitPolicyFor,
-    policies?: ResolverPolicies,
-    /** The build's type-naming rule — the resolve tree is keyed by the names it produced. */
-    resolveName?: TypeNameResolver,
-  ): CreatedResolver => {
+  return (build: WriteBuildOptions, opts: UpdateManyOptions): CreatedResolver => {
+    const { db, tables, relationMap, typeNameMapper, filterCtx, txCtx, nested, limits, policies, resolveName } = build;
+    const { tableName, table, updateManyInput, fieldName, typeName } = opts;
     const queryArgs = {
       updates: {
         type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(updateManyInput))),

--- a/src/util/builders/write-resolvers.ts
+++ b/src/util/builders/write-resolvers.ts
@@ -62,6 +62,65 @@ export type WriteDatabase = PgAsyncDatabase<any, any> | SQLiteAsyncDatabase<any,
  * Typed on `any` because `PgTable` and `SQLiteTable` are unrelated subtypes of `Table`, and a
  * parameter of the base type would not accept either dialect's narrower function.
  */
+/**
+ * What a write generator gets from the build rather than from the table. Every field is the
+ * same for every table in one `buildSchema` call, so the call sites assemble it once and pass
+ * it along unchanged — leaving each call to name only what actually varies per table.
+ */
+export interface WriteBuildOptions {
+  db: WriteDatabase;
+  /** Every table in the build — the relation columns a selection can reach live here. */
+  tables: Record<string, Table>;
+  relationMap: Record<string, Record<string, TableNamedRelations>>;
+  typeNameMapper?: TypeNameMapper;
+  filterCtx?: RelationFilterBase;
+  txCtx?: MutationTxCtx;
+  nested?: NestedWriteRuntime;
+  limits?: LimitPolicyFor;
+  policies?: ResolverPolicies;
+  /** The build's type-naming rule — the resolve tree is keyed by the names it produced. */
+  resolveName?: TypeNameResolver;
+}
+
+/** The half of a write generator's options that changes from table to table. */
+interface WriteTableOptions {
+  tableName: string;
+  table: Table;
+  /** The mutation field's name, already run through the build's naming rules. */
+  fieldName: string;
+  typeName: string;
+  /** One row in, one row out — as opposed to the list-shaped variant of the same mutation. */
+  single: boolean;
+}
+
+export interface InsertOptions extends WriteTableOptions {
+  /** The table's create input, shared by both insert shapes and by the upsert. */
+  baseType: GraphQLInputObjectType;
+  /** Conflicting rows are skipped rather than failing the statement. */
+  conflictDoNothing?: boolean;
+}
+
+export interface UpsertOptions extends WriteTableOptions {
+  baseType: GraphQLInputObjectType;
+  onConflictType: GraphQLInputObjectType;
+  uniqueSets: string[][];
+}
+
+export interface UpdateOptions extends WriteTableOptions {
+  setArgs: GraphQLInputObjectType;
+  filterArgs: GraphQLInputObjectType;
+  /** The table refuses an unfiltered write, so `where` is required even on the list shape. */
+  requireWhere: boolean;
+}
+
+export interface DeleteOptions extends WriteTableOptions {
+  filterArgs: GraphQLInputObjectType;
+  requireWhere: boolean;
+  /** Builds `restore<Table>` — the same resolver reading and writing the other way. */
+  restore?: boolean;
+  selectionCtx?: SelectionCtx;
+}
+
 export type PrimaryKeyPropNames = (table: any) => string[];
 
 /**
@@ -76,25 +135,9 @@ export const buildWriteResolvers = (primaryKeyPropNames: PrimaryKeyPropNames) =>
    * itself is the same multi-row statement either way, with the single variant supplying a
    * one-element list.
    */
-  const generateInsert = (
-    db: WriteDatabase,
-    tableName: string,
-    table: Table,
-    tables: Record<string, Table>,
-    relationMap: Record<string, Record<string, TableNamedRelations>>,
-    baseType: GraphQLInputObjectType,
-    fieldName: string,
-    typeName: string,
-    single: boolean,
-    typeNameMapper?: TypeNameMapper,
-    conflictDoNothing: boolean = false,
-    txCtx?: MutationTxCtx,
-    nested?: NestedWriteRuntime,
-    limits?: LimitPolicyFor,
-    policies?: ResolverPolicies,
-    /** The build's type-naming rule — the resolve tree is keyed by the names it produced. */
-    resolveName?: TypeNameResolver,
-  ): CreatedResolver => {
+  const generateInsert = (build: WriteBuildOptions, opts: InsertOptions): CreatedResolver => {
+    const { db, tables, relationMap, typeNameMapper, txCtx, nested, limits, policies, resolveName } = build;
+    const { tableName, table, baseType, fieldName, typeName, single, conflictDoNothing = false } = opts;
     const queryArgs: GraphQLFieldConfigArgumentMap = {
       values: {
         type: single ? new GraphQLNonNull(baseType) : new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(baseType))),
@@ -202,27 +245,9 @@ export const buildWriteResolvers = (primaryKeyPropNames: PrimaryKeyPropNames) =>
    *
    * Shares the insert input: an upsert supplies a whole row, same as a create.
    */
-  const generateUpsert = (
-    db: WriteDatabase,
-    tableName: string,
-    table: Table,
-    tables: Record<string, Table>,
-    relationMap: Record<string, Record<string, TableNamedRelations>>,
-    baseType: GraphQLInputObjectType,
-    onConflictType: GraphQLInputObjectType,
-    uniqueSets: string[][],
-    fieldName: string,
-    typeName: string,
-    single: boolean,
-    typeNameMapper?: TypeNameMapper,
-    filterCtx?: RelationFilterBase,
-    txCtx?: MutationTxCtx,
-    nested?: NestedWriteRuntime,
-    limits?: LimitPolicyFor,
-    policies?: ResolverPolicies,
-    /** The build's type-naming rule — the resolve tree is keyed by the names it produced. */
-    resolveName?: TypeNameResolver,
-  ): CreatedResolver => {
+  const generateUpsert = (build: WriteBuildOptions, opts: UpsertOptions): CreatedResolver => {
+    const { db, tables, relationMap, typeNameMapper, filterCtx, txCtx, nested, limits, policies, resolveName } = build;
+    const { tableName, table, baseType, onConflictType, uniqueSets, fieldName, typeName, single } = opts;
     const queryArgs: GraphQLFieldConfigArgumentMap = {
       values: {
         type: single ? new GraphQLNonNull(baseType) : new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(baseType))),
@@ -339,27 +364,9 @@ export const buildWriteResolvers = (primaryKeyPropNames: PrimaryKeyPropNames) =>
     });
   };
 
-  const generateUpdate = (
-    db: WriteDatabase,
-    tableName: string,
-    table: Table,
-    tables: Record<string, Table>,
-    relationMap: Record<string, Record<string, TableNamedRelations>>,
-    setArgs: GraphQLInputObjectType,
-    filterArgs: GraphQLInputObjectType,
-    fieldName: string,
-    typeName: string,
-    single: boolean,
-    requireWhere: boolean,
-    typeNameMapper?: TypeNameMapper,
-    filterCtx?: RelationFilterBase,
-    txCtx?: MutationTxCtx,
-    nested?: NestedWriteRuntime,
-    limits?: LimitPolicyFor,
-    policies?: ResolverPolicies,
-    /** The build's type-naming rule — the resolve tree is keyed by the names it produced. */
-    resolveName?: TypeNameResolver,
-  ): CreatedResolver => {
+  const generateUpdate = (build: WriteBuildOptions, opts: UpdateOptions): CreatedResolver => {
+    const { db, tables, relationMap, typeNameMapper, filterCtx, txCtx, nested, limits, policies, resolveName } = build;
+    const { tableName, table, setArgs, filterArgs, fieldName, typeName, single, requireWhere } = opts;
     const queryArgs = {
       set: {
         type: new GraphQLNonNull(setArgs),
@@ -487,23 +494,10 @@ export const buildWriteResolvers = (primaryKeyPropNames: PrimaryKeyPropNames) =>
    * `DELETE` — emptying the trash, reclaiming a unique key. It reads at `INCLUDE`, since the
    * rows it mostly exists to remove are the ones already marked; a `scope` still confines it.
    */
-  const generateDelete = (
-    db: WriteDatabase,
-    tableName: string,
-    table: Table,
-    filterArgs: GraphQLInputObjectType,
-    fieldName: string,
-    typeName: string,
-    single: boolean,
-    requireWhere: boolean,
-    filterCtx?: RelationFilterBase,
-    selectionCtx?: SelectionCtx,
-    txCtx?: MutationTxCtx,
-    policies?: ResolverPolicies,
-    restore: boolean = false,
-    /** The build's type-naming rule — the resolve tree is keyed by the names it produced. */
-    resolveName?: TypeNameResolver,
-  ): CreatedResolver => {
+  const generateDelete = (build: WriteBuildOptions, opts: DeleteOptions): CreatedResolver => {
+    const { db, filterCtx, txCtx, policies, resolveName } = build;
+    const { tableName, table, filterArgs, fieldName, typeName, single, requireWhere, selectionCtx } = opts;
+    const restore = opts.restore ?? false;
     const softDelete = policies?.softDelete?.(tableName);
     const operation: WriteOperation = restore ? 'restore' : 'delete';
     // Only a soft-deleting table that opted in gets the argument, so the schema itself says


### PR DESCRIPTION
Closes #137. Builds on #167 (the merged insert generator), so it is easiest to read after that lands.

`generateUpsert` took 18 positional arguments, `generateUpdate` 17, `generateDelete` 14, `UpdateManyGenerator` 15. Each generator now takes two objects:

- **`WriteBuildOptions`** — the ten values that are identical for every table in one `buildSchema` call: `db`, `tables`, `relationMap`, `typeNameMapper`, `filterCtx`, `txCtx`, `nested`, `limits`, `policies`, `resolveName`. `schema-data.ts` assembles it once, above the per-table loop, and passes it to all eleven call sites unchanged.
- **`InsertOptions` / `UpsertOptions` / `UpdateOptions` / `DeleteOptions` / `UpdateManyOptions`** — what actually varies per table: the table, its input types, the field name, and the flags.

All three hazards the issue names are gone:

```ts
// before
generateDelete(db, tableName, schema[tableName] as Table, tableFilters, restoreFieldName,
  typeName, false, tableFeatures.requireWhere, filterCtx,
  { tableName, relationMap: namedRelations, tables }, mutationTxCtx, policies, true, cacheCtx.typeName)

// after
generateDelete(writeBuild, {
  tableName,
  table: schema[tableName] as Table,
  filterArgs: tableFilters,
  fieldName: restoreFieldName,
  typeName,
  single: false,
  requireWhere: tableFeatures.requireWhere,
  restore: true,
  selectionCtx: { tableName, relationMap: namedRelations, tables },
})
```

This is the shape the newer generators in the same files already use — `generateWriteCount({ … })`, `generateOnConflictInput({ … })`, `generateUpdateManyInput({ … })`.

No runtime behaviour changes: the same values reach the same closures, and each generator destructures them at the top instead of receiving them as parameters. `createUpdateManyGenerator` in `update-many.ts` follows the same signature, since `UpdateManyGenerator` is the adapter slot the dialects fill.

MySQL's own local generators are untouched: they take 7-9 arguments each and were not part of the issue.

Lint (`biome ci .`), both typecheck passes and the PGlite + SQLite suites (1107 tests, run in three batches — this machine OOM-kills vitest workers when the whole set runs at once) are green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8CNohGit8bcDzuTau1G2W