### PR TITLE
refactor: run the per-table build loop once, in build-context.ts

### DIFF
--- a/src/util/builders/build-context.ts
+++ b/src/util/builders/build-context.ts
@@ -8,9 +8,12 @@
 // select fields, the aggregate field and the group-by field — is identical down to
 // the argument lists.
 //
-// This module holds all three stretches once. What a dialect still owns is its
-// mutation half: PostgreSQL and SQLite return the rows they wrote, MySQL cannot,
-// so its mutation fields, return types and resolvers differ throughout.
+// The per-table loop is shared as well: `forEachTable` works out what every dialect
+// needs per table, calls the dialect back for the mutations it generated, and then
+// registers those and the inputs and outputs they reference. What a dialect still
+// owns is the mutation half itself — PostgreSQL and SQLite return the rows they
+// wrote, MySQL cannot, so its mutation fields, return types and resolvers differ
+// throughout.
 //
 // Keeping this shared is not just deduplication. A feature added to the prelude
 // used to reach two of the three dialects — `uniqueKeyFilters` (#90) shipped as a
@@ -18,7 +21,7 @@
 // =============================================================================
 
 import { is, One, type Table } from 'drizzle-orm';
-import type { GraphQLFieldConfig, GraphQLInputObjectType, GraphQLObjectType } from 'graphql';
+import type { GraphQLFieldConfig, GraphQLInputObjectType, GraphQLObjectType, GraphQLOutputType } from 'graphql';
 import { GraphQLList, GraphQLNonNull } from 'graphql';
 import {
   aggregateFieldComplexity,
@@ -26,6 +29,7 @@ import {
   bindPolicies,
   buildNamedRelations,
   buildUniqueKeyMap,
+  computeResolverFieldNames,
   createMutationTxCtx,
   createRelationResolverFactory,
   defineRootField,
@@ -43,13 +47,14 @@ import {
   type ResolverFieldNames,
   type ResolverPolicies,
   registerColumnExclusions,
+  type SoftDeleteInfo,
   type TablesRelationalConfig,
   type TypeCacheCtx,
   type TypeNameMapper,
   type UniqueKeyMap,
   visibleColumns,
 } from '../builders/common.ts';
-import type { TableFieldExtensionFactory } from '../extensions.ts';
+import { type DrizzleMutationMeta, type TableFieldExtensionFactory, tableFieldExtensions } from '../extensions.ts';
 import { resolveTableFeatures } from '../features.ts';
 import { registerEnumConfig, registerScalarOverrides } from '../type-converter/index.ts';
 import {
@@ -70,7 +75,14 @@ import {
   type NestedWriteTypes,
 } from './nested-writes.ts';
 import { createSelectGenerators } from './select.ts';
-import type { GeneratedTableTypes, SchemaGeneratorOptions, TableFeatures, TableNamedRelations } from './types.ts';
+import type {
+  CreatedResolver,
+  GeneratedTableTypes,
+  GeneratedTableTypesOutputs,
+  SchemaGeneratorOptions,
+  TableFeatures,
+  TableNamedRelations,
+} from './types.ts';
 
 /** What {@link createSchemaBuilder} cannot work out for itself. */
 export type SchemaBuildAdapter<WithReturning extends boolean = boolean> = {
@@ -139,6 +151,51 @@ export type SchemaBuildContext<WithReturning extends boolean = boolean> = {
   outputs: Record<string, GraphQLObjectType>;
   limits: LimitPolicyFor | undefined;
   typeNameMapper: TypeNameMapper | undefined;
+};
+
+/**
+ * One generated mutation, ready to be hung off the mutation root: what the field returns,
+ * and what it says about itself. A dialect's per-table callback answers with a list of these
+ * rather than registering fields itself, so the registration — and the collision check in
+ * {@link defineRootField} — happens in one place for all three dialects.
+ */
+export type MutationRegistration = {
+  /** Undefined when this table's features left the mutation ungenerated. */
+  generated: CreatedResolver | undefined;
+  type: GraphQLOutputType;
+  /**
+   * The identity published on `extensions.drizzle`. Omitted by the count mutations, which
+   * answer with a number rather than rows and so have no row operation to dispatch on.
+   */
+  meta?: DrizzleMutationMeta;
+  description?: string;
+};
+
+/** What a dialect's per-table callback hands back for {@link forEachTable} to register. */
+export type TableMutations = {
+  /** In registration order, which is the order the fields appear in the schema. */
+  mutations: MutationRegistration[];
+  /**
+   * The two inputs whose presence is decided by the mutation half rather than by a feature
+   * flag, and which the shared loop needs in order to know whether to publish them.
+   */
+  onConflictInput?: GraphQLInputObjectType;
+  updateManyInput?: GraphQLInputObjectType;
+};
+
+/** The per-table values {@link forEachTable} has already worked out, handed to the dialect. */
+export type TableBuild<WithReturning extends boolean = boolean> = {
+  tableName: string;
+  table: Table;
+  /** This table's feature flags, with any per-table predicate already run. */
+  tableFeatures: TableFeatures;
+  /** Builds what a field of this table publishes under `extensions.drizzle`. */
+  drizzleMeta: TableFieldExtensionFactory;
+  /** The generated field names, from the naming config. */
+  names: ResolverFieldNames;
+  types: GeneratedTableTypes<WithReturning>;
+  /** Set when the table marks rows deleted instead of removing them. */
+  softDeleteInfo: SoftDeleteInfo | undefined;
 };
 
 /**
@@ -499,6 +556,99 @@ export const createSchemaBuilder = <WithReturning extends boolean>(adapter: Sche
     return { aggregateType, groupByType, havingInput };
   };
 
+  /**
+   * The per-table loop, run once for every table the build covers.
+   *
+   * The dialect's callback receives the values the loop has already worked out — the feature
+   * flags, the extension factory, the field names, the table's generated types and its
+   * soft-delete config — and answers with the mutations it generated. Registering them, and
+   * registering the inputs and outputs those mutations reference, happens here: both sides
+   * did it identically, down to the `description` strings on the count mutations, so a gate
+   * changed on one side and forgotten on the other used to be a silent dialect divergence.
+   *
+   * What stays in the dialect is what genuinely differs — which generators run, what each
+   * mutation returns, and (on MySQL) that a write cannot report the rows it touched.
+   */
+  const forEachTable = (
+    ctx: SchemaBuildContext<WithReturning>,
+    perTable: (build: TableBuild<WithReturning>) => TableMutations,
+  ): void => {
+    const { schema, featureOf, softDeleteOf, typeNameMapper, gqlSchemaTypes, mutations, inputs, outputs } = ctx;
+    const { prefixes, suffixes } = ctx.options;
+
+    for (const [tableName, tableTypes] of Object.entries(gqlSchemaTypes)) {
+      // Everything this table generates, with any per-table predicate already run.
+      const tableFeatures = featureOf(tableName);
+      // What every field this table generates publishes about itself under `extensions.drizzle`,
+      // so a wrapper can read a field's identity instead of parsing its configurable name.
+      const drizzleMeta = tableFieldExtensions(tableName, primaryKeyPropNames(schema[tableName] as Table));
+      // Compute field names using the mapper logic
+      const names = computeResolverFieldNames(tableName, typeNameMapper, prefixes, suffixes);
+      // A table that marks rows deleted instead of removing them also gets the mutation that
+      // reverses it — clearing the column through an ordinary update is not possible, since the
+      // column is not in the update input and a marked row is invisible to a `where` anyway.
+      const softDeleteInfo = softDeleteOf?.(tableName);
+
+      // Both selects, the aggregate and the group-by: generated and hung off the query root
+      // by the shared builder, since a read is a read on every dialect.
+      const readTypes = addReadFields(ctx, tableName, names, tableTypes, drizzleMeta);
+
+      const built = perTable({
+        tableName,
+        table: schema[tableName] as Table,
+        tableFeatures,
+        drizzleMeta,
+        names,
+        types: tableTypes,
+        softDeleteInfo,
+      });
+
+      for (const { generated, type, meta, description } of built.mutations) {
+        if (generated) {
+          defineRootField(mutations, 'mutation', generated.name, {
+            type,
+            args: generated.args,
+            resolve: generated.resolver,
+            ...(meta ? { extensions: { drizzle: drizzleMeta({ kind: 'mutation', ...meta }) } } : {}),
+            ...(description ? { description } : {}),
+          });
+        }
+      }
+
+      const { insertInput, updateInput, tableFilters, tableOrder } = tableTypes.inputs;
+      // The insert/update inputs are still built (they type the mutations that survive) but
+      // only reach the schema's type map when a mutation actually references them.
+      const activeInputs = [
+        // The insert input types the upsert mutations too, so either feature keeps it.
+        ...(tableFeatures.insert || built.onConflictInput ? [insertInput] : []),
+        ...(built.onConflictInput ? [built.onConflictInput] : []),
+        ...(tableFeatures.update ? [updateInput] : []),
+        ...(built.updateManyInput ? [built.updateManyInput] : []),
+        tableFilters,
+        tableOrder,
+      ];
+      activeInputs.forEach((e) => {
+        inputs[e.name] = e;
+      });
+      const { selectSingleOutput } = tableTypes.outputs;
+      outputs[selectSingleOutput.name] = selectSingleOutput;
+      if (adapter.returnsRows) {
+        // Only a dialect with RETURNING has a `${Table}Item` type — its mutations answer with
+        // one, where MySQL's answer with the build's shared `MutationReturn`.
+        const { singleTableItemOutput } = tableTypes.outputs as GeneratedTableTypesOutputs<true>;
+        outputs[singleTableItemOutput.name] = singleTableItemOutput;
+      }
+      const { aggregateType, groupByType, havingInput } = readTypes;
+      if (aggregateType) {
+        outputs[aggregateType.name] = aggregateType;
+      }
+      if (groupByType && havingInput) {
+        outputs[groupByType.name] = groupByType;
+        inputs[havingInput.name] = havingInput;
+      }
+    }
+  };
+
   /** The relation field resolvers and the transaction roster, once every root field exists. */
   const finalizeBuild = (ctx: SchemaBuildContext<WithReturning>): any => {
     // Every generated mutation name is now known — the first mutation resolver of a request
@@ -534,5 +684,5 @@ export const createSchemaBuilder = <WithReturning extends boolean>(adapter: Sche
     };
   };
 
-  return { primaryKeyPropNames, uniqueColumnSets, prepareBuild, addReadFields, finalizeBuild };
+  return { primaryKeyPropNames, uniqueColumnSets, prepareBuild, forEachTable, finalizeBuild };
 };

--- a/src/util/builders/mysql.ts
+++ b/src/util/builders/mysql.ts
@@ -13,8 +13,6 @@ import {
   applyContextValues,
   applyContextValuesAll,
   assertSingleMatch,
-  computeResolverFieldNames,
-  defineRootField,
   drizzleError,
   extractFilters,
   generateOnConflictInput,
@@ -38,8 +36,8 @@ import {
   writeResolver,
 } from '../builders/common.ts';
 import { remapFromGraphQLArrayInput, remapFromGraphQLSingleInput } from '../data-mappers/index.ts';
-import { type DrizzleMutationMeta, tableFieldExtensions } from '../extensions.ts';
-import { createSchemaBuilder } from './build-context.ts';
+import type { DrizzleMutationMeta } from '../extensions.ts';
+import { createSchemaBuilder, type MutationRegistration } from './build-context.ts';
 import { remapUpdateInput } from './field-updates.ts';
 import type { CreatedResolver, Filters, SchemaGeneratorOptions } from './types.ts';
 
@@ -433,7 +431,7 @@ const mysqlPrimaryKeyPropNames = (table: MySqlTable): string[] =>
   getPrimaryKeyPropNamesFromConfig(table, getTableConfig);
 
 // MySQL sorts NULLs as the smallest values (first in ASC), and its writes return no rows.
-const { prepareBuild, addReadFields, finalizeBuild } = createSchemaBuilder({
+const { prepareBuild, forEachTable, finalizeBuild } = createSchemaBuilder({
   tableClass: MySqlTable,
   getTableConfig,
   primaryKeyPropNames: mysqlPrimaryKeyPropNames,
@@ -459,25 +457,13 @@ export const generateSchemaData = <
   relations: TablesRelationalConfig,
   options: SchemaGeneratorOptions,
 ): GeneratedEntities<TDrizzleInstance, TSchema> => {
-  const { prefixes, suffixes, typeNameMapper } = options;
+  const { prefixes } = options;
 
   // Table discovery, the relation graph, the per-build registries, the filter context, the
   // type cache and every table's types — all of it dialect-independent, so all of it lives
   // in `build-context.ts` and is shared with the PostgreSQL/SQLite builder.
   const ctx = prepareBuild(db, schema as Record<string, unknown>, relations, options);
-  const {
-    featureOf,
-    anyTable,
-    filterCtx,
-    policies,
-    softDeleteOf,
-    cacheCtx,
-    mutationTxCtx,
-    gqlSchemaTypes,
-    mutations,
-    inputs,
-    outputs,
-  } = ctx;
+  const { anyTable, filterCtx, policies, cacheCtx, mutationTxCtx, outputs } = ctx;
 
   // MySQL cannot return the rows a write touched, so every mutation reports only whether it
   // succeeded — one shared type for the whole build.
@@ -495,17 +481,8 @@ export const generateSchemaData = <
     outputs['MutationReturn'] = mutationReturnType;
   }
 
-  for (const [tableName, tableTypes] of Object.entries(gqlSchemaTypes)) {
-    // Everything this table generates, with any per-table predicate already run.
-    const tableFeatures = featureOf(tableName);
-    // What every field this table generates publishes about itself under `extensions.drizzle`,
-    // so a wrapper can read a field's identity instead of parsing its configurable name.
-    const drizzleMeta = tableFieldExtensions(tableName, mysqlPrimaryKeyPropNames(schema[tableName] as MySqlTable));
-    const { insertInput, updateInput, tableFilters, tableOrder } = tableTypes.inputs;
-    const { selectSingleOutput } = tableTypes.outputs;
-
-    // Compute field names using the mapper logic
-    const names = computeResolverFieldNames(tableName, typeNameMapper, prefixes, suffixes);
+  forEachTable(ctx, ({ tableName, tableFeatures, names, types, softDeleteInfo }) => {
+    const { insertInput, updateInput, tableFilters } = types.inputs;
     const {
       typeName,
       createArrayFieldName,
@@ -522,14 +499,6 @@ export const generateSchemaData = <
       restoreSingleFieldName,
       deleteCountFieldName,
     } = names;
-    // A table that marks rows deleted instead of removing them also gets the mutation that
-    // reverses it — clearing the column through an ordinary update is not possible, since the
-    // column is not in the update input and a marked row is invisible to a `where` anyway.
-    const softDeleteInfo = softDeleteOf?.(tableName);
-
-    // Both selects, the aggregate and the group-by: generated and hung off the query root
-    // by the shared builder, since a read is a read on every dialect.
-    const { aggregateType, groupByType, havingInput } = addReadFields(ctx, tableName, names, tableTypes, drizzleMeta);
 
     const insertArrGenerated = tableFeatures.insert
       ? generateInsertArray(
@@ -737,74 +706,43 @@ export const generateSchemaData = <
         : undefined;
     // Each mutation is paired with the identity it publishes on `extensions.drizzle`, so a
     // consumer can tell an insert from an upsert without unpicking the configured prefixes —
-    // and, for a delete, whether the field can purge rather than mark.
+    // and, for a delete, whether the field can purge rather than mark. Every row-touching
+    // mutation shares one return type here, since MySQL answers with `isSuccess` rather than
+    // with rows; the count pair is the exception, and carries a description instead of a meta.
     const hardDeleteMeta = softDeleteInfo?.hardDelete ? ({ hardDelete: true } as const) : {};
-    const generatedMutations: [typeof insertArrGenerated, DrizzleMutationMeta][] = [
-      [insertArrGenerated, { operation: 'insert', single: false, targetArg: 'values' }],
-      [insertSingleGenerated, { operation: 'insert', single: true, targetArg: 'values' }],
-      [upsertArrGenerated, { operation: 'upsert', single: false, targetArg: 'values' }],
-      [upsertSingleGenerated, { operation: 'upsert', single: true, targetArg: 'values' }],
-      [updateGenerated, { operation: 'update', single: false, targetArg: 'where' }],
-      [updateManyGenerated, { operation: 'updateMany', single: false, targetArg: 'updates' }],
-      [updateSingleGenerated, { operation: 'update', single: true, targetArg: 'where' }],
-      [deleteGenerated, { operation: 'delete', single: false, targetArg: 'where', ...hardDeleteMeta }],
-      [deleteSingleGenerated, { operation: 'delete', single: true, targetArg: 'where', ...hardDeleteMeta }],
-      [restoreGenerated, { operation: 'restore', single: false, targetArg: 'where' }],
-      [restoreSingleGenerated, { operation: 'restore', single: true, targetArg: 'where' }],
-    ];
-    for (const [generated, meta] of generatedMutations) {
-      if (generated) {
-        defineRootField(mutations, 'mutation', generated.name, {
-          type: mutationReturnType,
-          args: generated.args,
-          resolve: generated.resolver,
-          extensions: { drizzle: drizzleMeta({ kind: 'mutation', ...meta }) },
-        });
-      }
-    }
-    // Apart from the loop above: the count mutations are the one pair whose return value is
-    // not MySQL's shared `isSuccess` shape.
-    if (updateCountGenerated) {
-      defineRootField(mutations, 'mutation', updateCountGenerated.name, {
+    const withMeta = (generated: CreatedResolver | undefined, meta: DrizzleMutationMeta): MutationRegistration => ({
+      generated,
+      type: mutationReturnType,
+      meta,
+    });
+    const generatedMutations: MutationRegistration[] = [
+      withMeta(insertArrGenerated, { operation: 'insert', single: false, targetArg: 'values' }),
+      withMeta(insertSingleGenerated, { operation: 'insert', single: true, targetArg: 'values' }),
+      withMeta(upsertArrGenerated, { operation: 'upsert', single: false, targetArg: 'values' }),
+      withMeta(upsertSingleGenerated, { operation: 'upsert', single: true, targetArg: 'values' }),
+      withMeta(updateGenerated, { operation: 'update', single: false, targetArg: 'where' }),
+      withMeta(updateManyGenerated, { operation: 'updateMany', single: false, targetArg: 'updates' }),
+      withMeta(updateSingleGenerated, { operation: 'update', single: true, targetArg: 'where' }),
+      withMeta(deleteGenerated, { operation: 'delete', single: false, targetArg: 'where', ...hardDeleteMeta }),
+      withMeta(deleteSingleGenerated, { operation: 'delete', single: true, targetArg: 'where', ...hardDeleteMeta }),
+      withMeta(restoreGenerated, { operation: 'restore', single: false, targetArg: 'where' }),
+      withMeta(restoreSingleGenerated, { operation: 'restore', single: true, targetArg: 'where' }),
+      {
+        generated: updateCountGenerated,
         type: new GraphQLNonNull(GraphQLInt),
-        args: updateCountGenerated.args,
-        resolve: updateCountGenerated.resolver,
         description:
           'How many rows the update touched. The rows themselves are not read back, which is the point of this mutation.',
-      });
-    }
-    if (deleteCountGenerated) {
-      defineRootField(mutations, 'mutation', deleteCountGenerated.name, {
+      },
+      {
+        generated: deleteCountGenerated,
         type: new GraphQLNonNull(GraphQLInt),
-        args: deleteCountGenerated.args,
-        resolve: deleteCountGenerated.resolver,
         description:
           'How many rows the delete removed. The rows themselves are not read back, which is the point of this mutation.',
-      });
-    }
-    // The insert/update inputs are still built (they type the mutations that survive) but
-    // only reach the schema's type map when a mutation actually references them.
-    const activeInputs = [
-      // The insert input types the upsert mutations too, so either feature keeps it.
-      ...(tableFeatures.insert || onConflictInput ? [insertInput] : []),
-      ...(onConflictInput ? [onConflictInput] : []),
-      ...(tableFeatures.update ? [updateInput] : []),
-      ...(updateManyInput ? [updateManyInput] : []),
-      tableFilters,
-      tableOrder,
+      },
     ];
-    activeInputs.forEach((e) => {
-      inputs[e.name] = e;
-    });
-    outputs[selectSingleOutput.name] = selectSingleOutput;
-    if (aggregateType) {
-      outputs[aggregateType.name] = aggregateType;
-    }
-    if (groupByType && havingInput) {
-      outputs[groupByType.name] = groupByType;
-      inputs[havingInput.name] = havingInput;
-    }
-  }
+
+    return { mutations: generatedMutations, onConflictInput, updateManyInput };
+  });
 
   return finalizeBuild(ctx);
 };

--- a/src/util/builders/schema-data.ts
+++ b/src/util/builders/schema-data.ts
@@ -5,26 +5,24 @@
 // {@link DialectSchemaAdapter}.
 //
 // The parts that are not even dialect-specific — everything up to each table's
-// types, the read fields, and the relation resolvers at the end — live in
-// `build-context.ts`, which MySQL shares. What remains here is the mutation half:
-// MySQL has no RETURNING clause, so its mutation fields, return types and
-// resolvers differ throughout.
+// types, the read fields, the per-table loop and the relation resolvers at the end
+// — live in `build-context.ts`, which MySQL shares. What remains here is the
+// mutation half, handed back to `forEachTable` for registration: MySQL has no
+// RETURNING clause, so its mutation fields, return types and resolvers differ
+// throughout.
 // =============================================================================
 
 import type { Table } from 'drizzle-orm';
-import type { GraphQLInputObjectType, GraphQLOutputType } from 'graphql';
+import type { GraphQLInputObjectType } from 'graphql';
 import { GraphQLInt, GraphQLList, GraphQLNonNull } from 'graphql';
 import {
-  computeResolverFieldNames,
-  defineRootField,
   generateOnConflictInput,
   generateUpdateManyInput,
   generateWriteCount,
   getUniqueColumnSets,
   type TablesRelationalConfig,
 } from '../builders/common.ts';
-import { type DrizzleMutationMeta, tableFieldExtensions } from '../extensions.ts';
-import { createSchemaBuilder, type SchemaBuildAdapter } from './build-context.ts';
+import { createSchemaBuilder, type MutationRegistration, type SchemaBuildAdapter } from './build-context.ts';
 import type { CreatedResolver, SchemaGeneratorOptions } from './types.ts';
 import { buildWriteResolvers, type WriteBuildOptions } from './write-resolvers.ts';
 
@@ -61,7 +59,7 @@ export const createSchemaDataGenerator = (adapter: DialectSchemaAdapter) => {
   const { generateInsert, generateUpsert, generateUpdate, generateDelete } = buildWriteResolvers(primaryKeyPropNames);
   // The three stretches of a build that have nothing to do with the dialect: everything up to
   // each table's types, the read fields in the middle, and the relation resolvers at the end.
-  const { prepareBuild, addReadFields, finalizeBuild } = createSchemaBuilder(adapter);
+  const { prepareBuild, forEachTable, finalizeBuild } = createSchemaBuilder(adapter);
 
   return (
     db: any,
@@ -69,28 +67,13 @@ export const createSchemaDataGenerator = (adapter: DialectSchemaAdapter) => {
     relations: TablesRelationalConfig,
     options: SchemaGeneratorOptions,
   ): any => {
-    const { prefixes, suffixes, conflictDoNothing, typeNameMapper, limits } = options;
+    const { prefixes, conflictDoNothing, typeNameMapper, limits } = options;
 
     // Table discovery, the relation graph, the per-build registries, the filter context, the
     // type cache and every table's types — all of it dialect-independent, so all of it lives
     // in `build-context.ts` and is shared with the MySQL builder.
     const ctx = prepareBuild(db, schema, relations, options);
-    const {
-      tables,
-      featureOf,
-      eagerRelations,
-      filterCtx,
-      policies,
-      softDeleteOf,
-      namedRelations,
-      cacheCtx,
-      nestedRuntime,
-      mutationTxCtx,
-      gqlSchemaTypes,
-      mutations,
-      inputs,
-      outputs,
-    } = ctx;
+    const { tables, eagerRelations, filterCtx, policies, namedRelations, cacheCtx, nestedRuntime, mutationTxCtx } = ctx;
 
     // Everything a write generator takes from the build rather than from the table. The same
     // object serves every table below, so each call names only what varies per table.
@@ -107,17 +90,9 @@ export const createSchemaDataGenerator = (adapter: DialectSchemaAdapter) => {
       resolveName: cacheCtx.typeName,
     };
 
-    for (const [tableName, tableTypes] of Object.entries(gqlSchemaTypes)) {
-      // Everything this table generates, with any per-table predicate already run.
-      const tableFeatures = featureOf(tableName);
-      // What every field this table generates publishes about itself under `extensions.drizzle`,
-      // so a wrapper can read a field's identity instead of parsing its configurable name.
-      const drizzleMeta = tableFieldExtensions(tableName, primaryKeyPropNames(schema[tableName] as Table));
-      const { insertInput, updateInput, tableFilters, tableOrder } = tableTypes.inputs;
-      const { selectSingleOutput, singleTableItemOutput, arrTableItemOutput } = tableTypes.outputs;
-
-      // Compute field names using the mapper logic
-      const names = computeResolverFieldNames(tableName, typeNameMapper, prefixes, suffixes);
+    forEachTable(ctx, ({ tableName, tableFeatures, names, types, softDeleteInfo }) => {
+      const { insertInput, updateInput, tableFilters } = types.inputs;
+      const { singleTableItemOutput, arrTableItemOutput } = types.outputs;
       const {
         typeName,
         createArrayFieldName,
@@ -134,14 +109,6 @@ export const createSchemaDataGenerator = (adapter: DialectSchemaAdapter) => {
         restoreSingleFieldName,
         deleteCountFieldName,
       } = names;
-      // A table that marks rows deleted instead of removing them also gets the mutation that
-      // reverses it — clearing the column through an ordinary update is not possible, since the
-      // column is not in the update input and a marked row is invisible to a `where` anyway.
-      const softDeleteInfo = softDeleteOf?.(tableName);
-
-      // Both selects, the aggregate and the group-by: generated and hung off the query root
-      // by the shared builder, since a read is a read on every dialect.
-      const { aggregateType, groupByType, havingInput } = addReadFields(ctx, tableName, names, tableTypes, drizzleMeta);
 
       const insertArrGenerated = tableFeatures.insert
         ? generateInsert(writeBuild, {
@@ -338,12 +305,7 @@ export const createSchemaDataGenerator = (adapter: DialectSchemaAdapter) => {
       // mark. The count pair is the one entry with a description and no meta: it answers with a
       // number rather than rows, so there is no row operation for a consumer to dispatch on.
       const hardDeleteMeta = softDeleteInfo?.hardDelete ? ({ hardDelete: true } as const) : {};
-      const generatedMutations: {
-        generated: CreatedResolver | undefined;
-        type: GraphQLOutputType;
-        meta?: DrizzleMutationMeta;
-        description?: string;
-      }[] = [
+      const generatedMutations: MutationRegistration[] = [
         {
           generated: insertArrGenerated,
           type: arrTableItemOutput,
@@ -419,41 +381,9 @@ export const createSchemaDataGenerator = (adapter: DialectSchemaAdapter) => {
             'How many rows the delete removed. The rows themselves are not read back, which is the point of this mutation.',
         },
       ];
-      for (const { generated, type, meta, description } of generatedMutations) {
-        if (generated) {
-          defineRootField(mutations, 'mutation', generated.name, {
-            type,
-            args: generated.args,
-            resolve: generated.resolver,
-            ...(meta ? { extensions: { drizzle: drizzleMeta({ kind: 'mutation', ...meta }) } } : {}),
-            ...(description ? { description } : {}),
-          });
-        }
-      }
-      // The insert/update inputs are still built (they type the mutations that survive) but
-      // only reach the schema's type map when a mutation actually references them.
-      const activeInputs = [
-        // The insert input types the upsert mutations too, so either feature keeps it.
-        ...(tableFeatures.insert || onConflictInput ? [insertInput] : []),
-        ...(onConflictInput ? [onConflictInput] : []),
-        ...(tableFeatures.update ? [updateInput] : []),
-        ...(updateManyInput ? [updateManyInput] : []),
-        tableFilters,
-        tableOrder,
-      ];
-      activeInputs.forEach((e) => {
-        inputs[e.name] = e;
-      });
-      outputs[selectSingleOutput.name] = selectSingleOutput;
-      outputs[singleTableItemOutput.name] = singleTableItemOutput;
-      if (aggregateType) {
-        outputs[aggregateType.name] = aggregateType;
-      }
-      if (groupByType && havingInput) {
-        outputs[groupByType.name] = groupByType;
-        inputs[havingInput.name] = havingInput;
-      }
-    }
+
+      return { mutations: generatedMutations, onConflictInput, updateManyInput };
+    });
 
     return finalizeBuild(ctx);
   };


### PR DESCRIPTION
Closes #136. Follows #169, which made both sides speak in mutation tuples first.

`build-context.ts` had already factored out the prelude, the read fields and the finalization, but the scaffolding *around* the mutation half was still written twice — the loop header, `featureOf` / `drizzleMeta` / the `tableTypes` destructures, `computeResolverFieldNames` and its 14-name destructure, `softDeleteOf?.(tableName)`, the `addReadFields` call, the mutation registration loop, `activeInputs` and its registration, and the output tail. The two count-mutation registrations were byte-identical including their `description` strings.

## `forEachTable(ctx, perTable)`

```ts
forEachTable(ctx, ({ tableName, tableFeatures, names, types, softDeleteInfo }) => {
  // …the dialect's generators…
  return { mutations: generatedMutations, onConflictInput, updateManyInput };
});
```

The shared loop works out `tableFeatures`, `drizzleMeta`, `names`, `softDeleteInfo` and the read fields, hands them to the dialect, and then registers what comes back:

- **`mutations: MutationRegistration[]`** — `{ generated, type, meta?, description? }`, registered in order through `defineRootField`, so the collision check runs in one place for all three dialects.
- **`onConflictInput` / `updateManyInput`** — the two inputs whose presence the mutation half decides rather than a feature flag, needed by `activeInputs`.

The `${Table}Item` output registration is gated on `adapter.returnsRows`, which is the one output-tail difference between the dialects; MySQL has no such type because its mutations answer with the build's shared `MutationReturn`.

## What each dialect keeps

Only the mutation half: which generators run for a table, and what each mutation returns. On MySQL that is `mutationReturnType` for all eleven row-touching mutations (a small `withMeta` helper pairs each with its meta); on PG/SQLite it is the per-mutation output types.

Field registration order is unchanged on both dialects, so the generated schema is identical: the same fields, in the same order, with the same `type`, `args`, `resolve`, `extensions` and `description`. MySQL's `updateMany` still carries no description, since its aligned-slot explanation is about returned rows and MySQL returns none.

`schema-data.ts` −56 lines, `mysql.ts` −90, `build-context.ts` +150 (the loop plus the three exported types and their docs).

Lint (`biome ci .`), both typecheck passes and the PGlite + SQLite suites (1256 tests) are green locally. The MySQL path has no local coverage — its suites need Docker — so CI's MySQL leg is the check that matters most on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8CNohGit8bcDzuTau1G2W